### PR TITLE
Add new vectorized method for interpolating positions using an array of measured depths

### DIFF
--- a/tests/test_survey_interpolate.py
+++ b/tests/test_survey_interpolate.py
@@ -1,4 +1,5 @@
 import welleng as we
+import numpy as np
 
 SURVEY = we.survey.Survey(
     md=[0, 500, 1000, 2000, 2500, 3500],
@@ -15,6 +16,31 @@ def test_survey_interpolate_survey(step=30):
 
     survey_interp = SURVEY.interpolate_survey(step=step)
     assert isinstance(survey_interp, we.survey.Survey)
+
+def test_survey_interpolate_survey_vs_interpolate_mds(step=30):
+    global SURVEY
+    mds = np.arange(SURVEY.md[0], SURVEY.md[-1], step)
+    survey_interp = we.survey.interpolate_mds(SURVEY, mds)
+    assert isinstance(survey_interp, we.survey.Survey)
+    
+    survey_interp_1 = we.survey.interpolate_survey(SURVEY, step=step)
+    assert np.allclose(survey_interp.md, survey_interp_1.md)
+    assert np.allclose(survey_interp.azi_grid_rad, survey_interp_1.azi_grid_rad)
+    assert np.allclose(survey_interp.inc_rad, survey_interp_1.inc_rad)
+    assert np.allclose(survey_interp.pos_xyz, survey_interp_1.pos_xyz)
+    assert np.allclose(survey_interp.pos_nev, survey_interp_1.pos_nev)
+    assert np.allclose(survey_interp.dogleg, survey_interp_1.dogleg)
+
+    survey_interp = SURVEY.interpolate_mds(mds)
+    assert isinstance(survey_interp, we.survey.Survey)
+    
+    survey_interp_1 = SURVEY.interpolate_survey(step=step)
+    assert np.allclose(survey_interp.md, survey_interp_1.md)
+    assert np.allclose(survey_interp.azi_grid_rad, survey_interp_1.azi_grid_rad)
+    assert np.allclose(survey_interp.inc_rad, survey_interp_1.inc_rad)
+    assert np.allclose(survey_interp.pos_xyz, survey_interp_1.pos_xyz)
+    assert np.allclose(survey_interp.pos_nev, survey_interp_1.pos_nev)
+    assert np.allclose(survey_interp.dogleg, survey_interp_1.dogleg)
 
 def test_survey_interpolate_survey_tvd(step=10):
     global SURVEY
@@ -36,3 +62,5 @@ def test_interpolate_tvd(tvd=800):
     global SURVEY
     node = SURVEY.interpolate_tvd(tvd=tvd)
     assert isinstance(node, we.node.Node)
+
+test_survey_interpolate_survey_vs_interpolate_mds()

--- a/tests/test_survey_interpolate.py
+++ b/tests/test_survey_interpolate.py
@@ -30,6 +30,7 @@ def test_survey_interpolate_survey_vs_interpolate_mds(step=30):
     assert np.allclose(survey_interp.pos_xyz, survey_interp_1.pos_xyz)
     assert np.allclose(survey_interp.pos_nev, survey_interp_1.pos_nev)
     assert np.allclose(survey_interp.dogleg, survey_interp_1.dogleg)
+    assert np.all(survey_interp.interpolated == survey_interp_1.interpolated)
 
     survey_interp = SURVEY.interpolate_mds(mds)
     assert isinstance(survey_interp, we.survey.Survey)
@@ -41,6 +42,7 @@ def test_survey_interpolate_survey_vs_interpolate_mds(step=30):
     assert np.allclose(survey_interp.pos_xyz, survey_interp_1.pos_xyz)
     assert np.allclose(survey_interp.pos_nev, survey_interp_1.pos_nev)
     assert np.allclose(survey_interp.dogleg, survey_interp_1.dogleg)
+    assert np.all(survey_interp.interpolated == survey_interp_1.interpolated)
 
 def test_survey_interpolate_survey_tvd(step=10):
     global SURVEY

--- a/welleng/survey.py
+++ b/welleng/survey.py
@@ -1687,10 +1687,7 @@ def _interpolate_surveys(survey, md, xs, indexes):
         error_model=None
     )
 
-    survey_interpolated.interpolated = [
-        False if md in survey.md else True
-        for md in survey_interpolated.md
-    ]
+    survey_interpolated.interpolated = ~np.isin(survey_interpolated.md, survey.md)
 
     i = -1
     radii = []

--- a/welleng/survey.py
+++ b/welleng/survey.py
@@ -1662,24 +1662,24 @@ def _interpolate_surveys(survey, md, xs, indexes):
 
     len_svy = len(survey.md)
     len_md = len(md)
-    sorted_arr = np.zeros((len_svy+len_md, 3))
-    sorted_arr[0:len_svy, 0] = survey.md
-    sorted_arr[len_svy:, 0] = md
-    sorted_arr[0:len_svy, 1] = survey.inc_rad
-    sorted_arr[len_svy:, 1] = inc
-    sorted_arr[0:len_svy, 2] = survey.azi_grid_rad
-    sorted_arr[len_svy:, 2] = azi
+    sorted_arr = np.zeros((3, len_svy+len_md))
+    sorted_arr[0, 0:len_svy] = survey.md
+    sorted_arr[0, len_svy:] = md
+    sorted_arr[1, 0:len_svy] = survey.inc_rad
+    sorted_arr[1, len_svy:] = inc
+    sorted_arr[2, 0:len_svy] = survey.azi_grid_rad
+    sorted_arr[2, len_svy:] = azi
 
     # sort on md
