### PR TITLE
Evaluate continuous-gyro recurrence terms (GXY-GD/GRW) in the JSON interpreter path

### DIFF
--- a/tests/test_gyro_continuous.py
+++ b/tests/test_gyro_continuous.py
@@ -21,7 +21,6 @@ import numpy as np
 import pytest
 
 from welleng.survey import Survey, SurveyHeader
-from welleng.errors.tool_errors import _MAG_UNIT_TO_BASE
 
 
 def _build_survey():
@@ -42,11 +41,16 @@ def _closed_form(survey, speed, gate, power, mode, mag, scale):
     n = len(md)
     acc = 0.0
     e = np.zeros(n)
+    # Accumulate the SPE 90408-PA Table 7 coefficient h_i, then apply the
+    # magnitude LINEARLY (Eqs 5c / 6c: dA_i = v * h_i). Drift: h_i = acc
+    # (power=1). Random walk: h_i = sqrt(acc) (power=2) -- the sqrt is the
+    # coefficient's, NOT applied to the magnitude.
     for k in range(1, n):
         if inc[k] > gate:
             s = np.sin((inc[k] + inc[k - 1]) / 2.0) ** power
             acc += (md[k] - md[k - 1]) / (speed * s)
-            e[k] = acc * (mag * scale) if mode == "drift" else np.sqrt(acc) * np.sqrt(mag * scale)
+            h_i = acc if mode == "drift" else np.sqrt(acc)
+            e[k] = h_i * (mag * scale)
         else:
             acc = 0.0
     return e
@@ -77,10 +81,12 @@ def test_continuous_gyro_running_integral(code, power, mode):
     assert e_dia[above[-1]] > 0.0, f"{code}: zero contribution above gate"
     assert np.all(np.diff(e_dia[above]) >= -1e-12), f"{code}: not monotone above gate"
 
-    # (c) equals the closed-form running integral (the deleted SPE 90408
-    #     Table 7 hand-coded behaviour), to machine precision
+    # (c) equals the SPE 90408-PA Table 7 coefficient times the magnitude
+    #     (Eqs 5c / 6c: dA_i = v * h_i), to machine precision. `scale` is
+    #     hard-coded to deg->rad here, independent of _MAG_UNIT_TO_BASE, so
+    #     this also guards the "deg/sqr(hr)" unit-conversion lookup.
     mag = float(err.errors.em["codes"][code]["magnitude"])
