### PR TITLE
Moving import of visualization library inside of function

### DIFF
--- a/welleng/survey.py
+++ b/welleng/survey.py
@@ -28,7 +28,6 @@ from .utils import (
 from .error import ErrorModel, ERROR_MODELS
 from .node import Node
 from .connector import Connector, interpolate_well
-from .visual import figure
 from .units import ureg
 
 from typing import List, Union
@@ -965,6 +964,8 @@ class Survey:
         return survey_interpolated
 
     def figure(self, type='scatter3d', **kwargs):
+        from .visual import figure
+
         fig = figure(self, type, **kwargs)
         return fig
 


### PR DESCRIPTION
This will prevent the installation of additional packages on linux when not using visualizations (e.g., when working running code in a container).