### PR TITLE
ci: bump actions to Node24-targeting majors

### DIFF
--- a/.github/workflows/documentation.yaml
+++ b/.github/workflows/documentation.yaml
@@ -9,9 +9,9 @@ jobs:
   docs:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - name: Install uv
-        uses: astral-sh/setup-uv@v5
+        uses: astral-sh/setup-uv@v8.2.0
       - name: Set up Python
         run: uv python install 3.12
       - name: Install dependencies                        

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -11,10 +11,10 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v5
+        uses: astral-sh/setup-uv@v8.2.0
 
       - name: Set up Python
         run: uv python install 3.12
@@ -23,7 +23,7 @@ jobs:
         run: uv build
 
       - name: Upload build artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: dist
           path: dist/
@@ -36,7 +36,7 @@ jobs:
       id-token: write
     steps:
       - name: Download build artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: dist
           path: dist/

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -18,9 +18,9 @@ jobs:
         python-version: ['3.10', '3.11', '3.12']
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v7
     - name: Install uv
-      uses: astral-sh/setup-uv@v5
+      uses: astral-sh/setup-uv@v8.2.0
       with:
         enable-cache: true
     - name: Set up Python ${{ matrix.python-version }}


### PR DESCRIPTION
Clears the Node.js 20 deprecation warnings seen on the v0.12.0 publish run (GitHub forces Node20-targeting actions onto Node 24 with a warning).

| action | from | to |
|---|---|---|
| actions/checkout | v4 | v7 |
| astral-sh/setup-uv | v5 | v8 |
| actions/upload-artifact | v4 | v7 |
| actions/download-artifact | v4 | v8 |

Across `publish.yml`, `python-package.yml`, `documentation.yaml`. No input changes (`enable-cache` / `name` / `path` stable across these majors). Left as-is: `pypa/gh-action-pypi-publish` (Docker, rolling `release/v1`) and `peaceiris/actions-gh-pages@v4` (already its latest major).

The `welleng-tests` check on this PR exercises the bumped `checkout`/`setup-uv` on 3.10/3.11/3.12.

🤖 Generated with [Claude Code](https://claude.com/claude-code)