-    sorted_arr = sorted_arr[np.argsort(sorted_arr[:, 0])]
+    sorted_arr = sorted_arr[:, np.argsort(sorted_arr[0, :])]
 
     sh = survey.header
     sh.azi_reference = 'grid'
 
     survey_interpolated = Survey(
-        md=sorted_arr[:,0],
-        inc=sorted_arr[:,1],
-        azi=sorted_arr[:,2],
+        md=sorted_arr[0,:],
+        inc=sorted_arr[1,:],
+        azi=sorted_arr[2,:],
         start_xyz=survey.start_xyz,
         start_nev=survey.start_nev,
         header=sh,

--- a/welleng/survey.py
+++ b/welleng/survey.py
@@ -1670,7 +1670,7 @@ def _interpolate_surveys(survey, md, xs, indexes):
     sorted_arr[0:len_svy, 2] = survey.azi_grid_rad
     sorted_arr[len_svy:, 2] = azi
 
-    # sort on 
+    # sort on md
     sorted_arr = sorted_arr[np.argsort(sorted_arr[:, 0])]
 
     sh = survey.header

--- a/welleng/survey.py
+++ b/welleng/survey.py
@@ -914,6 +914,28 @@ class Survey:
         """
         export_csv(self, filename)
 
+    def interpolate_mds(self, md):
+        """
+        Method to interpolate positions based on measured depths and return
+        a new `welleng.Survey` object.
+
+        Parameters
+        ----------
+        md: (,n) list or array of floats
+            The measured depths of the points of interest.
+
+        Returns
+        -------
+        A welleng.survey.Survey object.
+
+        Examples
+        --------
+        """
+         
+        s = interpolate_mds(self, md)
+        return s
+
+
     def interpolate_md(self, md):
         """
         Method to interpolate a position based on measured depth and return
@@ -1535,6 +1557,24 @@ def get_node(survey, idx, interpolated=False):
     )
     return node
 
