### PR TITLE
chore: gitignore docs/dev/ + .env

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,6 @@ VERSION*
 test/test_data/*.xlsx
 
 CLAUDE.md
+docs/dev/
+# secrets
+.env


### PR DESCRIPTION
Hygiene: ignore local-only `docs/dev/` and `.env` (secrets — never committed), add trailing newline. No tracked files affected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)