### PR TITLE
docs(readme): cite the welleng software DOI

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![Downloads](https://static.pepy.tech/personalized-badge/welleng?period=total&units=international_system&left_color=grey&right_color=orange&left_text=Downloads&kill_cache=1)](https://pepy.tech/project/welleng)
 [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
 [![welleng-tests Actions Status](https://github.com/jonnymaserati/welleng/workflows/welleng-tests/badge.svg)](https://github.com/jonnymaserati/welleng/actions)
-[![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.20940515.svg)](https://doi.org/10.5281/zenodo.20940515)
+[![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.20968887.svg)](https://doi.org/10.5281/zenodo.20968887)
 
 [welleng] is a collection of tools for Wells/Drilling Engineers, with a focus on well trajectory design and analysis.
 
@@ -271,12 +271,26 @@ The ISCWSA standard set of well paths for evaluating clearance scenarios have be
 
 ## Citation
 
-If welleng or its error-model validation supports your work, please cite the gyro error-model validation paper:
+If welleng supports your work, please cite the **software** (the concept DOI always resolves to the latest version):
+
+> Corcutt, J. *welleng: open-source well-engineering tools.* Zenodo. <https://doi.org/10.5281/zenodo.20968887>
+
+```bibtex
+@software{corcutt_welleng,
+  author    = {Corcutt, Jonathan},
+  title     = {welleng: open-source well-engineering tools},
+  publisher = {Zenodo},
+  doi       = {10.5281/zenodo.20968887},
+  url       = {https://doi.org/10.5281/zenodo.20968887}
+}
+```
+
+If your work relies on the **gyro error-model validation** specifically, please also cite:
 
 > Corcutt, J. (2026). *Reproducing the ISCWSA Gyro Error-Model Test Cases: Implementation Clarifications, Reference-Data Inconsistencies, and an Open-Source Reference Implementation.* Zenodo. <https://doi.org/10.5281/zenodo.20940515>
 
 ```bibtex
-@misc{corcutt2026welleng,
+@misc{corcutt2026gyro,
   author    = {Corcutt, Jonathan},
   title     = {Reproducing the {ISCWSA} Gyro Error-Model Test Cases: Implementation Clarifications, Reference-Data Inconsistencies, and an Open-Source Reference Implementation},
   year      = {2026},


### PR DESCRIPTION
Top DOI badge → welleng software concept DOI `10.5281/zenodo.20968887` (was the gyro paper DOI). Add a 'cite the software' block; keep the gyro paper as a secondary citation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)