+def interpolate_mds(survey, md):
+    """
+    Interpolates a survey at given measured depths.
+    """
+    md = np.array(md)
+    md = np.setdiff1d(md, survey.md)
+    _ = md.sort()
+
+    assert md[0] >= survey.md[0], "The shortest md is not within the survey"
+    assert md[-1] <= survey.md[-1], "The largest md is beyond the survey"
+
+    # get the closest survey stations
+    idxs = np.searchsorted(survey.md, md, side="left") - 1
+    idxs = np.clip(idxs, 0, len(survey.md)-2)
+
+    xs = md - survey.md[idxs]
+
+    return _interpolate_surveys(survey, md, xs, idxs)
 
 def interpolate_md(survey, md):
     """
@@ -1554,6 +1594,133 @@ def interpolate_md(survey, md):
 
     return _interpolate_survey(survey, x=x, index=idx)
 
+def _interpolate_surveys(survey, md, xs, indexes):
+    """
+    Interpolate multiple points distance xs between sets of two survey stations
+    using minimum curvature.
+
+    Parameters
+    ----------
+        survey: welleng.Survey
+            A survey object with at least two survey stations.
+        md: (,n) array of floats
+            The measured depths of the points of interest. Assumes that 
+            each value in md is not in survey.md
+        xs: (,n) array of floats
+            Lengths along well path from each indexed survey station to
+            perform the interpolation at. Must be less than length
+            to the next survey station.
+        indexes: (,n) array of ints
+            The indexes of the survey station from which to interpolate
+            each x in xs.
+
+    Returns
+    -------
+        survey_interpolated: welleng.survey.Survey object
+            Note that a `interpolated` property is added indicating if the survey
+            station is interpolated (True) or not (False).
+    """
+    # indexes = _ensure_int_or_float(indexes, int)
+    # xs = _ensure_int_or_float(xs, float)
+
+    assert indexes[-1] < len(survey.md) - 1, "Index is out of range"
+
+    total_doglegs = survey.dogleg[indexes+1]
+    azi, inc = np.zeros(len(xs)), np.zeros(len(xs))
+
+    # regions which are effectively straight
+    mask = np.where(total_doglegs < 1e-14) 
+    azi[mask] = survey.azi_grid_rad[indexes][mask]
+    inc[mask] = survey.inc_rad[indexes][mask]
+
+    # regions which are not straight
+    mask = np.where(total_doglegs >= 1e-14)
+    t1 = survey.vec_xyz[indexes][mask]
+    t2 = survey.vec_xyz[indexes + 1][mask]
+    
+    dogleg = (xs[mask]) * (total_doglegs[mask] / survey.delta_md[indexes + 1][mask])
+
+    t = (
+        t1 * (np.sin(total_doglegs[mask] - dogleg) / np.sin(total_doglegs[mask]))[:, np.newaxis]
+        + t2 * (np.sin(dogleg) / np.sin(total_doglegs[mask]))[:, np.newaxis]
+    )
+
+    # normalise tangent vectors
+    t = t / np.linalg.norm(t, axis=-1).reshape(-1, 1)
+
+    inc_azi = get_angles(t)
+    inc[mask], azi[mask] = inc_azi[:, 0], inc_azi[:,1]
+
+    len_svy = len(survey.md)
+    len_md = len(md)
+    sorted_arr = np.zeros((len_svy+len_md, 3))
+    sorted_arr[0:len_svy, 0] = survey.md
+    sorted_arr[len_svy:, 0] = md
+    sorted_arr[0:len_svy, 1] = survey.inc_rad
+    sorted_arr[len_svy:, 1] = inc
+    sorted_arr[0:len_svy, 2] = survey.azi_grid_rad
+    sorted_arr[len_svy:, 2] = azi
+
+    # sort on 
+    sorted_arr = sorted_arr[np.argsort(sorted_arr[:, 0])]
+
+    sh = survey.header
+    sh.azi_reference = 'grid'
+
+    survey_interpolated = Survey(
+        md=sorted_arr[:,0],
+        inc=sorted_arr[:,1],
+        azi=sorted_arr[:,2],
+        start_xyz=survey.start_xyz,
+        start_nev=survey.start_nev,
+        header=sh,
+        deg=False,
+        error_model=None
+    )
+
+    survey_interpolated.interpolated = [
+        False if md in survey.md else True
+        for md in survey_interpolated.md
+    ]
+
+    i = -1
+    radii = []
+    cov_nev = []
+    for (md, boolean) in zip(
+        survey_interpolated.md,
+        survey_interpolated.interpolated
+    ):
+        if not boolean:
+            i += 1
+            if survey.error_model is not None:
+                # interpolate covariance error between survey stations
+                j = 1 if i < len(survey.md) - 1 else 0
+                delta_md = survey.md[i + j] - survey.md[i]
+                delta_cov_nev = (
+                    survey.cov_nev[i + j] - survey.cov_nev[i]
+                )
+                unit_cov_nev = (
+                    delta_cov_nev / delta_md
+                    if j == 1
+                    else 0
+                )
+        radii.append(survey.radius[i])
+        if survey.error_model is not None:
+            cov_nev.append(
+                survey.cov_nev[i]
+                + (
+                    (md - survey.md[i]) * unit_cov_nev
+                )
+            )
+    survey_interpolated.radius = np.array(radii)
+    if bool(cov_nev):
+        survey_interpolated.cov_nev = np.array(cov_nev)
+        survey_interpolated.cov_hla = NEV_to_HLA(
+            survey_interpolated.survey_rad,
+            survey_interpolated.cov_nev.T
+        ).T
+
+    return survey_interpolated
 
 def _interpolate_survey(survey, x=0, index=0):
     """

--- a/welleng/survey.py
+++ b/welleng/survey.py
@@ -930,11 +930,20 @@ class Survey:
 
         Examples
         --------
+        >>> import welleng as we
+        >>> import numpy as np
+        >>> survey=we.survey.Survey(
+        ...       md=[0, 500, 1000, 2000, 3000],
+        ...       inc=[0, 0, 30, 90, 90],
+        ...       azi=[0, 0, 45, 135, 180],
+        ...    )
+        >>> survey_interp = survey.interpolate_mds(
+        ...    np.arange(0, 3000, 30)
+        ... )
         """
          
         s = interpolate_mds(self, md)
         return s
-
 
     def interpolate_md(self, md):
         """


### PR DESCRIPTION
Hey Jonny, great package! I've written a vectorized version of the interpolation function because I was wanting to use it to convert measured depths of downhole surveys into tvd at my work place, which can have up to 10,000 data points (e.g. every 0.3 m for 3000 m). 

It's based on the implementation of `interpolate_md`. This solves issue #134. 

The equivalent version to calling `interpolate_survey` would be:

```python
step = 30
survey.interpolate_survey(step=step)
survey.interpolate_mds(np.round(np.arange(s.md[0], s.md[-1], step), 1))
```

I've added test cases to prove that output is equivalent to `interpolate_survey`.

Performance is significantly faster than using `interpolate_survey` on my machine for a particular micro-benchmark. This is around 50x for larger step sizes (e.g. 30 m) and around 5-10x faster for smaller step sizes (e.g. 0.1 m). The performance advantage over calling `interpolate_md` e.g. in a generator, is lower at around 10x for larger step sizes (e.g. 30 m) and around 50-70x for smaller step sizes (e.g. 0.1m). The well I was using for these micro-benchmarks is close to vertical (inclination generally between 1 and 3 degrees), has a 2400 m md and 643 survey stations

If only certain outputs were targeted (e.g. directly targeting tvd) we could make this significantly faster by not calling the Survey object on line 1670 of `survey.py` (e.g. replace with the part of MinCurve for the interest output). I've fully vectorized a version of this directly targeting the tvd and the performance is close to using linear interpolation between station md and tvd for e.g. 10,000 points