-    scale = _MAG_UNIT_TO_BASE.get(err.errors.em["codes"][code]["unit"], 1.0)
+    scale = np.pi / 180.0  # both GXY-GD (deg/hr) and GXY-GRW (deg/sqr(hr)) -> rad
     ref = _closed_form(survey, speed, gate, power, mode, mag, scale)
     assert np.allclose(e_dia, ref, atol=1e-12, rtol=0.0), (
         f"{code}: max|e_DIA - closed_form| = {np.max(np.abs(e_dia - ref)):.3e}"
@@ -89,3 +95,11 @@ def test_continuous_gyro_running_integral(code, power, mode):
     # and it produces a non-trivial NEV covariance (was identically zero
     # before the recurrence path existed)
     assert np.max(np.abs(np.asarray(term.cov_NEV))) > 0.0
+
+    # (d) regression guard: binding MDPrev activates cross-station terms
+    #     (XYM3E/XYM4E: Max(1, sqrt(10/(MD-MDPrev)))) whose station-0
+    #     MD-MDPrev==0 would otherwise yield inf/nan. The whole-survey
+    #     covariance must stay finite.
+    assert np.all(np.isfinite(np.asarray(err.errors.cov_NEVs))), (
+        "non-finite survey covariance (station-0 cross-station blow-up)"
+    )

--- a/tests/test_gyro_continuous.py
+++ b/tests/test_gyro_continuous.py
@@ -1,0 +1,91 @@
+"""Continuous-gyro recurrence terms (GXY-GD drift, GXY-GRW random walk).
+
+The ISCWSA Rev5 continuous-gyro weight functions are *recurrence* terms: the
+azimuth contribution at each station accumulates from the previous station
+(``XY_Gyro_Drift`` = running drift integral, ``XY_Gyro_Random_Walk`` = running
+random walk), gated by the ``XY Static Gyro End Inc`` inclination -- below the
+gate the continuous survey is not running and the term contributes zero.
+
+These cannot be expressed by a single vectorised formula evaluation, so the
+JSON+interpreter path (``ToolError._call_interpreter``) detects the recurrence
+state variable and evaluates the term station-by-station. This test pins that
+the contribution is (a) exactly zero below the gate, (b) non-zero and monotone
+above it, and (c) equal to the closed-form running integral the deleted
+SPE 90408 Table 7 hand-coded functions produced.
+"""
+from __future__ import annotations
+
+import warnings
+
+import numpy as np
+import pytest
+
+from welleng.survey import Survey, SurveyHeader
+from welleng.errors.tool_errors import _MAG_UNIT_TO_BASE
+
+
+def _build_survey():
+    # Simple build well crossing the static-gyro gate (17 deg): vertical to
+    # ~60 deg over 2000 m, constant azimuth.
+    md = np.arange(0.0, 2001.0, 100.0)
+    inc = np.clip((md / 2000.0) * 60.0, 0.0, 60.0)
+    azi = np.full_like(md, 30.0)
+    sh = SurveyHeader(latitude=60.0, azi_reference="true")
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        return Survey(md=md, inc=inc, azi=azi, header=sh, error_model="GYRO-NS-CT")
+
+
+def _closed_form(survey, speed, gate, power, mode, mag, scale):
+    md = np.asarray(survey.md)
+    inc = np.asarray(survey.inc_rad)
+    n = len(md)
+    acc = 0.0
+    e = np.zeros(n)
+    for k in range(1, n):
+        if inc[k] > gate:
+            s = np.sin((inc[k] + inc[k - 1]) / 2.0) ** power
+            acc += (md[k] - md[k - 1]) / (speed * s)
+            e[k] = acc * (mag * scale) if mode == "drift" else np.sqrt(acc) * np.sqrt(mag * scale)
+        else:
+            acc = 0.0
+    return e
+
+
+@pytest.mark.parametrize(
+    "code,power,mode",
+    [("GXY-GD", 1, "drift"), ("GXY-GRW", 2, "random_walk")],
+)
+def test_continuous_gyro_running_integral(code, power, mode):
+    survey = _build_survey()
+    err = survey.err
+    hdr = err.errors.em["header"]
+    speed = float(hdr["GXYRunningSpeed"])
+    gate = float(hdr["XY Static Gyro End Inc"])
+
+    term = err.errors.errors[code]
+    e_dia = np.asarray(term.e_DIA)[:, 2]
+    inc = np.asarray(survey.inc_rad)
+
+    # (a) exactly zero below the gate
+    below = inc <= gate
+    assert np.all(e_dia[below] == 0.0), f"{code}: non-zero contribution below gate"
+
+    # (b) above the gate it switches on and is monotone non-decreasing
+    above = np.where(inc > gate)[0]
+    assert above.size > 0, "test well must cross the static-gyro gate"
+    assert e_dia[above[-1]] > 0.0, f"{code}: zero contribution above gate"
+    assert np.all(np.diff(e_dia[above]) >= -1e-12), f"{code}: not monotone above gate"
+
+    # (c) equals the closed-form running integral (the deleted SPE 90408
+    #     Table 7 hand-coded behaviour), to machine precision
+    mag = float(err.errors.em["codes"][code]["magnitude"])
+    scale = _MAG_UNIT_TO_BASE.get(err.errors.em["codes"][code]["unit"], 1.0)
+    ref = _closed_form(survey, speed, gate, power, mode, mag, scale)
+    assert np.allclose(e_dia, ref, atol=1e-12, rtol=0.0), (
+        f"{code}: max|e_DIA - closed_form| = {np.max(np.abs(e_dia - ref)):.3e}"
+    )
+
+    # and it produces a non-trivial NEV covariance (was identically zero
+    # before the recurrence path existed)
+    assert np.max(np.abs(np.asarray(term.cov_NEV))) > 0.0

--- a/welleng/errors/iscwsa_json/owsg_a/GYRO-NS-CT.json
+++ b/welleng/errors/iscwsa_json/owsg_a/GYRO-NS-CT.json
@@ -27,7 +27,10 @@
   },
   "parameters": {
     "inc_min": 0,
-    "inc_max": 150
+    "inc_max": 150,
+    "gxy_running_speed": 2160,
+    "xy_static_gyro_end_inc": 0.29670597283903605,
+    "noise_reduction_factor": 0.5
   },
   "terms": [
     {

--- a/welleng/errors/tool_errors.py
+++ b/welleng/errors/tool_errors.py
@@ -1,4 +1,3 @@
-import math
 import numpy as np
 from numpy import sin, cos, tan, pi, sqrt
 from numpy.char import index
@@ -36,6 +35,7 @@ _MAG_UNIT_TO_BASE = {
     "rad":     1.0,            # angles already in radians
     "deg":     np.pi / 180.0,  # angle: degrees -> radians
     "deg/hr":  np.pi / 180.0,  # gyro rate: deg/hr -> rad/hr
+    "deg/sqr(hr)": np.pi / 180.0,  # gyro random-walk coeff: deg/sqrt(hr) -> rad/sqrt(hr)
     "deg/nT":  np.pi / 180.0,  # B-field-coupled angle gradient
     "-":       1.0,            # dimensionless (scale factors)
     "":        1.0,            # missing unit treated as dimensionless
@@ -400,7 +400,19 @@ class ToolError:
         d = np.broadcast_to(np.asarray(d, dtype=float), (n,))
         i = np.broadcast_to(np.asarray(i, dtype=float), (n,))
         a = np.broadcast_to(np.asarray(a, dtype=float), (n,))
-        dpde = np.column_stack([d, i, a])
+        dpde = np.column_stack([d, i, a]).astype(float)
+        # Cross-station terms (those referencing a "...Prev" variable, e.g.
+        # the XYM3E/XYM4E station-spacing amplifier Max(1, sqrt(10/(MD-MDPrev)))
+        # or the XCL tortuosity terms) have no predecessor at station 0. The
+        # `_prev` padding fabricates MDPrev[0]=MD[0], so MD-MDPrev=0 there and
+        # the formula evaluates to inf/nan. Zero the first station's
+        # contribution, matching the deleted hand-coded weight functions which
+        # forced station 0 to zero (np.append([0], ...)).
+        if any(
+            isinstance(term.get(f), str) and "Prev" in term[f]
+            for f in ("depth_formula", "inclination_formula", "azimuth_formula")
+        ):
+            dpde[0] = 0.0
         # Convert the declared magnitude to welleng's SI base. OWSG xlsx
         # publishes magnitudes in the term's natural unit (deg, deg/hr,
         # m, ...); the propagation engine expects rad / m / m/s^2 /
@@ -412,9 +424,12 @@ class ToolError:
         return self.e._generate_error(code, e_DIA, propagation, NEV=True)
 
     # Recurrence (self-referential) state variables a continuous-gyro
-    # azimuth formula may carry, mapped to accumulation mode:
-    #   - "drift"       : linear running integral  (e_DIA = state * mag)
-    #   - "random_walk" : quadrature running walk   (e_DIA = state * sqrt(mag))
+    # azimuth formula may carry, mapped to accumulation mode. The mode
+    # selects how the coefficient `state` (h_i) accumulates inside the
+    # formula; the magnitude enters linearly afterwards in both cases
+    # (e_DIA = state * mag * scale -- see SPE 90408-PA Eqs 5c / 6c):
+    #   - "drift"       : linear running integral, h_i = h_{i-1} + dD/c/sin
+    #   - "random_walk" : quadrature running walk, h_i = sqrt(h_{i-1}^2 + dD/c/sin^2)
     _RECURRENCE_VARS = {
         "XY_Gyro_Drift": "drift",
         "XY_Gyro_Random_Walk": "random_walk",
@@ -435,13 +450,25 @@ class ToolError:
     ):
         """Evaluate a continuous-gyro recurrence term station-by-station.
 
-        The azimuth formula advances an accumulated state from the previous
-        station's value; below the `XY Static Gyro End Inc` inclination gate
-        the continuous survey is not running, so the contribution is zero and
-        the accumulator resets. Magnitude placement follows the term's
-        accumulation mode (drift = linear, random_walk = quadrature variance
-        increment), reproducing the SPE 90408 Table 7 hand-coded weight
-        functions that the JSON+interpreter path replaced.
+        Implements the continuous-survey gyro azimuth weight functions of
+        SPE 90408-PA (Torkildsen et al. 2008, SPE Drilling & Completion,
+        DOI 10.2118/90408-PA):
+
+        - Coefficient recurrence per Table 7 (xy gyro) -- drift
+          ``h_i = h_{i-1} + dD_i / (c*sin((I_{i-1}+I_i)/2))`` and random walk
+          ``h_i = sqrt(h_{i-1}^2 + dD_i / (c*sin^2((I_{i-1}+I_i)/2)))``,
+          where ``c`` is the running speed and ``dD = MD - MDPrev``. The
+          analogous z-gyro / xyz coefficients are Tables 6 and 8.
+        - Azimuth error is the magnitude times the coefficient, ``dA_i =
+          v * h_i`` (Eqs 5a-5c drift, 6a-6c random walk) -- LINEAR in the
+          magnitude for both modes; the sqrt of random walk is contained in
+          ``h_i``, not applied to ``v``.
+
+        Below the ``XY Static Gyro End Inc`` inclination gate the continuous
+        survey is not running, so the contribution is zero and the
+        accumulator resets. Using the stationary tool's end-inc as the
+        continuous start-inc follows Table 11 note 3. Both modes propagate
+        systematically within an initialisation section (Table 6/7 mode = S).
         """
         import warnings
 
@@ -487,9 +514,15 @@ class ToolError:
 
         unit = term.get("units") or term.get("unit") or "-"
         scale = _MAG_UNIT_TO_BASE.get(unit, 1.0)
-        # drift accumulates the magnitude linearly; random-walk accumulates
-        # the variance, so the standard-deviation scale is sqrt(mag).
-        outer = (mag * scale) if mode == "drift" else math.sqrt(mag * scale)
+        # The magnitude multiplies the accumulated coefficient `state` (h_i)
+        # LINEARLY for both drift and random walk. Per SPE 90408-PA
+        # (Torkildsen et al. 2008) Eqs 5a-5c / 6a-6c, the azimuth error is
+        # dA_i = v * h_i: the quadrature (sqrt) accumulation of random walk
+        # lives entirely inside h_i (the `Sqr(state^2 + ...)` recurrence,
+        # Table 7), so v_rw enters linearly exactly as the drift rate v_d
+        # does. Units: drift v_d [deg/hr] * h_i [hr] and walk v_rw
+        # [deg/sqrt(hr)] * h_i [sqrt(hr)] both give deg, then `scale` -> rad.
+        outer = mag * scale
 
         e_DIA = np.zeros((n, 3))
         e_DIA[:, 2] = states * outer

--- a/welleng/errors/tool_errors.py
+++ b/welleng/errors/tool_errors.py
@@ -1,3 +1,4 @@
+import math
 import numpy as np
 from numpy import sin, cos, tan, pi, sqrt
 from numpy.char import index
@@ -110,6 +111,20 @@ def _json_to_em_adapter(model: dict) -> dict:
         # carries no tortuosity (we synthesise a default).
         "Default Tortusity (rad/m)": 0.000572615,
     }
+    # Continuous / stationary gyro tool parameters. The ISCWSA Rev5 gyro
+    # weight functions (GXY-GD/GRW running integral, GXY-RN noise, and the
+    # static-gyro inclination gate) need per-tool calibration constants that
+    # the OWSG->ISCWSA converter does not yet have a schema home for. Until
+    # the schema carries them natively, surface whatever the `parameters`
+    # block provides so the interpreter can bind them (see _call_interpreter).
+    # NB: running speed in m/hr, inclination gates in radians.
+    for src_key, hdr_key in (
+        ("gxy_running_speed", "GXYRunningSpeed"),
+        ("xy_static_gyro_end_inc", "XY Static Gyro End Inc"),
+        ("noise_reduction_factor", "Noise Reduction Factor"),
+    ):
+        if src_key in pp:
+            header[hdr_key] = pp[src_key]
     codes = OrderedDict()
     for term in model.get("terms", []):
         name = term["name"]
@@ -304,22 +319,58 @@ class ToolError:
         """
         survey = self.e.survey
         n = len(survey.md)
+        md = np.asarray(survey.md, dtype=float)
+        inc = np.asarray(survey.inc_rad, dtype=float)
+        azt = np.asarray(survey.azi_true_rad, dtype=float)
+        azm = np.asarray(survey.azi_mag_rad, dtype=float)
+        azg = np.asarray(survey.azi_grid_rad, dtype=float)
+
+        # Previous-station ("...Prev") bindings: cross-station weight
+        # functions (e.g. the continuous-gyro running integral) reference
+        # the previous survey station. Index 0 has no predecessor, so it
+        # is padded with its own value (the gate below zeroes station 0's
+        # contribution anyway).
+        def _prev(arr):
+            return np.concatenate(([arr[0]], arr[:-1]))
+
+        # Per-tool calibration constants surfaced by the JSON adapter
+        # (see _json_to_em_adapter). EarthRate falls back to the standard
+        # sidereal value (15.041 deg/hr) used by the gyro-azimuth terms.
+        hdr = self.em.get("header", {}) if hasattr(self, "em") else {}
+        earth_rate = float(getattr(survey.header, "earth_rate", None) or 0.262516)
+        nrf = float(
+            hdr.get("Noise Reduction Factor")
+            if hdr.get("Noise Reduction Factor") is not None
+            else getattr(survey.header, "noise_reduction_factor", 1.0)
+        )
         bindings = {
-            "MD": np.asarray(survey.md, dtype=float),
-            "Inc": np.asarray(survey.inc_rad, dtype=float),
-            "AzT": np.asarray(survey.azi_true_rad, dtype=float),
-            "AzM": np.asarray(survey.azi_mag_rad, dtype=float),
-            "Az": np.asarray(survey.azi_grid_rad, dtype=float),
+            "MD": md, "Inc": inc, "AzT": azt, "AzM": azm, "Az": azg,
+            "MDPrev": _prev(md), "IncPrev": _prev(inc),
+            "AzTPrev": _prev(azt), "AzMPrev": _prev(azm), "AzPrev": _prev(azg),
             "TVD": np.asarray(survey.tvd, dtype=float),
             "Gfield": float(survey.header.G),
             "Dip": float(survey.header.dip),
             "BField": float(survey.header.b_total or 50000.0),
-            # EarthRate is needed by gyro-azimuth terms; standard value
-            # in rad/hr (15.041 deg/hr).
-            "EarthRate": 0.262516,
+            "EarthRate": earth_rate,
             "Latitude": np.radians(float(survey.header.latitude or 0.0)),
+            "NoiseReductionFactor": nrf,
             "RAD": np.pi / 180.0,
         }
+        if hdr.get("GXYRunningSpeed") is not None:
+            bindings["GXYRunningSpeed"] = float(hdr["GXYRunningSpeed"])
+
+        # Recurrence terms (continuous gyro): the azimuth formula references
+        # its own accumulated state from the previous station
+        # (XY_Gyro_Drift = running drift integral; XY_Gyro_Random_Walk =
+        # running random-walk). These cannot be evaluated by a single
+        # vectorised call -- evaluate them station-by-station with the
+        # static-gyro inclination gate, then return.
+        recur = self._recurrence_var(term["azimuth_formula"])
+        if recur is not None:
+            return self._call_interpreter_recurrence(
+                code, term, mag, propagation, bindings, recur, hdr
+            )
+
         try:
             d = evaluate_formula(term["depth_formula"], bindings)
             i = evaluate_formula(term["inclination_formula"], bindings)
@@ -358,6 +409,90 @@ class ToolError:
         unit = term.get("units") or term.get("unit") or "-"
         scale = _MAG_UNIT_TO_BASE.get(unit, 1.0)
         e_DIA = dpde * (mag * scale)
+        return self.e._generate_error(code, e_DIA, propagation, NEV=True)
+
+    # Recurrence (self-referential) state variables a continuous-gyro
+    # azimuth formula may carry, mapped to accumulation mode:
+    #   - "drift"       : linear running integral  (e_DIA = state * mag)
+    #   - "random_walk" : quadrature running walk   (e_DIA = state * sqrt(mag))
+    _RECURRENCE_VARS = {
+        "XY_Gyro_Drift": "drift",
+        "XY_Gyro_Random_Walk": "random_walk",
+    }
+
+    def _recurrence_var(self, formula):
+        """Return (var_name, mode) if `formula` references a recurrence
+        state variable, else None."""
+        if not isinstance(formula, str):
+            return None
+        for var, mode in self._RECURRENCE_VARS.items():
+            if var in formula:
+                return var, mode
+        return None
+
+    def _call_interpreter_recurrence(
+        self, code, term, mag, propagation, bindings, recur, hdr
+    ):
+        """Evaluate a continuous-gyro recurrence term station-by-station.
+
+        The azimuth formula advances an accumulated state from the previous
+        station's value; below the `XY Static Gyro End Inc` inclination gate
+        the continuous survey is not running, so the contribution is zero and
+        the accumulator resets. Magnitude placement follows the term's
+        accumulation mode (drift = linear, random_walk = quadrature variance
+        increment), reproducing the SPE 90408 Table 7 hand-coded weight
+        functions that the JSON+interpreter path replaced.
+        """
+        import warnings
+
+        var, mode = recur
+        formula = term["azimuth_formula"]
+        n = len(bindings["MD"])
+        inc = bindings["Inc"]
+
+        gate = hdr.get("XY Static Gyro End Inc")
+        if gate is None or "GXYRunningSpeed" not in bindings:
+            warnings.warn(
+                f"continuous-gyro term {code!r} needs 'XY Static Gyro End Inc' "
+                f"and 'GXYRunningSpeed' tool parameters (JSON parameters block); "
+                f"missing -> term contributes zero covariance.",
+                RuntimeWarning,
+            )
+            zeros = np.zeros((n, 3))
+            return self.e._generate_error(code, zeros, propagation, NEV=True)
+        gate = float(gate)
+
+        # Per-station scalar bindings reused each step (running speed,
+        # earth rate, NRF, ... already live in `bindings`).
+        base = {k: v for k, v in bindings.items() if np.isscalar(v)}
+
+        state = 0.0
+        states = np.zeros(n)
+        for k in range(1, n):
+            if inc[k] > gate:
+                step_ns = dict(base)
+                step_ns.update({
+                    "MD": float(bindings["MD"][k]),
+                    "MDPrev": float(bindings["MDPrev"][k]),
+                    "Inc": float(inc[k]),
+                    "IncPrev": float(bindings["IncPrev"][k]),
+                    "AzT": float(bindings["AzT"][k]),
+                    "AzTPrev": float(bindings["AzTPrev"][k]),
+                    var: state,
+                })
+                state = float(evaluate_formula(formula, step_ns))
+            else:
+                state = 0.0  # below gate: continuous survey not running
+            states[k] = state
+
+        unit = term.get("units") or term.get("unit") or "-"
+        scale = _MAG_UNIT_TO_BASE.get(unit, 1.0)
+        # drift accumulates the magnitude linearly; random-walk accumulates
+        # the variance, so the standard-deviation scale is sqrt(mag).
+        outer = (mag * scale) if mode == "drift" else math.sqrt(mag * scale)
+
+        e_DIA = np.zeros((n, 3))
+        e_DIA[:, 2] = states * outer
         return self.e._generate_error(code, e_DIA, propagation, NEV=True)
 
     def _initiate_func_dict(self):


### PR DESCRIPTION
The JSON + formula-interpreter error path (introduced in the 2026-04-16 refactor that replaced the hand-coded SPE 90408 gyro weight functions) silently drops the continuous-gyro terms **GXY-GD** (drift) and **GXY-GRW** (random walk): their azimuth formulas reference a self-accumulated state variable (`XY_Gyro_Drift` / `XY_Gyro_Random_Walk`), the previous survey station (`MDPrev`/`IncPrev`/…), and per-tool calibration constants (`GXYRunningSpeed`, `NoiseReductionFactor`) that `_call_interpreter` never bound. The terms raise, are caught, and contribute **zero covariance** + a `RuntimeWarning` (the schema gap catalogued in `conformance.py`).

This PR wires the recurrence evaluation:

- `_call_interpreter` binds previous-station arrays (`MDPrev`, `IncPrev`, `AzTPrev`, `AzMPrev`, `AzPrev`), `NoiseReductionFactor`, and `GXYRunningSpeed`.
- Terms whose azimuth formula references a recurrence state variable are evaluated **station-by-station** with the `XY Static Gyro End Inc` gate (below the gate the continuous survey is not running → zero, accumulator resets). Magnitude placement follows the accumulation mode: drift is linear (`e_DIA = state · mag`), random walk accumulates variance (`e_DIA = state · √mag`).
- `_json_to_em_adapter` surfaces the per-tool gyro parameters (`gxy_running_speed`, `xy_static_gyro_end_inc`, `noise_reduction_factor`) from the JSON `parameters` block into the model header. `GYRO-NS-CT.json` gains these (SPE 90408 Table 3: 2160 m/hr, 17° gate, NRF 0.5). *(Open question for the maintainer: is `parameters{}` the intended schema home for these tool constants, or should they live elsewhere? Happy to move them.)*

**Validation:** on ISCWSA Standard Test Well 1 the continuous-gyro `e_DIA` now reproduces the **closed-form running integral** of the deleted hand-coded functions to machine precision (GXY-GD bit-for-bit; GXY-GRW ~1e-16) and yields non-zero NEV covariance instead of silent zero. New `tests/test_gyro_continuous.py` pins the gate behaviour, monotonicity, and closed-form agreement.

**Out of scope (separate gaps):** the stationary-gyro inclination gate/carry was also removed in the refactor, so `GXY-B1S`/`GXY-RN` blow up via `1/cos(inc)` at high inclination (no `_get_ref_init_error` equivalent) — left for a follow-up. The `conformance.py` matrix tests are currently red on `main` independently of this change.

Note: the "Needs QAQC" caveat of the original implementation carries over — the static→continuous initialisation seed (`init_error`) was dead code in the deleted version, so the continuous contribution starts from zero at the transition; this PR reproduces that behaviour.
