### PR TITLE
docs: add Zenodo DOI citation to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@
 [![Downloads](https://static.pepy.tech/personalized-badge/welleng?period=total&units=international_system&left_color=grey&right_color=orange&left_text=Downloads&kill_cache=1)](https://pepy.tech/project/welleng)
 [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
 [![welleng-tests Actions Status](https://github.com/jonnymaserati/welleng/workflows/welleng-tests/badge.svg)](https://github.com/jonnymaserati/welleng/actions)
+[![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.20940515.svg)](https://doi.org/10.5281/zenodo.20940515)
 
 [welleng] is a collection of tools for Wells/Drilling Engineers, with a focus on well trajectory design and analysis.
 
@@ -267,6 +268,23 @@ It's possible to generate data for visualizing well trajectories with [welleng],
 ISCWSA Standard Set of Well Paths
 
 The ISCWSA standard set of well paths for evaluating clearance scenarios have been rendered in [blender] above. See the [examples] for the code used to generate a [volve] scene, extracting the data from the [volve] EDM.xml file.
+
+## Citation
+
+If welleng or its error-model validation supports your work, please cite the gyro error-model validation paper:
+
+> Corcutt, J. (2026). *Reproducing the ISCWSA Gyro Error-Model Test Cases: Implementation Clarifications, Reference-Data Inconsistencies, and an Open-Source Reference Implementation.* Zenodo. <https://doi.org/10.5281/zenodo.20940515>
+
+```bibtex
+@misc{corcutt2026welleng,
+  author    = {Corcutt, Jonathan},
+  title     = {Reproducing the {ISCWSA} Gyro Error-Model Test Cases: Implementation Clarifications, Reference-Data Inconsistencies, and an Open-Source Reference Implementation},
+  year      = {2026},
+  publisher = {Zenodo},
+  doi       = {10.5281/zenodo.20940515},
+  url       = {https://doi.org/10.5281/zenodo.20940515}
+}
+```
 
 ## License
 


### PR DESCRIPTION
Adds a Zenodo DOI badge + a Citation section (reference + BibTeX) for the gyro error-model validation paper, [10.5281/zenodo.20940515](https://doi.org/10.5281/zenodo.20940515). README-only.