### PR TITLE
fix(errors): ISCWSA error-model integrity — XCL/GField/Bfield silent-zero, binding guard, geomag, OWSG sheet parsing

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,6 @@
+# The ISCWSA error-model JSON is GENERATED from the ISCWSA-issued OWSG spreadsheets
+# by welleng/errors/tools/owsg_to_json.py. Mark it as generated so GitHub collapses
+# it in pull-request diffs and flags it as not-hand-authored. Do NOT hand-edit these
+# files — regenerate from the source xlsx. The test_iscwsa_json_generated.py CI guard
+# fails any PR whose committed JSON diverges from the generator output.
+welleng/errors/iscwsa_json/**/*.json linguist-generated=true

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,19 @@
+# Code owners — paths that require maintainer review on every pull request.
+#
+# To ENFORCE this, enable "Require review from Code Owners" in the branch-protection
+# rule for the default branch (Settings → Branches). Listing owners here alone does
+# not block merges until that toggle is on.
+#
+# Why the error-model paths are gated: the ISCWSA error-model JSON under
+# iscwsa_json/ is GENERATED from the ISCWSA-issued OWSG spreadsheets by
+# owsg_to_json.py — it must never be hand-edited (a past PR hijacked
+# GYRO-NS-CT.json, overwriting its ISCWSA sheet parameters with SPE-90408 paper
+# values to satisfy a test). Any change to the generator, the generated models, the
+# error engine, or the generated-JSON guard test needs maintainer eyes — even though
+# test_iscwsa_json_generated.py already fails a hand-edit in CI.
+
+/welleng/errors/iscwsa_json/           @jonnymaserati
+/welleng/errors/tools/owsg_to_json.py  @jonnymaserati
+/welleng/errors/tool_errors.py         @jonnymaserati
+/welleng/errors/conformance.py         @jonnymaserati
+/tests/test_iscwsa_json_generated.py   @jonnymaserati

--- a/README.md
+++ b/README.md
@@ -21,20 +21,48 @@
 - **Data exchange** — import/export Landmark .wbp files; read EDM datasets
 - **World Magnetic Model** — auto-calculates magnetic field data when not supplied
 
-Available error models:
+### Selecting an error model
+
+`Survey`/`SurveyHeader` take an `error_model` name — **switch models by changing the
+string**. The **default and recommended model is `"ISCWSA MWD Rev5.11"`**: the current
+ISCWSA standard, validated 35/35 sources against all three ISCWSA example workbooks.
+Omit `error_model` (leave it `None`) for no uncertainty calculation.
+
 ```python
 import welleng as we
-we.error.get_error_models()
+
+we.error.get_error_models()            # -> list every available model name
+
+survey = we.survey.Survey(
+    md, inc, azi, header=header,
+    error_model="ISCWSA MWD Rev5.11",  # the standard; change this string to switch
+)
+cov = survey.err.errors.cov_NEVs       # NEV covariance per station
 ```
 
+**Model families** (all selectable by name via `error_model=`):
+- **Canonical ISCWSA MWD** — `"ISCWSA MWD Rev5.11"` (**default**, validated),
+  `"ISCWSA MWD Rev4"` (legacy, to reproduce older results). (The older
+  `"ISCWSA MWD Rev5"` name has been retired — use `"ISCWSA MWD Rev5.11"`.)
+- **OWSG tool stacks** (Set A, JSON-driven) — the toolcode library:
+  `"MWD+SRGM"`, `"MWD+SRGM+SAG"`, `"MWD+SRGM+AX"` (axial-interference correction),
+  `"MWD+IFR1"` / `"MWD+IFR1+AX"` (in-field referencing), and the gyro stacks
+  `"GYRO-NS"` (north-seeking stationary), `"GYRO-NS-CT"` (mixed continuous),
+  `"GYRO-MWD"`. A `_Fl` suffix is the floating-rig variant.
+
+> **Revisions.** welleng ships **Rev5-1 / Rev5.11** as the default. The older **OWSG
+> Rev2** (2015) toolcodes can be regenerated from their workbooks with
+> `python -m welleng.errors.tools.owsg_to_json`, but are not yet shipped as a
+> selectable revision (tracked in `docs/dev/FUTURE_WORK.md`). Validate any model only
+> against a **matching-revision** reference.
+
 > **Error model update (welleng 0.10.0).** The MWD Rev 5 model has been brought
-> into compliance with the ISCWSA Rev 5.11 example workbooks. The
-> `"ISCWSA MWD Rev5"` string remains a selectable alias with a
-> `DeprecationWarning` pointing at the new `"ISCWSA MWD Rev5.11"` name, but
-> produces the corrected Rev 5.11 covariance (slightly different numerical
-> output to welleng ≤ 0.9.x). `"ISCWSA MWD Rev4"` is unchanged for users who
-> need to reproduce older results. See `welleng/errors/iscwsa_validate.py` for
-> the validation harness used to audit against each ISCWSA example workbook.
+> into compliance with the ISCWSA Rev 5.11 example workbooks; select it as
+> `"ISCWSA MWD Rev5.11"` (the older `"ISCWSA MWD Rev5"` name has since been
+> retired). Its covariance differs slightly from welleng ≤ 0.9.x (the Rev 5.11
+> corrections). `"ISCWSA MWD Rev4"` is unchanged for users who need to reproduce
+> older results. See `welleng/errors/iscwsa_validate.py` for the validation harness
+> used to audit against each ISCWSA example workbook.
 
 > **Gyro support + JSON-driven tool models (welleng 0.11.0).** ISCWSA is
 > moving its error-model standard from the legacy Excel workbooks to a

--- a/tests/test_gyro_continuous.py
+++ b/tests/test_gyro_continuous.py
@@ -24,8 +24,9 @@ from welleng.survey import Survey, SurveyHeader
 
 
 def _build_survey():
-    # Simple build well crossing the static-gyro gate (17 deg): vertical to
-    # ~60 deg over 2000 m, constant azimuth.
+    # Simple build well crossing the static-gyro gate (15 deg, GYRO-NS-CT's
+    # ISCWSA-sheet value -- read from the model, not assumed): vertical to ~60 deg
+    # over 2000 m, constant azimuth.
     md = np.arange(0.0, 2001.0, 100.0)
     inc = np.clip((md / 2000.0) * 60.0, 0.0, 60.0)
     azi = np.full_like(md, 30.0)

--- a/tests/test_iscwsa_json_bindings.py
+++ b/tests/test_iscwsa_json_bindings.py
@@ -1,0 +1,87 @@
+"""Every formula variable in every shipped OWSG JSON model must be bindable.
+
+A silent binding-name mismatch -- a formula referencing ``Bfield`` while the
+interpreter binds ``BField``, or ``GField`` vs ``Gfield`` -- makes the interpreter
+throw, the term is caught, and it contributes ZERO covariance *silently*. That is
+exactly how XCLTortuosity (whole XCL term) and GField/Bfield (the ABIXY/MFI axial-
+interference terms) were dead for ~32 models without any test noticing.
+
+This sweep evaluates every formula axis of every shipped model against the full
+production binding set and fails if any variable is unbound, so the class of bug
+can't regress.
+"""
+from __future__ import annotations
+
+import json
+import re
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+from welleng.errors.conformance import _bindings_from_survey, standard_test_survey
+from welleng.errors.interpreter import evaluate_formula
+
+JSON_ROOT = Path(__file__).parent.parent / "welleng" / "errors" / "iscwsa_json"
+
+# Per-tool parameter(s) that non-deferred terms reference; supplied so only
+# GENUINELY unbound (mis-named) variables surface. XCLTortuosity is usually carried
+# in the model's own parameters block, but a fallback here keeps models that omit it
+# from false-flagging.
+_EXTRA = {
+    "XCLTortuosity": 5.726e-4,
+}
+
+# Gyro drift / random-walk / noise terms are evaluated station-by-station via the
+# recurrence path (tool_errors), not a single vectorised formula eval -- and the
+# Z-gyro variants (GZ-*) are not yet wired (the recurrence path is XY-only). Their
+# per-tool / state variables (GXYRunningSpeed, GZRunningSpeed, XY/Z_Gyro_Drift, ...)
+# are out of scope for this binding-name check; skip the family. Tracked as deferred
+# gyro work (GYRO_SURVEY_PLAN.md / FUTURE_WORK).
+_DEFERRED = re.compile(r"^G(XY|Z|XYZ)-(GD|GRW|RN)")
+
+_AXES = (
+    "depth_formula", "inclination_formula", "azimuth_formula",
+    "north_singularity", "east_singularity", "vertical_singularity",
+)
+
+_MODELS = sorted(JSON_ROOT.glob("owsg_*/*.json"))
+
+
+def _full_bindings() -> dict:
+    b = dict(_bindings_from_survey(standard_test_survey()))
+    b.update(_EXTRA)
+    return b
+
+
+@pytest.mark.parametrize(
+    "json_path", _MODELS, ids=[f"{p.parent.name}/{p.stem}" for p in _MODELS]
+)
+def test_all_formula_variables_are_bindable(json_path):
+    model = json.loads(json_path.read_text())
+    bindings = _full_bindings()
+    for k, v in (model.get("parameters") or {}).items():
+        if isinstance(v, (int, float)):
+            bindings[k] = float(v)
+
+    undefined: dict[str, set] = {}
+    for term in model["terms"]:
+        if _DEFERRED.match(term["name"]):
+            continue
+        for axis in _AXES:
+            f = term.get(axis)
+            if not isinstance(f, str):
+                continue
+            try:
+                with np.errstate(all="ignore"):
+                    evaluate_formula(f, bindings)
+            except Exception as exc:  # noqa: BLE001 -- only NameErrors are bugs here
+                m = re.search(r"name '([^']+)' is not defined", str(exc))
+                if m:
+                    undefined.setdefault(m.group(1), set()).add(term["name"])
+
+    assert not undefined, (
+        f"{json_path.name}: formula variable(s) not in the interpreter bindings -- "
+        f"these terms would silently contribute ZERO covariance: "
+        + "; ".join(f"{var!r} in {sorted(terms)}" for var, terms in undefined.items())
+    )

--- a/tests/test_iscwsa_json_conformance.py
+++ b/tests/test_iscwsa_json_conformance.py
@@ -34,11 +34,17 @@ JSON_ROOT = Path(__file__).parent.parent / "welleng" / "errors" / "iscwsa_json" 
 # vertical section now exercises the interpreter's SING substitution, which
 # agrees with the legacy hand-coded singular branch (was masked by the broken
 # well, where no station had inc < 0.0001 deg). Totals unchanged.
+# Re-baselined 2026-06-29: binding the previous-station arrays (MDPrev/IncPrev/
+# AzPrev) in conformance._bindings_from_survey lets the cross-station terms (XCLA/
+# XCLH, XYM3E/XYM4E) evaluate in the interpreter -- they move INTERP_FAILED ->
+# NO_LEGACY (they evaluate but welleng's legacy hand-coded dispatcher never
+# implemented them, so there is nothing to diff against). The only remaining
+# INTERP_FAILED are the recurrence/noise gyro terms (GXY-RN/GD/GRW).
 EXPECTED = [
-    ("MWD+SRGM.json",   29, 1, 4, 1, 35),
-    ("GYRO-NS.json",     6, 0, 5, 7, 18),
-    ("GYRO-NS-CT.json",  6, 0, 7, 6, 19),
-    ("GYRO-MWD.json",    6, 0, 5, 7, 18),
+    ("MWD+SRGM.json",   29, 1, 0,  5, 35),
+    ("GYRO-NS.json",     6, 0, 1, 11, 18),
+    ("GYRO-NS-CT.json",  6, 0, 3, 10, 19),
+    ("GYRO-MWD.json",    6, 0, 1, 11, 18),
 ]
 
 
@@ -92,11 +98,14 @@ def test_conformance_matrix(survey, json_name, exp_match, exp_differ,
 
 
 def test_known_schema_gaps_present(survey):
-    """The catalogued schema gaps should still be detected.
+    """Lock which terms evaluate vs remain a gap.
 
-    If any of these terms suddenly evaluates cleanly, either the schema
-    has gained a new variable (good — update this test) or the interpreter
-    is silently substituting something wrong (bad — investigate).
+    Cross-station terms (XCLA/XCLH, XYM3E/XYM4E) now evaluate -- the prev-station
+    arrays (MDPrev/IncPrev/AzPrev) are bound (2026-06-29), matching production. The
+    remaining interpreter gaps are the recurrence/noise gyro terms (GXY-RN noise,
+    GXY-GD drift, GXY-GRW random walk), which the single-vectorised conformance eval
+    cannot express (they need the station-by-station recurrence path). If one of
+    those suddenly evaluates, the harness gained the recurrence path -- update this.
     """
     path = JSON_ROOT / "GYRO-NS-CT.json"
     if not path.exists():
@@ -105,17 +114,20 @@ def test_known_schema_gaps_present(survey):
     results = compare_model(str(path), survey)
     by_name = {r.name: r for r in results}
 
-    cross_station = {"XYM3E", "XYM4E", "XCLA", "XCLH"}
-    per_tool_calibration = {"GXY-RN", "GXY-GD", "GXY-GRW"}
+    # Now evaluate (were INTERP_FAILED before the prev-station bindings):
+    for term in ("XCLA", "XCLH", "XYM3E", "XYM4E"):
+        if term in by_name:
+            assert by_name[term].interp_available, (
+                f"{term} no longer evaluates — prev-station bindings regressed?"
+            )
 
-    for term in cross_station | per_tool_calibration:
-        if term not in by_name:
-            continue
-        r = by_name[term]
-        assert not r.interp_available, (
-            f"{term} unexpectedly evaluated — schema gap closed? "
-            f"Update the conformance matrix expectation."
-        )
+    # Still a gap (recurrence/noise terms the vectorised harness can't express):
+    for term in ("GXY-RN", "GXY-GD", "GXY-GRW"):
+        if term in by_name:
+            assert not by_name[term].interp_available, (
+                f"{term} unexpectedly evaluated — harness gained the recurrence "
+                f"path? Update the conformance matrix expectation."
+            )
 
 
 def test_mwd_canonical_terms_match_to_machine_precision(survey):

--- a/tests/test_iscwsa_json_generated.py
+++ b/tests/test_iscwsa_json_generated.py
@@ -1,0 +1,61 @@
+"""Guard: the shipped OWSG JSON models must be EXACTLY the generator's output.
+
+``welleng/errors/iscwsa_json/owsg_{a,b}/*.json`` are generated artefacts, parsed
+from the ISCWSA-issued OWSG spreadsheets by ``owsg_to_json.py``. They must never be
+hand-edited: a past commit (6885334) hijacked ``GYRO-NS-CT.json``, overwriting its
+ISCWSA sheet parameters (running speed 2743.2 m/hr, static-gyro gate 15 deg, NRF
+0.4082) with SPE-90408 paper values (2160 / 17 deg / 0.5) just to satisfy a
+validation test. That corrupts the authoritative model for every other consumer.
+
+This test regenerates the models from the vendored source spreadsheets and asserts
+they match what is committed. Any manual edit -- a "convenient" parameter override,
+a hand-tweaked formula -- fails here. If a test needs different parameter values for
+its own validation, it must override them LOCALLY, not mutate the shipped model.
+"""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from welleng.errors.tools.owsg_to_json import (
+    DEFAULT_XLSX_A,
+    DEFAULT_XLSX_B,
+    convert_workbook,
+)
+
+JSON_ROOT = Path(__file__).parent.parent / "welleng" / "errors" / "iscwsa_json"
+
+
+@pytest.mark.parametrize(
+    "label,xlsx",
+    [("a", DEFAULT_XLSX_A), ("b", DEFAULT_XLSX_B)],
+    ids=["owsg_a", "owsg_b"],
+)
+def test_shipped_json_matches_generator(label, xlsx, tmp_path):
+    if not Path(xlsx).is_file():
+        pytest.skip(f"source spreadsheet not vendored: {xlsx}")
+
+    out_dir = tmp_path / f"owsg_{label}"
+    convert_workbook(str(xlsx), str(out_dir), f"Set{label.upper()}")
+    committed_dir = JSON_ROOT / f"owsg_{label}"
+
+    mismatches: list[str] = []
+    for generated in sorted(out_dir.glob("*.json")):
+        committed = committed_dir / generated.name
+        if not committed.exists():
+            mismatches.append(f"{generated.name}: generated but not committed")
+            continue
+        if json.loads(generated.read_text()) != json.loads(committed.read_text()):
+            mismatches.append(
+                f"{generated.name}: differs from generator output (hand-edited?)"
+            )
+
+    assert not mismatches, (
+        "Shipped OWSG JSON diverges from owsg_to_json output. These are GENERATED "
+        "from the ISCWSA-issued spreadsheets -- do NOT hand-edit them. Regenerate "
+        "with `python -m welleng.errors.tools.owsg_to_json`, or, if a test needs "
+        "different parameters, override them locally in the test:\n  "
+        + "\n  ".join(mismatches)
+    )

--- a/tests/test_survey_parameters.py
+++ b/tests/test_survey_parameters.py
@@ -15,23 +15,36 @@ REFERENCE = {
 CALCULATOR = we.survey.SurveyParameters(REFERENCE.get('srs'))
 
 
-def test_known_location():
-    # Magnetic-field params need the optional 'magnetic_field_calculator'
-    # (welleng[all]) and the BGS service; skip cleanly when either is absent.
-    pytest.importorskip("magnetic_field_calculator")
+def test_known_location(monkeypatch):
+    # Always runs -- no optional 'magnetic_field_calculator' install and no live BGS
+    # network call needed. Stub the API client to return the known BGS response for
+    # this location/date, so we deterministically validate welleng's own code: the
+    # projection factors (real pyproj) and the magnetic-field processing (dip sign
+    # from the "down" units, nested-field extraction). The external service's values
+    # are not welleng's to test.
+    class _StubMagCalc:
+        def calculate(self, **kwargs):
+            return {"field-value": {
+                "total-intensity": {"value": REFERENCE["magnetic_field_intensity"]},
+                "declination": {"value": REFERENCE["declination"]},
+                # welleng negates a "down" inclination -> dip; feed +intensity so the
+                # sign handling is what's under test.
+                "inclination": {"value": -REFERENCE["dip"], "units": "deg (down)"},
+            }}
+    monkeypatch.setattr(we.survey, "MAG_CALC", True)
+    monkeypatch.setattr(we.survey, "MagneticFieldCalculator", _StubMagCalc, raising=False)
+
     survey_parameters = CALCULATOR.get_factors_from_x_y(
         x=REFERENCE.get('x'), y=REFERENCE.get('y'),
         date=REFERENCE.get('date')
     )
-    if survey_parameters.get('declination') is None:
-        pytest.skip("magnetic-field service unavailable (offline?)")
     for k, v in survey_parameters.items():
+        if REFERENCE.get(k) is None:
+            continue
         try:
             assert round(v, 3) == round(REFERENCE.get(k), 3)
         except TypeError:
             assert v == REFERENCE.get(k)
-
-    pass
 
 def test_transform_projection_coordinates():
     # Convert survey coordinates from UTM31_ED50 to UTM31_WGS84

--- a/tests/test_survey_parameters.py
+++ b/tests/test_survey_parameters.py
@@ -1,5 +1,6 @@
 import welleng as we
 import numpy as np
+import pytest
 
 REFERENCE = {
     'x': 588319.02, 'y': 5770571.03, 'northing': 5770571.03,
@@ -15,10 +16,15 @@ CALCULATOR = we.survey.SurveyParameters(REFERENCE.get('srs'))
 
 
 def test_known_location():
+    # Magnetic-field params need the optional 'magnetic_field_calculator'
+    # (welleng[all]) and the BGS service; skip cleanly when either is absent.
+    pytest.importorskip("magnetic_field_calculator")
     survey_parameters = CALCULATOR.get_factors_from_x_y(
         x=REFERENCE.get('x'), y=REFERENCE.get('y'),
         date=REFERENCE.get('date')
     )
+    if survey_parameters.get('declination') is None:
+        pytest.skip("magnetic-field service unavailable (offline?)")
     for k, v in survey_parameters.items():
         try:
             assert round(v, 3) == round(REFERENCE.get(k), 3)

--- a/welleng/errors/conformance.py
+++ b/welleng/errors/conformance.py
@@ -65,12 +65,25 @@ class TermResult:
 
 def _bindings_from_survey(survey) -> dict[str, Any]:
     """Variable namespace for formula evaluation."""
+    md = np.asarray(survey.md, dtype=float)
+    inc = np.asarray(survey.inc_rad, dtype=float)
+    azt = np.asarray(survey.azi_true_rad, dtype=float)
+    azm = np.asarray(survey.azi_mag_rad, dtype=float)
+    azg = np.asarray(survey.azi_grid_rad, dtype=float)
+
+    # Previous-station arrays (padded so station 0's "...Prev" equals its own value;
+    # the cross-station terms that consume them gate or zero station 0). Without
+    # these the XCL (XCLA/XCLH) and extended-misalignment (XYM3E/XYM4E) formulas
+    # raise and were bucketed as a schema gap -- binding them lets the conformance
+    # matrix actually cross-check those terms against the legacy path, matching what
+    # tool_errors._call_interpreter binds in production.
+    def _prev(a):
+        return np.concatenate(([a[0]], a[:-1]))
+
     return {
-        "MD": np.asarray(survey.md, dtype=float),
-        "Inc": np.asarray(survey.inc_rad, dtype=float),
-        "AzT": np.asarray(survey.azi_true_rad, dtype=float),
-        "AzM": np.asarray(survey.azi_mag_rad, dtype=float),
-        "Az": np.asarray(survey.azi_grid_rad, dtype=float),
+        "MD": md, "Inc": inc, "AzT": azt, "AzM": azm, "Az": azg,
+        "MDPrev": _prev(md), "IncPrev": _prev(inc),
+        "AzTPrev": _prev(azt), "AzMPrev": _prev(azm), "AzPrev": _prev(azg),
         "TVD": np.asarray(survey.tvd, dtype=float),
         "Gfield": float(survey.header.G),
         "Dip": float(survey.header.dip),
@@ -123,9 +136,14 @@ def _interp_eval_term(term: dict, mag_si: float, survey, bindings: dict) -> np.n
     e_DIA matches what the legacy path produces.
     """
     n = len(survey.md)
-    d = evaluate_formula(term["depth_formula"], bindings)
-    i = evaluate_formula(term["inclination_formula"], bindings)
-    a = evaluate_formula(term["azimuth_formula"], bindings)
+    # Some formulas (e.g. XCLA's /Sin(Inc)) are singular at the vertical station; the
+    # harness evaluates them anyway (the production path gates / SING-substitutes
+    # there). Suppress the divide warnings -- the values are exact away from the
+    # singularity, and irrelevant for the NO_LEGACY cross-station terms.
+    with np.errstate(divide="ignore", invalid="ignore"):
+        d = evaluate_formula(term["depth_formula"], bindings)
+        i = evaluate_formula(term["inclination_formula"], bindings)
+        a = evaluate_formula(term["azimuth_formula"], bindings)
     d = np.broadcast_to(np.asarray(d, dtype=float), (n,))
     i = np.broadcast_to(np.asarray(i, dtype=float), (n,))
     a = np.broadcast_to(np.asarray(a, dtype=float), (n,))

--- a/welleng/errors/conformance.py
+++ b/welleng/errors/conformance.py
@@ -145,6 +145,12 @@ def compare_model(json_path: str, survey, *,
     with open(json_path) as f:
         model = json.load(f)
     bindings = _bindings_from_survey(survey)
+    # Surface the JSON parameters block (XCLTortuosity, per-tool gyro constants, ...)
+    # into the formula bindings so weight functions referencing them resolve instead
+    # of throwing (the silent-zero gap). See ERROR_MODEL_ENGINE.md S8.
+    for _pk, _pv in (model.get("parameters") or {}).items():
+        if isinstance(_pv, (int, float)):
+            bindings[_pk] = float(_pv)
     n = len(survey.md)
 
     results: list[TermResult] = []

--- a/welleng/errors/conformance.py
+++ b/welleng/errors/conformance.py
@@ -86,8 +86,10 @@ def _bindings_from_survey(survey) -> dict[str, Any]:
         "AzTPrev": _prev(azt), "AzMPrev": _prev(azm), "AzPrev": _prev(azg),
         "TVD": np.asarray(survey.tvd, dtype=float),
         "Gfield": float(survey.header.G),
+        "GField": float(survey.header.G),   # casing alias (ABIXY formulas use GField)
         "Dip": float(survey.header.dip),
         "BField": float(survey.header.b_total or 50000.0),
+        "Bfield": float(survey.header.b_total or 50000.0),   # casing alias (MFI formulas use Bfield)
         "EarthRate": 0.262516,            # rad/hr (~ 15.041 deg/hr)
         "Latitude": np.radians(float(survey.header.latitude or 0.0)),
         "RAD": np.pi / 180.0,             # used in some singularity formulas

--- a/welleng/errors/copsegrove_validate.py
+++ b/welleng/errors/copsegrove_validate.py
@@ -65,8 +65,10 @@ def _bindings_for_station(
         "Az": azi_rad,
         "TVD": md_arr,     # rough; Copsegrove doesn't report TVD per term
         "Gfield": G,
+        "GField": G,        # casing alias (ABIXY formulas use GField)
         "Dip": dip_rad,
         "BField": b_total,
+        "Bfield": b_total,  # casing alias (MFI formulas use Bfield)
         "EarthRate": 0.262516,
         "Latitude": np.radians(latitude_deg),
         "RAD": np.pi / 180.0,

--- a/welleng/errors/iscwsa_json/owsg_a/BLIND.json
+++ b/welleng/errors/iscwsa_json/owsg_a/BLIND.json
@@ -1,5 +1,6 @@
 {
   "$schema": "../../iscwsa_schema/draft.json",
+  "_comment": "GENERATED from the ISCWSA-issued OWSG spreadsheet by welleng/errors/tools/owsg_to_json.py -- DO NOT EDIT BY HAND. Regenerate from the source xlsx. If a test needs different parameter values for validation, it must override them locally, never modify this shipped model. (test_iscwsa_json_generated.py enforces this.)",
   "metadata": {
     "schema_uuid": "00000000-0000-0000-0000-000000000000",
     "model_uuid": "a797aec9-13ae-5d5e-a43e-c4a4396cf1d2",

--- a/welleng/errors/iscwsa_json/owsg_a/BLIND_Fl.json
+++ b/welleng/errors/iscwsa_json/owsg_a/BLIND_Fl.json
@@ -1,5 +1,6 @@
 {
   "$schema": "../../iscwsa_schema/draft.json",
+  "_comment": "GENERATED from the ISCWSA-issued OWSG spreadsheet by welleng/errors/tools/owsg_to_json.py -- DO NOT EDIT BY HAND. Regenerate from the source xlsx. If a test needs different parameter values for validation, it must override them locally, never modify this shipped model. (test_iscwsa_json_generated.py enforces this.)",
   "metadata": {
     "schema_uuid": "00000000-0000-0000-0000-000000000000",
     "model_uuid": "a797aec9-13ae-5d5e-a43e-c4a4396cf1d2",

--- a/welleng/errors/iscwsa_json/owsg_a/CB_Film_GMS.json
+++ b/welleng/errors/iscwsa_json/owsg_a/CB_Film_GMS.json
@@ -1,5 +1,6 @@
 {
   "$schema": "../../iscwsa_schema/draft.json",
+  "_comment": "GENERATED from the ISCWSA-issued OWSG spreadsheet by welleng/errors/tools/owsg_to_json.py -- DO NOT EDIT BY HAND. Regenerate from the source xlsx. If a test needs different parameter values for validation, it must override them locally, never modify this shipped model. (test_iscwsa_json_generated.py enforces this.)",
   "metadata": {
     "schema_uuid": "00000000-0000-0000-0000-000000000000",
     "model_uuid": "9126b128-da51-5feb-9d4c-a15d072544fc",
@@ -25,7 +26,9 @@
   },
   "parameters": {
     "inc_min": 0,
-    "inc_max": 89
+    "inc_max": 89,
+    "XCLTortuosity": 0.000572614583987641,
+    "noise_reduction_factor": 1.0
   },
   "terms": [
     {

--- a/welleng/errors/iscwsa_json/owsg_a/CB_Film_GMS_Fl.json
+++ b/welleng/errors/iscwsa_json/owsg_a/CB_Film_GMS_Fl.json
@@ -1,5 +1,6 @@
 {
   "$schema": "../../iscwsa_schema/draft.json",
+  "_comment": "GENERATED from the ISCWSA-issued OWSG spreadsheet by welleng/errors/tools/owsg_to_json.py -- DO NOT EDIT BY HAND. Regenerate from the source xlsx. If a test needs different parameter values for validation, it must override them locally, never modify this shipped model. (test_iscwsa_json_generated.py enforces this.)",
   "metadata": {
     "schema_uuid": "00000000-0000-0000-0000-000000000000",
     "model_uuid": "9126b128-da51-5feb-9d4c-a15d072544fc",
@@ -25,7 +26,9 @@
   },
   "parameters": {
     "inc_min": 0,
-    "inc_max": 89
+    "inc_max": 89,
+    "XCLTortuosity": 0.000572614583987641,
+    "noise_reduction_factor": 1.0
   },
   "terms": [
     {

--- a/welleng/errors/iscwsa_json/owsg_a/CB_Film_GSS.json
+++ b/welleng/errors/iscwsa_json/owsg_a/CB_Film_GSS.json
@@ -1,5 +1,6 @@
 {
   "$schema": "../../iscwsa_schema/draft.json",
+  "_comment": "GENERATED from the ISCWSA-issued OWSG spreadsheet by welleng/errors/tools/owsg_to_json.py -- DO NOT EDIT BY HAND. Regenerate from the source xlsx. If a test needs different parameter values for validation, it must override them locally, never modify this shipped model. (test_iscwsa_json_generated.py enforces this.)",
   "metadata": {
     "schema_uuid": "00000000-0000-0000-0000-000000000000",
     "model_uuid": "dbd104c2-e8d5-508f-b2e2-7a547188562a",
@@ -25,7 +26,9 @@
   },
   "parameters": {
     "inc_min": 0,
-    "inc_max": 89
+    "inc_max": 89,
+    "XCLTortuosity": 0.000572614583987641,
+    "noise_reduction_factor": 1.0
   },
   "terms": [
     {

--- a/welleng/errors/iscwsa_json/owsg_a/CB_Film_GSS_Fl.json
+++ b/welleng/errors/iscwsa_json/owsg_a/CB_Film_GSS_Fl.json
@@ -1,5 +1,6 @@
 {
   "$schema": "../../iscwsa_schema/draft.json",
+  "_comment": "GENERATED from the ISCWSA-issued OWSG spreadsheet by welleng/errors/tools/owsg_to_json.py -- DO NOT EDIT BY HAND. Regenerate from the source xlsx. If a test needs different parameter values for validation, it must override them locally, never modify this shipped model. (test_iscwsa_json_generated.py enforces this.)",
   "metadata": {
     "schema_uuid": "00000000-0000-0000-0000-000000000000",
     "model_uuid": "dbd104c2-e8d5-508f-b2e2-7a547188562a",
@@ -25,7 +26,9 @@
   },
   "parameters": {
     "inc_min": 0,
-    "inc_max": 89
+    "inc_max": 89,
+    "XCLTortuosity": 0.000572614583987641,
+    "noise_reduction_factor": 1.0
   },
   "terms": [
     {

--- a/welleng/errors/iscwsa_json/owsg_a/CB_Film_MMS.json
+++ b/welleng/errors/iscwsa_json/owsg_a/CB_Film_MMS.json
@@ -1,5 +1,6 @@
 {
   "$schema": "../../iscwsa_schema/draft.json",
+  "_comment": "GENERATED from the ISCWSA-issued OWSG spreadsheet by welleng/errors/tools/owsg_to_json.py -- DO NOT EDIT BY HAND. Regenerate from the source xlsx. If a test needs different parameter values for validation, it must override them locally, never modify this shipped model. (test_iscwsa_json_generated.py enforces this.)",
   "metadata": {
     "schema_uuid": "00000000-0000-0000-0000-000000000000",
     "model_uuid": "0da47901-7eba-59ba-a705-a4f4cc45d40b",
@@ -26,7 +27,8 @@
   },
   "parameters": {
     "inc_min": 0,
-    "inc_max": 180
+    "inc_max": 180,
+    "XCLTortuosity": 0.000572614583987641
   },
   "terms": [
     {

--- a/welleng/errors/iscwsa_json/owsg_a/CB_Film_MMS_Fl.json
+++ b/welleng/errors/iscwsa_json/owsg_a/CB_Film_MMS_Fl.json
@@ -1,5 +1,6 @@
 {
   "$schema": "../../iscwsa_schema/draft.json",
+  "_comment": "GENERATED from the ISCWSA-issued OWSG spreadsheet by welleng/errors/tools/owsg_to_json.py -- DO NOT EDIT BY HAND. Regenerate from the source xlsx. If a test needs different parameter values for validation, it must override them locally, never modify this shipped model. (test_iscwsa_json_generated.py enforces this.)",
   "metadata": {
     "schema_uuid": "00000000-0000-0000-0000-000000000000",
     "model_uuid": "0da47901-7eba-59ba-a705-a4f4cc45d40b",
@@ -26,7 +27,8 @@
   },
   "parameters": {
     "inc_min": 0,
-    "inc_max": 180
+    "inc_max": 180,
+    "XCLTortuosity": 0.000572614583987641
   },
   "terms": [
     {

--- a/welleng/errors/iscwsa_json/owsg_a/CB_Film_MSS.json
+++ b/welleng/errors/iscwsa_json/owsg_a/CB_Film_MSS.json
@@ -1,5 +1,6 @@
 {
   "$schema": "../../iscwsa_schema/draft.json",
+  "_comment": "GENERATED from the ISCWSA-issued OWSG spreadsheet by welleng/errors/tools/owsg_to_json.py -- DO NOT EDIT BY HAND. Regenerate from the source xlsx. If a test needs different parameter values for validation, it must override them locally, never modify this shipped model. (test_iscwsa_json_generated.py enforces this.)",
   "metadata": {
     "schema_uuid": "00000000-0000-0000-0000-000000000000",
     "model_uuid": "26871bbe-ff5f-5a9d-97ea-dedaaf4d5db4",
@@ -26,7 +27,8 @@
   },
   "parameters": {
     "inc_min": 0,
-    "inc_max": 180
+    "inc_max": 180,
+    "XCLTortuosity": 0.000572614583987641
   },
   "terms": [
     {

--- a/welleng/errors/iscwsa_json/owsg_a/CB_Film_MSS_Fl.json
+++ b/welleng/errors/iscwsa_json/owsg_a/CB_Film_MSS_Fl.json
@@ -1,5 +1,6 @@
 {
   "$schema": "../../iscwsa_schema/draft.json",
+  "_comment": "GENERATED from the ISCWSA-issued OWSG spreadsheet by welleng/errors/tools/owsg_to_json.py -- DO NOT EDIT BY HAND. Regenerate from the source xlsx. If a test needs different parameter values for validation, it must override them locally, never modify this shipped model. (test_iscwsa_json_generated.py enforces this.)",
   "metadata": {
     "schema_uuid": "00000000-0000-0000-0000-000000000000",
     "model_uuid": "26871bbe-ff5f-5a9d-97ea-dedaaf4d5db4",
@@ -26,7 +27,8 @@
   },
   "parameters": {
     "inc_min": 0,
-    "inc_max": 180
+    "inc_max": 180,
+    "XCLTortuosity": 0.000572614583987641
   },
   "terms": [
     {

--- a/welleng/errors/iscwsa_json/owsg_a/DIPMETER.json
+++ b/welleng/errors/iscwsa_json/owsg_a/DIPMETER.json
@@ -1,5 +1,6 @@
 {
   "$schema": "../../iscwsa_schema/draft.json",
+  "_comment": "GENERATED from the ISCWSA-issued OWSG spreadsheet by welleng/errors/tools/owsg_to_json.py -- DO NOT EDIT BY HAND. Regenerate from the source xlsx. If a test needs different parameter values for validation, it must override them locally, never modify this shipped model. (test_iscwsa_json_generated.py enforces this.)",
   "metadata": {
     "schema_uuid": "00000000-0000-0000-0000-000000000000",
     "model_uuid": "3ce7fad4-379c-51c3-ab2e-0a2579c25061",
@@ -26,7 +27,8 @@
   },
   "parameters": {
     "inc_min": 0,
-    "inc_max": 180
+    "inc_max": 180,
+    "XCLTortuosity": 0.000572614583987641
   },
   "terms": [
     {

--- a/welleng/errors/iscwsa_json/owsg_a/DIPMETER_Fl.json
+++ b/welleng/errors/iscwsa_json/owsg_a/DIPMETER_Fl.json
@@ -1,5 +1,6 @@
 {
   "$schema": "../../iscwsa_schema/draft.json",
+  "_comment": "GENERATED from the ISCWSA-issued OWSG spreadsheet by welleng/errors/tools/owsg_to_json.py -- DO NOT EDIT BY HAND. Regenerate from the source xlsx. If a test needs different parameter values for validation, it must override them locally, never modify this shipped model. (test_iscwsa_json_generated.py enforces this.)",
   "metadata": {
     "schema_uuid": "00000000-0000-0000-0000-000000000000",
     "model_uuid": "3ce7fad4-379c-51c3-ab2e-0a2579c25061",
@@ -26,7 +27,8 @@
   },
   "parameters": {
     "inc_min": 0,
-    "inc_max": 180
+    "inc_max": 180,
+    "XCLTortuosity": 0.000572614583987641
   },
   "terms": [
     {

--- a/welleng/errors/iscwsa_json/owsg_a/EMS+SRGM+AX+SAG.json
+++ b/welleng/errors/iscwsa_json/owsg_a/EMS+SRGM+AX+SAG.json
@@ -1,5 +1,6 @@
 {
   "$schema": "../../iscwsa_schema/draft.json",
+  "_comment": "GENERATED from the ISCWSA-issued OWSG spreadsheet by welleng/errors/tools/owsg_to_json.py -- DO NOT EDIT BY HAND. Regenerate from the source xlsx. If a test needs different parameter values for validation, it must override them locally, never modify this shipped model. (test_iscwsa_json_generated.py enforces this.)",
   "metadata": {
     "schema_uuid": "00000000-0000-0000-0000-000000000000",
     "model_uuid": "3d56797c-decf-595b-8736-e79b89b5f500",
@@ -27,7 +28,8 @@
   },
   "parameters": {
     "inc_min": 0,
-    "inc_max": 180
+    "inc_max": 180,
+    "XCLTortuosity": 0.000572614583987641
   },
   "terms": [
     {

--- a/welleng/errors/iscwsa_json/owsg_a/EMS+SRGM+AX+SAG_Fl.json
+++ b/welleng/errors/iscwsa_json/owsg_a/EMS+SRGM+AX+SAG_Fl.json
@@ -1,5 +1,6 @@
 {
   "$schema": "../../iscwsa_schema/draft.json",
+  "_comment": "GENERATED from the ISCWSA-issued OWSG spreadsheet by welleng/errors/tools/owsg_to_json.py -- DO NOT EDIT BY HAND. Regenerate from the source xlsx. If a test needs different parameter values for validation, it must override them locally, never modify this shipped model. (test_iscwsa_json_generated.py enforces this.)",
   "metadata": {
     "schema_uuid": "00000000-0000-0000-0000-000000000000",
     "model_uuid": "3d56797c-decf-595b-8736-e79b89b5f500",
@@ -27,7 +28,8 @@
   },
   "parameters": {
     "inc_min": 0,
-    "inc_max": 180
+    "inc_max": 180,
+    "XCLTortuosity": 0.000572614583987641
   },
   "terms": [
     {

--- a/welleng/errors/iscwsa_json/owsg_a/EMS+SRGM+AX.json
+++ b/welleng/errors/iscwsa_json/owsg_a/EMS+SRGM+AX.json
@@ -1,5 +1,6 @@
 {
   "$schema": "../../iscwsa_schema/draft.json",
+  "_comment": "GENERATED from the ISCWSA-issued OWSG spreadsheet by welleng/errors/tools/owsg_to_json.py -- DO NOT EDIT BY HAND. Regenerate from the source xlsx. If a test needs different parameter values for validation, it must override them locally, never modify this shipped model. (test_iscwsa_json_generated.py enforces this.)",
   "metadata": {
     "schema_uuid": "00000000-0000-0000-0000-000000000000",
     "model_uuid": "f3592406-465c-5a9b-a583-7e83fa56c73c",
@@ -27,7 +28,8 @@
   },
   "parameters": {
     "inc_min": 0,
-    "inc_max": 180
+    "inc_max": 180,
+    "XCLTortuosity": 0.000572614583987641
   },
   "terms": [
     {

--- a/welleng/errors/iscwsa_json/owsg_a/EMS+SRGM+AX_Fl.json
+++ b/welleng/errors/iscwsa_json/owsg_a/EMS+SRGM+AX_Fl.json
@@ -1,5 +1,6 @@
 {
   "$schema": "../../iscwsa_schema/draft.json",
+  "_comment": "GENERATED from the ISCWSA-issued OWSG spreadsheet by welleng/errors/tools/owsg_to_json.py -- DO NOT EDIT BY HAND. Regenerate from the source xlsx. If a test needs different parameter values for validation, it must override them locally, never modify this shipped model. (test_iscwsa_json_generated.py enforces this.)",
   "metadata": {
     "schema_uuid": "00000000-0000-0000-0000-000000000000",
     "model_uuid": "f3592406-465c-5a9b-a583-7e83fa56c73c",
@@ -27,7 +28,8 @@
   },
   "parameters": {
     "inc_min": 0,
-    "inc_max": 180
+    "inc_max": 180,
+    "XCLTortuosity": 0.000572614583987641
   },
   "terms": [
     {

--- a/welleng/errors/iscwsa_json/owsg_a/EMS+SRGM+SAG.json
+++ b/welleng/errors/iscwsa_json/owsg_a/EMS+SRGM+SAG.json
@@ -1,5 +1,6 @@
 {
   "$schema": "../../iscwsa_schema/draft.json",
+  "_comment": "GENERATED from the ISCWSA-issued OWSG spreadsheet by welleng/errors/tools/owsg_to_json.py -- DO NOT EDIT BY HAND. Regenerate from the source xlsx. If a test needs different parameter values for validation, it must override them locally, never modify this shipped model. (test_iscwsa_json_generated.py enforces this.)",
   "metadata": {
     "schema_uuid": "00000000-0000-0000-0000-000000000000",
     "model_uuid": "b9ec41cf-01bb-5194-b07c-7dcf2afc49f4",
@@ -27,7 +28,8 @@
   },
   "parameters": {
     "inc_min": 0,
-    "inc_max": 180
+    "inc_max": 180,
+    "XCLTortuosity": 0.000572614583987641
   },
   "terms": [
     {

--- a/welleng/errors/iscwsa_json/owsg_a/EMS+SRGM+SAG_Fl.json
+++ b/welleng/errors/iscwsa_json/owsg_a/EMS+SRGM+SAG_Fl.json
@@ -1,5 +1,6 @@
 {
   "$schema": "../../iscwsa_schema/draft.json",
+  "_comment": "GENERATED from the ISCWSA-issued OWSG spreadsheet by welleng/errors/tools/owsg_to_json.py -- DO NOT EDIT BY HAND. Regenerate from the source xlsx. If a test needs different parameter values for validation, it must override them locally, never modify this shipped model. (test_iscwsa_json_generated.py enforces this.)",
   "metadata": {
     "schema_uuid": "00000000-0000-0000-0000-000000000000",
     "model_uuid": "b9ec41cf-01bb-5194-b07c-7dcf2afc49f4",
@@ -27,7 +28,8 @@
   },
   "parameters": {
     "inc_min": 0,
-    "inc_max": 180
+    "inc_max": 180,
+    "XCLTortuosity": 0.000572614583987641
   },
   "terms": [
     {

--- a/welleng/errors/iscwsa_json/owsg_a/EMS+SRGM.json
+++ b/welleng/errors/iscwsa_json/owsg_a/EMS+SRGM.json
@@ -1,5 +1,6 @@
 {
   "$schema": "../../iscwsa_schema/draft.json",
+  "_comment": "GENERATED from the ISCWSA-issued OWSG spreadsheet by welleng/errors/tools/owsg_to_json.py -- DO NOT EDIT BY HAND. Regenerate from the source xlsx. If a test needs different parameter values for validation, it must override them locally, never modify this shipped model. (test_iscwsa_json_generated.py enforces this.)",
   "metadata": {
     "schema_uuid": "00000000-0000-0000-0000-000000000000",
     "model_uuid": "e35e5c58-c38f-57ba-999e-388ee3cb9d1a",
@@ -27,7 +28,8 @@
   },
   "parameters": {
     "inc_min": 0,
-    "inc_max": 180
+    "inc_max": 180,
+    "XCLTortuosity": 0.000572614583987641
   },
   "terms": [
     {

--- a/welleng/errors/iscwsa_json/owsg_a/EMS+SRGM_Fl.json
+++ b/welleng/errors/iscwsa_json/owsg_a/EMS+SRGM_Fl.json
@@ -1,5 +1,6 @@
 {
   "$schema": "../../iscwsa_schema/draft.json",
+  "_comment": "GENERATED from the ISCWSA-issued OWSG spreadsheet by welleng/errors/tools/owsg_to_json.py -- DO NOT EDIT BY HAND. Regenerate from the source xlsx. If a test needs different parameter values for validation, it must override them locally, never modify this shipped model. (test_iscwsa_json_generated.py enforces this.)",
   "metadata": {
     "schema_uuid": "00000000-0000-0000-0000-000000000000",
     "model_uuid": "e35e5c58-c38f-57ba-999e-388ee3cb9d1a",
@@ -27,7 +28,8 @@
   },
   "parameters": {
     "inc_min": 0,
-    "inc_max": 180
+    "inc_max": 180,
+    "XCLTortuosity": 0.000572614583987641
   },
   "terms": [
     {

--- a/welleng/errors/iscwsa_json/owsg_a/GYRO-MWD.json
+++ b/welleng/errors/iscwsa_json/owsg_a/GYRO-MWD.json
@@ -1,5 +1,6 @@
 {
   "$schema": "../../iscwsa_schema/draft.json",
+  "_comment": "GENERATED from the ISCWSA-issued OWSG spreadsheet by welleng/errors/tools/owsg_to_json.py -- DO NOT EDIT BY HAND. Regenerate from the source xlsx. If a test needs different parameter values for validation, it must override them locally, never modify this shipped model. (test_iscwsa_json_generated.py enforces this.)",
   "metadata": {
     "schema_uuid": "00000000-0000-0000-0000-000000000000",
     "model_uuid": "f3f4aa63-013c-5890-a95d-fef1db4a8e3b",
@@ -26,7 +27,9 @@
   },
   "parameters": {
     "inc_min": 0,
-    "inc_max": 89
+    "inc_max": 89,
+    "XCLTortuosity": 0.000572614583987641,
+    "xy_static_gyro_end_inc": 3.141592653589793
   },
   "terms": [
     {

--- a/welleng/errors/iscwsa_json/owsg_a/GYRO-MWD_Fl.json
+++ b/welleng/errors/iscwsa_json/owsg_a/GYRO-MWD_Fl.json
@@ -1,5 +1,6 @@
 {
   "$schema": "../../iscwsa_schema/draft.json",
+  "_comment": "GENERATED from the ISCWSA-issued OWSG spreadsheet by welleng/errors/tools/owsg_to_json.py -- DO NOT EDIT BY HAND. Regenerate from the source xlsx. If a test needs different parameter values for validation, it must override them locally, never modify this shipped model. (test_iscwsa_json_generated.py enforces this.)",
   "metadata": {
     "schema_uuid": "00000000-0000-0000-0000-000000000000",
     "model_uuid": "f3f4aa63-013c-5890-a95d-fef1db4a8e3b",
@@ -26,7 +27,9 @@
   },
   "parameters": {
     "inc_min": 0,
-    "inc_max": 89
+    "inc_max": 89,
+    "XCLTortuosity": 0.000572614583987641,
+    "xy_static_gyro_end_inc": 3.141592653589793
   },
   "terms": [
     {

--- a/welleng/errors/iscwsa_json/owsg_a/GYRO-NS-CT.json
+++ b/welleng/errors/iscwsa_json/owsg_a/GYRO-NS-CT.json
@@ -1,5 +1,6 @@
 {
   "$schema": "../../iscwsa_schema/draft.json",
+  "_comment": "GENERATED from the ISCWSA-issued OWSG spreadsheet by welleng/errors/tools/owsg_to_json.py -- DO NOT EDIT BY HAND. Regenerate from the source xlsx. If a test needs different parameter values for validation, it must override them locally, never modify this shipped model. (test_iscwsa_json_generated.py enforces this.)",
   "metadata": {
     "schema_uuid": "00000000-0000-0000-0000-000000000000",
     "model_uuid": "ead5db0e-70c3-552f-9ff7-755c2dabeb09",
@@ -28,9 +29,10 @@
   "parameters": {
     "inc_min": 0,
     "inc_max": 150,
-    "gxy_running_speed": 2160,
-    "xy_static_gyro_end_inc": 0.29670597283903605,
-    "noise_reduction_factor": 0.5
+    "XCLTortuosity": 0.000572614583987641,
+    "xy_static_gyro_end_inc": 0.2617993877991494,
+    "gxy_running_speed": 2743.2,
+    "noise_reduction_factor": 0.4082
   },
   "terms": [
     {

--- a/welleng/errors/iscwsa_json/owsg_a/GYRO-NS-CT_Fl.json
+++ b/welleng/errors/iscwsa_json/owsg_a/GYRO-NS-CT_Fl.json
@@ -1,5 +1,6 @@
 {
   "$schema": "../../iscwsa_schema/draft.json",
+  "_comment": "GENERATED from the ISCWSA-issued OWSG spreadsheet by welleng/errors/tools/owsg_to_json.py -- DO NOT EDIT BY HAND. Regenerate from the source xlsx. If a test needs different parameter values for validation, it must override them locally, never modify this shipped model. (test_iscwsa_json_generated.py enforces this.)",
   "metadata": {
     "schema_uuid": "00000000-0000-0000-0000-000000000000",
     "model_uuid": "ead5db0e-70c3-552f-9ff7-755c2dabeb09",
@@ -27,7 +28,11 @@
   },
   "parameters": {
     "inc_min": 0,
-    "inc_max": 150
+    "inc_max": 150,
+    "XCLTortuosity": 0.000572614583987641,
+    "xy_static_gyro_end_inc": 0.2617993877991494,
+    "gxy_running_speed": 2743.2,
+    "noise_reduction_factor": 0.4082
   },
   "terms": [
     {

--- a/welleng/errors/iscwsa_json/owsg_a/GYRO-NS.json
+++ b/welleng/errors/iscwsa_json/owsg_a/GYRO-NS.json
@@ -1,5 +1,6 @@
 {
   "$schema": "../../iscwsa_schema/draft.json",
+  "_comment": "GENERATED from the ISCWSA-issued OWSG spreadsheet by welleng/errors/tools/owsg_to_json.py -- DO NOT EDIT BY HAND. Regenerate from the source xlsx. If a test needs different parameter values for validation, it must override them locally, never modify this shipped model. (test_iscwsa_json_generated.py enforces this.)",
   "metadata": {
     "schema_uuid": "00000000-0000-0000-0000-000000000000",
     "model_uuid": "cadf70d9-aaec-53b5-a5b0-8e6c9ff12433",
@@ -26,7 +27,9 @@
   },
   "parameters": {
     "inc_min": 0,
-    "inc_max": 89
+    "inc_max": 89,
+    "XCLTortuosity": 0.000572614583987641,
+    "xy_static_gyro_end_inc": 3.141592653589793
   },
   "terms": [
     {

--- a/welleng/errors/iscwsa_json/owsg_a/GYRO-NS_Fl.json
+++ b/welleng/errors/iscwsa_json/owsg_a/GYRO-NS_Fl.json
@@ -1,5 +1,6 @@
 {
   "$schema": "../../iscwsa_schema/draft.json",
+  "_comment": "GENERATED from the ISCWSA-issued OWSG spreadsheet by welleng/errors/tools/owsg_to_json.py -- DO NOT EDIT BY HAND. Regenerate from the source xlsx. If a test needs different parameter values for validation, it must override them locally, never modify this shipped model. (test_iscwsa_json_generated.py enforces this.)",
   "metadata": {
     "schema_uuid": "00000000-0000-0000-0000-000000000000",
     "model_uuid": "cadf70d9-aaec-53b5-a5b0-8e6c9ff12433",
@@ -26,7 +27,9 @@
   },
   "parameters": {
     "inc_min": 0,
-    "inc_max": 89
+    "inc_max": 89,
+    "XCLTortuosity": 0.000572614583987641,
+    "xy_static_gyro_end_inc": 3.141592653589793
   },
   "terms": [
     {

--- a/welleng/errors/iscwsa_json/owsg_a/INC-ONLY.json
+++ b/welleng/errors/iscwsa_json/owsg_a/INC-ONLY.json
@@ -1,5 +1,6 @@
 {
   "$schema": "../../iscwsa_schema/draft.json",
+  "_comment": "GENERATED from the ISCWSA-issued OWSG spreadsheet by welleng/errors/tools/owsg_to_json.py -- DO NOT EDIT BY HAND. Regenerate from the source xlsx. If a test needs different parameter values for validation, it must override them locally, never modify this shipped model. (test_iscwsa_json_generated.py enforces this.)",
   "metadata": {
     "schema_uuid": "00000000-0000-0000-0000-000000000000",
     "model_uuid": "d99082f3-58f2-5bd4-9cc4-490fa62eba62",

--- a/welleng/errors/iscwsa_json/owsg_a/INC-ONLY_Fl.json
+++ b/welleng/errors/iscwsa_json/owsg_a/INC-ONLY_Fl.json
@@ -1,5 +1,6 @@
 {
   "$schema": "../../iscwsa_schema/draft.json",
+  "_comment": "GENERATED from the ISCWSA-issued OWSG spreadsheet by welleng/errors/tools/owsg_to_json.py -- DO NOT EDIT BY HAND. Regenerate from the source xlsx. If a test needs different parameter values for validation, it must override them locally, never modify this shipped model. (test_iscwsa_json_generated.py enforces this.)",
   "metadata": {
     "schema_uuid": "00000000-0000-0000-0000-000000000000",
     "model_uuid": "d99082f3-58f2-5bd4-9cc4-490fa62eba62",

--- a/welleng/errors/iscwsa_json/owsg_a/INC-ONLY_PLANNED_5_DEG.json
+++ b/welleng/errors/iscwsa_json/owsg_a/INC-ONLY_PLANNED_5_DEG.json
@@ -1,5 +1,6 @@
 {
   "$schema": "../../iscwsa_schema/draft.json",
+  "_comment": "GENERATED from the ISCWSA-issued OWSG spreadsheet by welleng/errors/tools/owsg_to_json.py -- DO NOT EDIT BY HAND. Regenerate from the source xlsx. If a test needs different parameter values for validation, it must override them locally, never modify this shipped model. (test_iscwsa_json_generated.py enforces this.)",
   "metadata": {
     "schema_uuid": "00000000-0000-0000-0000-000000000000",
     "model_uuid": "4012caa1-0963-5f7a-b82d-34b62278b33d",

--- a/welleng/errors/iscwsa_json/owsg_a/INC-ONLY_PLANNED_5_DEG_Fl.json
+++ b/welleng/errors/iscwsa_json/owsg_a/INC-ONLY_PLANNED_5_DEG_Fl.json
@@ -1,5 +1,6 @@
 {
   "$schema": "../../iscwsa_schema/draft.json",
+  "_comment": "GENERATED from the ISCWSA-issued OWSG spreadsheet by welleng/errors/tools/owsg_to_json.py -- DO NOT EDIT BY HAND. Regenerate from the source xlsx. If a test needs different parameter values for validation, it must override them locally, never modify this shipped model. (test_iscwsa_json_generated.py enforces this.)",
   "metadata": {
     "schema_uuid": "00000000-0000-0000-0000-000000000000",
     "model_uuid": "4012caa1-0963-5f7a-b82d-34b62278b33d",

--- a/welleng/errors/iscwsa_json/owsg_a/MWD+IFR1+AX+SAG.json
+++ b/welleng/errors/iscwsa_json/owsg_a/MWD+IFR1+AX+SAG.json
@@ -1,5 +1,6 @@
 {
   "$schema": "../../iscwsa_schema/draft.json",
+  "_comment": "GENERATED from the ISCWSA-issued OWSG spreadsheet by welleng/errors/tools/owsg_to_json.py -- DO NOT EDIT BY HAND. Regenerate from the source xlsx. If a test needs different parameter values for validation, it must override them locally, never modify this shipped model. (test_iscwsa_json_generated.py enforces this.)",
   "metadata": {
     "schema_uuid": "00000000-0000-0000-0000-000000000000",
     "model_uuid": "e9f2462d-1410-5ccc-8768-d10137b18813",
@@ -27,7 +28,8 @@
   },
   "parameters": {
     "inc_min": 0,
-    "inc_max": 180
+    "inc_max": 180,
+    "XCLTortuosity": 0.000572614583987641
   },
   "terms": [
     {

--- a/welleng/errors/iscwsa_json/owsg_a/MWD+IFR1+AX+SAG_Fl.json
+++ b/welleng/errors/iscwsa_json/owsg_a/MWD+IFR1+AX+SAG_Fl.json
@@ -1,5 +1,6 @@
 {
   "$schema": "../../iscwsa_schema/draft.json",
+  "_comment": "GENERATED from the ISCWSA-issued OWSG spreadsheet by welleng/errors/tools/owsg_to_json.py -- DO NOT EDIT BY HAND. Regenerate from the source xlsx. If a test needs different parameter values for validation, it must override them locally, never modify this shipped model. (test_iscwsa_json_generated.py enforces this.)",
   "metadata": {
     "schema_uuid": "00000000-0000-0000-0000-000000000000",
     "model_uuid": "e9f2462d-1410-5ccc-8768-d10137b18813",
@@ -27,7 +28,8 @@
   },
   "parameters": {
     "inc_min": 0,
-    "inc_max": 180
+    "inc_max": 180,
+    "XCLTortuosity": 0.000572614583987641
   },
   "terms": [
     {

--- a/welleng/errors/iscwsa_json/owsg_a/MWD+IFR1+AX.json
+++ b/welleng/errors/iscwsa_json/owsg_a/MWD+IFR1+AX.json
@@ -1,5 +1,6 @@
 {
   "$schema": "../../iscwsa_schema/draft.json",
+  "_comment": "GENERATED from the ISCWSA-issued OWSG spreadsheet by welleng/errors/tools/owsg_to_json.py -- DO NOT EDIT BY HAND. Regenerate from the source xlsx. If a test needs different parameter values for validation, it must override them locally, never modify this shipped model. (test_iscwsa_json_generated.py enforces this.)",
   "metadata": {
     "schema_uuid": "00000000-0000-0000-0000-000000000000",
     "model_uuid": "214a8bac-95bb-5cee-956a-3ad8cfbf203b",
@@ -27,7 +28,8 @@
   },
   "parameters": {
     "inc_min": 0,
-    "inc_max": 180
+    "inc_max": 180,
+    "XCLTortuosity": 0.000572614583987641
   },
   "terms": [
     {

--- a/welleng/errors/iscwsa_json/owsg_a/MWD+IFR1+AX_Fl.json
+++ b/welleng/errors/iscwsa_json/owsg_a/MWD+IFR1+AX_Fl.json
@@ -1,5 +1,6 @@
 {
   "$schema": "../../iscwsa_schema/draft.json",
+  "_comment": "GENERATED from the ISCWSA-issued OWSG spreadsheet by welleng/errors/tools/owsg_to_json.py -- DO NOT EDIT BY HAND. Regenerate from the source xlsx. If a test needs different parameter values for validation, it must override them locally, never modify this shipped model. (test_iscwsa_json_generated.py enforces this.)",
   "metadata": {
     "schema_uuid": "00000000-0000-0000-0000-000000000000",
     "model_uuid": "214a8bac-95bb-5cee-956a-3ad8cfbf203b",
@@ -27,7 +28,8 @@
   },
   "parameters": {
     "inc_min": 0,
-    "inc_max": 180
+    "inc_max": 180,
+    "XCLTortuosity": 0.000572614583987641
   },
   "terms": [
     {

--- a/welleng/errors/iscwsa_json/owsg_a/MWD+IFR1+MS.json
+++ b/welleng/errors/iscwsa_json/owsg_a/MWD+IFR1+MS.json
@@ -1,5 +1,6 @@
 {
   "$schema": "../../iscwsa_schema/draft.json",
+  "_comment": "GENERATED from the ISCWSA-issued OWSG spreadsheet by welleng/errors/tools/owsg_to_json.py -- DO NOT EDIT BY HAND. Regenerate from the source xlsx. If a test needs different parameter values for validation, it must override them locally, never modify this shipped model. (test_iscwsa_json_generated.py enforces this.)",
   "metadata": {
     "schema_uuid": "00000000-0000-0000-0000-000000000000",
     "model_uuid": "23db450f-7ec5-50a3-a281-8697787c5f9c",
@@ -27,7 +28,8 @@
   },
   "parameters": {
     "inc_min": 0,
-    "inc_max": 180
+    "inc_max": 180,
+    "XCLTortuosity": 0.000572614583987641
   },
   "terms": [
     {

--- a/welleng/errors/iscwsa_json/owsg_a/MWD+IFR1+MS_Fl.json
+++ b/welleng/errors/iscwsa_json/owsg_a/MWD+IFR1+MS_Fl.json
@@ -1,5 +1,6 @@
 {
   "$schema": "../../iscwsa_schema/draft.json",
+  "_comment": "GENERATED from the ISCWSA-issued OWSG spreadsheet by welleng/errors/tools/owsg_to_json.py -- DO NOT EDIT BY HAND. Regenerate from the source xlsx. If a test needs different parameter values for validation, it must override them locally, never modify this shipped model. (test_iscwsa_json_generated.py enforces this.)",
   "metadata": {
     "schema_uuid": "00000000-0000-0000-0000-000000000000",
     "model_uuid": "23db450f-7ec5-50a3-a281-8697787c5f9c",
@@ -27,7 +28,8 @@
   },
   "parameters": {
     "inc_min": 0,
-    "inc_max": 180
+    "inc_max": 180,
+    "XCLTortuosity": 0.000572614583987641
   },
   "terms": [
     {

--- a/welleng/errors/iscwsa_json/owsg_a/MWD+IFR1+SAG+MS.json
+++ b/welleng/errors/iscwsa_json/owsg_a/MWD+IFR1+SAG+MS.json
@@ -1,5 +1,6 @@
 {
   "$schema": "../../iscwsa_schema/draft.json",
+  "_comment": "GENERATED from the ISCWSA-issued OWSG spreadsheet by welleng/errors/tools/owsg_to_json.py -- DO NOT EDIT BY HAND. Regenerate from the source xlsx. If a test needs different parameter values for validation, it must override them locally, never modify this shipped model. (test_iscwsa_json_generated.py enforces this.)",
   "metadata": {
     "schema_uuid": "00000000-0000-0000-0000-000000000000",
     "model_uuid": "ec6b35dd-5f7d-541d-9182-c2c8475a4780",
@@ -27,7 +28,8 @@
   },
   "parameters": {
     "inc_min": 0,
-    "inc_max": 180
+    "inc_max": 180,
+    "XCLTortuosity": 0.000572614583987641
   },
   "terms": [
     {

--- a/welleng/errors/iscwsa_json/owsg_a/MWD+IFR1+SAG+MS_Fl.json
+++ b/welleng/errors/iscwsa_json/owsg_a/MWD+IFR1+SAG+MS_Fl.json
@@ -1,5 +1,6 @@
 {
   "$schema": "../../iscwsa_schema/draft.json",
+  "_comment": "GENERATED from the ISCWSA-issued OWSG spreadsheet by welleng/errors/tools/owsg_to_json.py -- DO NOT EDIT BY HAND. Regenerate from the source xlsx. If a test needs different parameter values for validation, it must override them locally, never modify this shipped model. (test_iscwsa_json_generated.py enforces this.)",
   "metadata": {
     "schema_uuid": "00000000-0000-0000-0000-000000000000",
     "model_uuid": "ec6b35dd-5f7d-541d-9182-c2c8475a4780",
@@ -27,7 +28,8 @@
   },
   "parameters": {
     "inc_min": 0,
-    "inc_max": 180
+    "inc_max": 180,
+    "XCLTortuosity": 0.000572614583987641
   },
   "terms": [
     {

--- a/welleng/errors/iscwsa_json/owsg_a/MWD+IFR1+SAG.json
+++ b/welleng/errors/iscwsa_json/owsg_a/MWD+IFR1+SAG.json
@@ -1,5 +1,6 @@
 {
   "$schema": "../../iscwsa_schema/draft.json",
+  "_comment": "GENERATED from the ISCWSA-issued OWSG spreadsheet by welleng/errors/tools/owsg_to_json.py -- DO NOT EDIT BY HAND. Regenerate from the source xlsx. If a test needs different parameter values for validation, it must override them locally, never modify this shipped model. (test_iscwsa_json_generated.py enforces this.)",
   "metadata": {
     "schema_uuid": "00000000-0000-0000-0000-000000000000",
     "model_uuid": "8f56a227-cfc2-59b4-a689-d4b71030b54f",
@@ -27,7 +28,8 @@
   },
   "parameters": {
     "inc_min": 0,
-    "inc_max": 180
+    "inc_max": 180,
+    "XCLTortuosity": 0.000572614583987641
   },
   "terms": [
     {

--- a/welleng/errors/iscwsa_json/owsg_a/MWD+IFR1+SAG_Fl.json
+++ b/welleng/errors/iscwsa_json/owsg_a/MWD+IFR1+SAG_Fl.json
@@ -1,5 +1,6 @@
 {
   "$schema": "../../iscwsa_schema/draft.json",
+  "_comment": "GENERATED from the ISCWSA-issued OWSG spreadsheet by welleng/errors/tools/owsg_to_json.py -- DO NOT EDIT BY HAND. Regenerate from the source xlsx. If a test needs different parameter values for validation, it must override them locally, never modify this shipped model. (test_iscwsa_json_generated.py enforces this.)",
   "metadata": {
     "schema_uuid": "00000000-0000-0000-0000-000000000000",
     "model_uuid": "8f56a227-cfc2-59b4-a689-d4b71030b54f",
@@ -27,7 +28,8 @@
   },
   "parameters": {
     "inc_min": 0,
-    "inc_max": 180
+    "inc_max": 180,
+    "XCLTortuosity": 0.000572614583987641
   },
   "terms": [
     {

--- a/welleng/errors/iscwsa_json/owsg_a/MWD+IFR1.json
+++ b/welleng/errors/iscwsa_json/owsg_a/MWD+IFR1.json
@@ -1,5 +1,6 @@
 {
   "$schema": "../../iscwsa_schema/draft.json",
+  "_comment": "GENERATED from the ISCWSA-issued OWSG spreadsheet by welleng/errors/tools/owsg_to_json.py -- DO NOT EDIT BY HAND. Regenerate from the source xlsx. If a test needs different parameter values for validation, it must override them locally, never modify this shipped model. (test_iscwsa_json_generated.py enforces this.)",
   "metadata": {
     "schema_uuid": "00000000-0000-0000-0000-000000000000",
     "model_uuid": "cba00f9b-a8cb-5b3c-9397-1937e92129a4",
@@ -27,7 +28,8 @@
   },
   "parameters": {
     "inc_min": 0,
-    "inc_max": 180
+    "inc_max": 180,
+    "XCLTortuosity": 0.000572614583987641
   },
   "terms": [
     {

--- a/welleng/errors/iscwsa_json/owsg_a/MWD+IFR1_Fl.json
+++ b/welleng/errors/iscwsa_json/owsg_a/MWD+IFR1_Fl.json
@@ -1,5 +1,6 @@
 {
   "$schema": "../../iscwsa_schema/draft.json",
+  "_comment": "GENERATED from the ISCWSA-issued OWSG spreadsheet by welleng/errors/tools/owsg_to_json.py -- DO NOT EDIT BY HAND. Regenerate from the source xlsx. If a test needs different parameter values for validation, it must override them locally, never modify this shipped model. (test_iscwsa_json_generated.py enforces this.)",
   "metadata": {
     "schema_uuid": "00000000-0000-0000-0000-000000000000",
     "model_uuid": "cba00f9b-a8cb-5b3c-9397-1937e92129a4",
@@ -27,7 +28,8 @@
   },
   "parameters": {
     "inc_min": 0,
-    "inc_max": 180
+    "inc_max": 180,
+    "XCLTortuosity": 0.000572614583987641
   },
   "terms": [
     {

--- a/welleng/errors/iscwsa_json/owsg_a/MWD+IFR2+AX+SAG.json
+++ b/welleng/errors/iscwsa_json/owsg_a/MWD+IFR2+AX+SAG.json
@@ -1,5 +1,6 @@
 {
   "$schema": "../../iscwsa_schema/draft.json",
+  "_comment": "GENERATED from the ISCWSA-issued OWSG spreadsheet by welleng/errors/tools/owsg_to_json.py -- DO NOT EDIT BY HAND. Regenerate from the source xlsx. If a test needs different parameter values for validation, it must override them locally, never modify this shipped model. (test_iscwsa_json_generated.py enforces this.)",
   "metadata": {
     "schema_uuid": "00000000-0000-0000-0000-000000000000",
     "model_uuid": "a0940a08-b118-5ee1-aa72-504bb48139e8",
@@ -27,7 +28,8 @@
   },
   "parameters": {
     "inc_min": 0,
-    "inc_max": 180
+    "inc_max": 180,
+    "XCLTortuosity": 0.000572614583987641
   },
   "terms": [
     {

--- a/welleng/errors/iscwsa_json/owsg_a/MWD+IFR2+AX+SAG_Fl.json
+++ b/welleng/errors/iscwsa_json/owsg_a/MWD+IFR2+AX+SAG_Fl.json
@@ -1,5 +1,6 @@
 {
   "$schema": "../../iscwsa_schema/draft.json",
+  "_comment": "GENERATED from the ISCWSA-issued OWSG spreadsheet by welleng/errors/tools/owsg_to_json.py -- DO NOT EDIT BY HAND. Regenerate from the source xlsx. If a test needs different parameter values for validation, it must override them locally, never modify this shipped model. (test_iscwsa_json_generated.py enforces this.)",
   "metadata": {
     "schema_uuid": "00000000-0000-0000-0000-000000000000",
     "model_uuid": "a0940a08-b118-5ee1-aa72-504bb48139e8",
@@ -27,7 +28,8 @@
   },
   "parameters": {
     "inc_min": 0,
-    "inc_max": 180
+    "inc_max": 180,
+    "XCLTortuosity": 0.000572614583987641
   },
   "terms": [
     {

--- a/welleng/errors/iscwsa_json/owsg_a/MWD+IFR2+SAG+MS.json
+++ b/welleng/errors/iscwsa_json/owsg_a/MWD+IFR2+SAG+MS.json
@@ -1,5 +1,6 @@
 {
   "$schema": "../../iscwsa_schema/draft.json",
+  "_comment": "GENERATED from the ISCWSA-issued OWSG spreadsheet by welleng/errors/tools/owsg_to_json.py -- DO NOT EDIT BY HAND. Regenerate from the source xlsx. If a test needs different parameter values for validation, it must override them locally, never modify this shipped model. (test_iscwsa_json_generated.py enforces this.)",
   "metadata": {
     "schema_uuid": "00000000-0000-0000-0000-000000000000",
     "model_uuid": "a271a956-4b22-5620-a5b8-fbf633663a6e",
@@ -27,7 +28,8 @@
   },
   "parameters": {
     "inc_min": 0,
-    "inc_max": 180
+    "inc_max": 180,
+    "XCLTortuosity": 0.000572614583987641
   },
   "terms": [
     {

--- a/welleng/errors/iscwsa_json/owsg_a/MWD+IFR2+SAG+MS_Fl.json
+++ b/welleng/errors/iscwsa_json/owsg_a/MWD+IFR2+SAG+MS_Fl.json
@@ -1,5 +1,6 @@
 {
   "$schema": "../../iscwsa_schema/draft.json",
+  "_comment": "GENERATED from the ISCWSA-issued OWSG spreadsheet by welleng/errors/tools/owsg_to_json.py -- DO NOT EDIT BY HAND. Regenerate from the source xlsx. If a test needs different parameter values for validation, it must override them locally, never modify this shipped model. (test_iscwsa_json_generated.py enforces this.)",
   "metadata": {
     "schema_uuid": "00000000-0000-0000-0000-000000000000",
     "model_uuid": "a271a956-4b22-5620-a5b8-fbf633663a6e",
@@ -27,7 +28,8 @@
   },
   "parameters": {
     "inc_min": 0,
-    "inc_max": 180
+    "inc_max": 180,
+    "XCLTortuosity": 0.000572614583987641
   },
   "terms": [
     {

--- a/welleng/errors/iscwsa_json/owsg_a/MWD+IFR2+SAG.json
+++ b/welleng/errors/iscwsa_json/owsg_a/MWD+IFR2+SAG.json
@@ -1,5 +1,6 @@
 {
   "$schema": "../../iscwsa_schema/draft.json",
+  "_comment": "GENERATED from the ISCWSA-issued OWSG spreadsheet by welleng/errors/tools/owsg_to_json.py -- DO NOT EDIT BY HAND. Regenerate from the source xlsx. If a test needs different parameter values for validation, it must override them locally, never modify this shipped model. (test_iscwsa_json_generated.py enforces this.)",
   "metadata": {
     "schema_uuid": "00000000-0000-0000-0000-000000000000",
     "model_uuid": "c61edb38-7cf0-58cc-a8f7-da78392bbef7",
@@ -27,7 +28,8 @@
   },
   "parameters": {
     "inc_min": 0,
-    "inc_max": 180
+    "inc_max": 180,
+    "XCLTortuosity": 0.000572614583987641
   },
   "terms": [
     {

--- a/welleng/errors/iscwsa_json/owsg_a/MWD+IFR2+SAG_Fl.json
+++ b/welleng/errors/iscwsa_json/owsg_a/MWD+IFR2+SAG_Fl.json
@@ -1,5 +1,6 @@
 {
   "$schema": "../../iscwsa_schema/draft.json",
+  "_comment": "GENERATED from the ISCWSA-issued OWSG spreadsheet by welleng/errors/tools/owsg_to_json.py -- DO NOT EDIT BY HAND. Regenerate from the source xlsx. If a test needs different parameter values for validation, it must override them locally, never modify this shipped model. (test_iscwsa_json_generated.py enforces this.)",
   "metadata": {
     "schema_uuid": "00000000-0000-0000-0000-000000000000",
     "model_uuid": "c61edb38-7cf0-58cc-a8f7-da78392bbef7",
@@ -27,7 +28,8 @@
   },
   "parameters": {
     "inc_min": 0,
-    "inc_max": 180
+    "inc_max": 180,
+    "XCLTortuosity": 0.000572614583987641
   },
   "terms": [
     {

--- a/welleng/errors/iscwsa_json/owsg_a/MWD+SRGM+AX+SAG.json
+++ b/welleng/errors/iscwsa_json/owsg_a/MWD+SRGM+AX+SAG.json
@@ -1,5 +1,6 @@
 {
   "$schema": "../../iscwsa_schema/draft.json",
+  "_comment": "GENERATED from the ISCWSA-issued OWSG spreadsheet by welleng/errors/tools/owsg_to_json.py -- DO NOT EDIT BY HAND. Regenerate from the source xlsx. If a test needs different parameter values for validation, it must override them locally, never modify this shipped model. (test_iscwsa_json_generated.py enforces this.)",
   "metadata": {
     "schema_uuid": "00000000-0000-0000-0000-000000000000",
     "model_uuid": "7576f72f-aae8-558d-887a-da2977ac171b",
@@ -27,7 +28,8 @@
   },
   "parameters": {
     "inc_min": 0,
-    "inc_max": 180
+    "inc_max": 180,
+    "XCLTortuosity": 0.000572614583987641
   },
   "terms": [
     {

--- a/welleng/errors/iscwsa_json/owsg_a/MWD+SRGM+AX+SAG_Fl.json
+++ b/welleng/errors/iscwsa_json/owsg_a/MWD+SRGM+AX+SAG_Fl.json
@@ -1,5 +1,6 @@
 {
   "$schema": "../../iscwsa_schema/draft.json",
+  "_comment": "GENERATED from the ISCWSA-issued OWSG spreadsheet by welleng/errors/tools/owsg_to_json.py -- DO NOT EDIT BY HAND. Regenerate from the source xlsx. If a test needs different parameter values for validation, it must override them locally, never modify this shipped model. (test_iscwsa_json_generated.py enforces this.)",
   "metadata": {
     "schema_uuid": "00000000-0000-0000-0000-000000000000",
     "model_uuid": "7576f72f-aae8-558d-887a-da2977ac171b",
@@ -27,7 +28,8 @@
   },
   "parameters": {
     "inc_min": 0,
-    "inc_max": 180
+    "inc_max": 180,
+    "XCLTortuosity": 0.000572614583987641
   },
   "terms": [
     {

--- a/welleng/errors/iscwsa_json/owsg_a/MWD+SRGM+AX.json
+++ b/welleng/errors/iscwsa_json/owsg_a/MWD+SRGM+AX.json
@@ -1,5 +1,6 @@
 {
   "$schema": "../../iscwsa_schema/draft.json",
+  "_comment": "GENERATED from the ISCWSA-issued OWSG spreadsheet by welleng/errors/tools/owsg_to_json.py -- DO NOT EDIT BY HAND. Regenerate from the source xlsx. If a test needs different parameter values for validation, it must override them locally, never modify this shipped model. (test_iscwsa_json_generated.py enforces this.)",
   "metadata": {
     "schema_uuid": "00000000-0000-0000-0000-000000000000",
     "model_uuid": "36e8ad3b-2d3d-5786-8675-6e004eddd216",
@@ -27,7 +28,8 @@
   },
   "parameters": {
     "inc_min": 0,
-    "inc_max": 180
+    "inc_max": 180,
+    "XCLTortuosity": 0.000572614583987641
   },
   "terms": [
     {

--- a/welleng/errors/iscwsa_json/owsg_a/MWD+SRGM+AX_Fl.json
+++ b/welleng/errors/iscwsa_json/owsg_a/MWD+SRGM+AX_Fl.json
@@ -1,5 +1,6 @@
 {
   "$schema": "../../iscwsa_schema/draft.json",
+  "_comment": "GENERATED from the ISCWSA-issued OWSG spreadsheet by welleng/errors/tools/owsg_to_json.py -- DO NOT EDIT BY HAND. Regenerate from the source xlsx. If a test needs different parameter values for validation, it must override them locally, never modify this shipped model. (test_iscwsa_json_generated.py enforces this.)",
   "metadata": {
     "schema_uuid": "00000000-0000-0000-0000-000000000000",
     "model_uuid": "36e8ad3b-2d3d-5786-8675-6e004eddd216",
@@ -27,7 +28,8 @@
   },
   "parameters": {
     "inc_min": 0,
-    "inc_max": 180
+    "inc_max": 180,
+    "XCLTortuosity": 0.000572614583987641
   },
   "terms": [
     {

--- a/welleng/errors/iscwsa_json/owsg_a/MWD+SRGM+SAG.json
+++ b/welleng/errors/iscwsa_json/owsg_a/MWD+SRGM+SAG.json
@@ -1,5 +1,6 @@
 {
   "$schema": "../../iscwsa_schema/draft.json",
+  "_comment": "GENERATED from the ISCWSA-issued OWSG spreadsheet by welleng/errors/tools/owsg_to_json.py -- DO NOT EDIT BY HAND. Regenerate from the source xlsx. If a test needs different parameter values for validation, it must override them locally, never modify this shipped model. (test_iscwsa_json_generated.py enforces this.)",
   "metadata": {
     "schema_uuid": "00000000-0000-0000-0000-000000000000",
     "model_uuid": "f88e25e8-2b18-5320-aef1-87f7617e84ee",
@@ -27,7 +28,8 @@
   },
   "parameters": {
     "inc_min": 0,
-    "inc_max": 180
+    "inc_max": 180,
+    "XCLTortuosity": 0.000572614583987641
   },
   "terms": [
     {

--- a/welleng/errors/iscwsa_json/owsg_a/MWD+SRGM+SAG_Fl.json
+++ b/welleng/errors/iscwsa_json/owsg_a/MWD+SRGM+SAG_Fl.json
@@ -1,5 +1,6 @@
 {
   "$schema": "../../iscwsa_schema/draft.json",
+  "_comment": "GENERATED from the ISCWSA-issued OWSG spreadsheet by welleng/errors/tools/owsg_to_json.py -- DO NOT EDIT BY HAND. Regenerate from the source xlsx. If a test needs different parameter values for validation, it must override them locally, never modify this shipped model. (test_iscwsa_json_generated.py enforces this.)",
   "metadata": {
     "schema_uuid": "00000000-0000-0000-0000-000000000000",
     "model_uuid": "f88e25e8-2b18-5320-aef1-87f7617e84ee",
@@ -27,7 +28,8 @@
   },
   "parameters": {
     "inc_min": 0,
-    "inc_max": 180
+    "inc_max": 180,
+    "XCLTortuosity": 0.000572614583987641
   },
   "terms": [
     {

--- a/welleng/errors/iscwsa_json/owsg_a/MWD+SRGM.json
+++ b/welleng/errors/iscwsa_json/owsg_a/MWD+SRGM.json
@@ -1,5 +1,6 @@
 {
   "$schema": "../../iscwsa_schema/draft.json",
+  "_comment": "GENERATED from the ISCWSA-issued OWSG spreadsheet by welleng/errors/tools/owsg_to_json.py -- DO NOT EDIT BY HAND. Regenerate from the source xlsx. If a test needs different parameter values for validation, it must override them locally, never modify this shipped model. (test_iscwsa_json_generated.py enforces this.)",
   "metadata": {
     "schema_uuid": "00000000-0000-0000-0000-000000000000",
     "model_uuid": "90e9a25c-0910-5606-9428-b680a64feb8a",
@@ -27,7 +28,8 @@
   },
   "parameters": {
     "inc_min": 0,
-    "inc_max": 180
+    "inc_max": 180,
+    "XCLTortuosity": 0.000572614583987641
   },
   "terms": [
     {

--- a/welleng/errors/iscwsa_json/owsg_a/MWD+SRGM_Fl.json
+++ b/welleng/errors/iscwsa_json/owsg_a/MWD+SRGM_Fl.json
@@ -1,5 +1,6 @@
 {
   "$schema": "../../iscwsa_schema/draft.json",
+  "_comment": "GENERATED from the ISCWSA-issued OWSG spreadsheet by welleng/errors/tools/owsg_to_json.py -- DO NOT EDIT BY HAND. Regenerate from the source xlsx. If a test needs different parameter values for validation, it must override them locally, never modify this shipped model. (test_iscwsa_json_generated.py enforces this.)",
   "metadata": {
     "schema_uuid": "00000000-0000-0000-0000-000000000000",
     "model_uuid": "90e9a25c-0910-5606-9428-b680a64feb8a",
@@ -27,7 +28,8 @@
   },
   "parameters": {
     "inc_min": 0,
-    "inc_max": 180
+    "inc_max": 180,
+    "XCLTortuosity": 0.000572614583987641
   },
   "terms": [
     {

--- a/welleng/errors/iscwsa_json/owsg_a/UNKNOWN.json
+++ b/welleng/errors/iscwsa_json/owsg_a/UNKNOWN.json
@@ -1,5 +1,6 @@
 {
   "$schema": "../../iscwsa_schema/draft.json",
+  "_comment": "GENERATED from the ISCWSA-issued OWSG spreadsheet by welleng/errors/tools/owsg_to_json.py -- DO NOT EDIT BY HAND. Regenerate from the source xlsx. If a test needs different parameter values for validation, it must override them locally, never modify this shipped model. (test_iscwsa_json_generated.py enforces this.)",
   "metadata": {
     "schema_uuid": "00000000-0000-0000-0000-000000000000",
     "model_uuid": "164bbcb9-b397-5f4d-b1ee-7444aa63a5ca",
@@ -27,7 +28,8 @@
   },
   "parameters": {
     "inc_min": 0,
-    "inc_max": 180
+    "inc_max": 180,
+    "XCLTortuosity": 0.000572614583987641
   },
   "terms": [
     {

--- a/welleng/errors/iscwsa_json/owsg_a/UNKNOWN_Fl.json
+++ b/welleng/errors/iscwsa_json/owsg_a/UNKNOWN_Fl.json
@@ -1,5 +1,6 @@
 {
   "$schema": "../../iscwsa_schema/draft.json",
+  "_comment": "GENERATED from the ISCWSA-issued OWSG spreadsheet by welleng/errors/tools/owsg_to_json.py -- DO NOT EDIT BY HAND. Regenerate from the source xlsx. If a test needs different parameter values for validation, it must override them locally, never modify this shipped model. (test_iscwsa_json_generated.py enforces this.)",
   "metadata": {
     "schema_uuid": "00000000-0000-0000-0000-000000000000",
     "model_uuid": "164bbcb9-b397-5f4d-b1ee-7444aa63a5ca",
@@ -27,7 +28,8 @@
   },
   "parameters": {
     "inc_min": 0,
-    "inc_max": 180
+    "inc_max": 180,
+    "XCLTortuosity": 0.000572614583987641
   },
   "terms": [
     {

--- a/welleng/errors/iscwsa_json/owsg_b/BLIND+TREND.json
+++ b/welleng/errors/iscwsa_json/owsg_b/BLIND+TREND.json
@@ -1,5 +1,6 @@
 {
   "$schema": "../../iscwsa_schema/draft.json",
+  "_comment": "GENERATED from the ISCWSA-issued OWSG spreadsheet by welleng/errors/tools/owsg_to_json.py -- DO NOT EDIT BY HAND. Regenerate from the source xlsx. If a test needs different parameter values for validation, it must override them locally, never modify this shipped model. (test_iscwsa_json_generated.py enforces this.)",
   "metadata": {
     "schema_uuid": "00000000-0000-0000-0000-000000000000",
     "model_uuid": "ccf4e53f-829d-57e4-86bf-b8a00e8ce9a3",

--- a/welleng/errors/iscwsa_json/owsg_b/EMS+HRGM+AX+SAG.json
+++ b/welleng/errors/iscwsa_json/owsg_b/EMS+HRGM+AX+SAG.json
@@ -1,5 +1,6 @@
 {
   "$schema": "../../iscwsa_schema/draft.json",
+  "_comment": "GENERATED from the ISCWSA-issued OWSG spreadsheet by welleng/errors/tools/owsg_to_json.py -- DO NOT EDIT BY HAND. Regenerate from the source xlsx. If a test needs different parameter values for validation, it must override them locally, never modify this shipped model. (test_iscwsa_json_generated.py enforces this.)",
   "metadata": {
     "schema_uuid": "00000000-0000-0000-0000-000000000000",
     "model_uuid": "bd91be02-f14b-58f0-bfca-44f0ef8a54ce",
@@ -27,7 +28,8 @@
   },
   "parameters": {
     "inc_min": 0,
-    "inc_max": 180
+    "inc_max": 180,
+    "XCLTortuosity": 0.000572614583987641
   },
   "terms": [
     {

--- a/welleng/errors/iscwsa_json/owsg_b/EMS+HRGM+AX+SAG_Fl.json
+++ b/welleng/errors/iscwsa_json/owsg_b/EMS+HRGM+AX+SAG_Fl.json
@@ -1,5 +1,6 @@
 {
   "$schema": "../../iscwsa_schema/draft.json",
+  "_comment": "GENERATED from the ISCWSA-issued OWSG spreadsheet by welleng/errors/tools/owsg_to_json.py -- DO NOT EDIT BY HAND. Regenerate from the source xlsx. If a test needs different parameter values for validation, it must override them locally, never modify this shipped model. (test_iscwsa_json_generated.py enforces this.)",
   "metadata": {
     "schema_uuid": "00000000-0000-0000-0000-000000000000",
     "model_uuid": "bd91be02-f14b-58f0-bfca-44f0ef8a54ce",
@@ -27,7 +28,8 @@
   },
   "parameters": {
     "inc_min": 0,
-    "inc_max": 180
+    "inc_max": 180,
+    "XCLTortuosity": 0.000572614583987641
   },
   "terms": [
     {

--- a/welleng/errors/iscwsa_json/owsg_b/EMS+HRGM+AX.json
+++ b/welleng/errors/iscwsa_json/owsg_b/EMS+HRGM+AX.json
@@ -1,5 +1,6 @@
 {
   "$schema": "../../iscwsa_schema/draft.json",
+  "_comment": "GENERATED from the ISCWSA-issued OWSG spreadsheet by welleng/errors/tools/owsg_to_json.py -- DO NOT EDIT BY HAND. Regenerate from the source xlsx. If a test needs different parameter values for validation, it must override them locally, never modify this shipped model. (test_iscwsa_json_generated.py enforces this.)",
   "metadata": {
     "schema_uuid": "00000000-0000-0000-0000-000000000000",
     "model_uuid": "df08a203-7284-5f88-a4da-a5de36a6b796",
@@ -27,7 +28,8 @@
   },
   "parameters": {
     "inc_min": 0,
-    "inc_max": 180
+    "inc_max": 180,
+    "XCLTortuosity": 0.000572614583987641
   },
   "terms": [
     {

--- a/welleng/errors/iscwsa_json/owsg_b/EMS+HRGM+AX_Fl.json
+++ b/welleng/errors/iscwsa_json/owsg_b/EMS+HRGM+AX_Fl.json
@@ -1,5 +1,6 @@
 {
   "$schema": "../../iscwsa_schema/draft.json",
+  "_comment": "GENERATED from the ISCWSA-issued OWSG spreadsheet by welleng/errors/tools/owsg_to_json.py -- DO NOT EDIT BY HAND. Regenerate from the source xlsx. If a test needs different parameter values for validation, it must override them locally, never modify this shipped model. (test_iscwsa_json_generated.py enforces this.)",
   "metadata": {
     "schema_uuid": "00000000-0000-0000-0000-000000000000",
     "model_uuid": "df08a203-7284-5f88-a4da-a5de36a6b796",
@@ -27,7 +28,8 @@
   },
   "parameters": {
     "inc_min": 0,
-    "inc_max": 180
+    "inc_max": 180,
+    "XCLTortuosity": 0.000572614583987641
   },
   "terms": [
     {

--- a/welleng/errors/iscwsa_json/owsg_b/EMS+HRGM+SAG.json
+++ b/welleng/errors/iscwsa_json/owsg_b/EMS+HRGM+SAG.json
@@ -1,5 +1,6 @@
 {
   "$schema": "../../iscwsa_schema/draft.json",
+  "_comment": "GENERATED from the ISCWSA-issued OWSG spreadsheet by welleng/errors/tools/owsg_to_json.py -- DO NOT EDIT BY HAND. Regenerate from the source xlsx. If a test needs different parameter values for validation, it must override them locally, never modify this shipped model. (test_iscwsa_json_generated.py enforces this.)",
   "metadata": {
     "schema_uuid": "00000000-0000-0000-0000-000000000000",
     "model_uuid": "26cbe784-004a-55db-a04e-c4f62571eaea",
@@ -27,7 +28,8 @@
   },
   "parameters": {
     "inc_min": 0,
-    "inc_max": 180
+    "inc_max": 180,
+    "XCLTortuosity": 0.000572614583987641
   },
   "terms": [
     {

--- a/welleng/errors/iscwsa_json/owsg_b/EMS+HRGM+SAG_Fl.json
+++ b/welleng/errors/iscwsa_json/owsg_b/EMS+HRGM+SAG_Fl.json
@@ -1,5 +1,6 @@
 {
   "$schema": "../../iscwsa_schema/draft.json",
+  "_comment": "GENERATED from the ISCWSA-issued OWSG spreadsheet by welleng/errors/tools/owsg_to_json.py -- DO NOT EDIT BY HAND. Regenerate from the source xlsx. If a test needs different parameter values for validation, it must override them locally, never modify this shipped model. (test_iscwsa_json_generated.py enforces this.)",
   "metadata": {
     "schema_uuid": "00000000-0000-0000-0000-000000000000",
     "model_uuid": "26cbe784-004a-55db-a04e-c4f62571eaea",
@@ -27,7 +28,8 @@
   },
   "parameters": {
     "inc_min": 0,
-    "inc_max": 180
+    "inc_max": 180,
+    "XCLTortuosity": 0.000572614583987641
   },
   "terms": [
     {

--- a/welleng/errors/iscwsa_json/owsg_b/EMS+HRGM.json
+++ b/welleng/errors/iscwsa_json/owsg_b/EMS+HRGM.json
@@ -1,5 +1,6 @@
 {
   "$schema": "../../iscwsa_schema/draft.json",
+  "_comment": "GENERATED from the ISCWSA-issued OWSG spreadsheet by welleng/errors/tools/owsg_to_json.py -- DO NOT EDIT BY HAND. Regenerate from the source xlsx. If a test needs different parameter values for validation, it must override them locally, never modify this shipped model. (test_iscwsa_json_generated.py enforces this.)",
   "metadata": {
     "schema_uuid": "00000000-0000-0000-0000-000000000000",
     "model_uuid": "7f2aeb19-46b1-5a37-b050-f13a00488f0b",
@@ -27,7 +28,8 @@
   },
   "parameters": {
     "inc_min": 0,
-    "inc_max": 180
+    "inc_max": 180,
+    "XCLTortuosity": 0.000572614583987641
   },
   "terms": [
     {

--- a/welleng/errors/iscwsa_json/owsg_b/EMS+HRGM_Fl.json
+++ b/welleng/errors/iscwsa_json/owsg_b/EMS+HRGM_Fl.json
@@ -1,5 +1,6 @@
 {
   "$schema": "../../iscwsa_schema/draft.json",
+  "_comment": "GENERATED from the ISCWSA-issued OWSG spreadsheet by welleng/errors/tools/owsg_to_json.py -- DO NOT EDIT BY HAND. Regenerate from the source xlsx. If a test needs different parameter values for validation, it must override them locally, never modify this shipped model. (test_iscwsa_json_generated.py enforces this.)",
   "metadata": {
     "schema_uuid": "00000000-0000-0000-0000-000000000000",
     "model_uuid": "7f2aeb19-46b1-5a37-b050-f13a00488f0b",
@@ -27,7 +28,8 @@
   },
   "parameters": {
     "inc_min": 0,
-    "inc_max": 180
+    "inc_max": 180,
+    "XCLTortuosity": 0.000572614583987641
   },
   "terms": [
     {

--- a/welleng/errors/iscwsa_json/owsg_b/EMS+IFR1+AX+SAG.json
+++ b/welleng/errors/iscwsa_json/owsg_b/EMS+IFR1+AX+SAG.json
@@ -1,5 +1,6 @@
 {
   "$schema": "../../iscwsa_schema/draft.json",
+  "_comment": "GENERATED from the ISCWSA-issued OWSG spreadsheet by welleng/errors/tools/owsg_to_json.py -- DO NOT EDIT BY HAND. Regenerate from the source xlsx. If a test needs different parameter values for validation, it must override them locally, never modify this shipped model. (test_iscwsa_json_generated.py enforces this.)",
   "metadata": {
     "schema_uuid": "00000000-0000-0000-0000-000000000000",
     "model_uuid": "8e938938-63f0-59e4-9a53-2863cfbb4cfa",
@@ -27,7 +28,8 @@
   },
   "parameters": {
     "inc_min": 0,
-    "inc_max": 180
+    "inc_max": 180,
+    "XCLTortuosity": 0.000572614583987641
   },
   "terms": [
     {

--- a/welleng/errors/iscwsa_json/owsg_b/EMS+IFR1+AX+SAG_Fl.json
+++ b/welleng/errors/iscwsa_json/owsg_b/EMS+IFR1+AX+SAG_Fl.json
@@ -1,5 +1,6 @@
 {
   "$schema": "../../iscwsa_schema/draft.json",
+  "_comment": "GENERATED from the ISCWSA-issued OWSG spreadsheet by welleng/errors/tools/owsg_to_json.py -- DO NOT EDIT BY HAND. Regenerate from the source xlsx. If a test needs different parameter values for validation, it must override them locally, never modify this shipped model. (test_iscwsa_json_generated.py enforces this.)",
   "metadata": {
     "schema_uuid": "00000000-0000-0000-0000-000000000000",
     "model_uuid": "8e938938-63f0-59e4-9a53-2863cfbb4cfa",
@@ -27,7 +28,8 @@
   },
   "parameters": {
     "inc_min": 0,
-    "inc_max": 180
+    "inc_max": 180,
+    "XCLTortuosity": 0.000572614583987641
   },
   "terms": [
     {

--- a/welleng/errors/iscwsa_json/owsg_b/EMS+IFR1+SAG+MS.json
+++ b/welleng/errors/iscwsa_json/owsg_b/EMS+IFR1+SAG+MS.json
@@ -1,5 +1,6 @@
 {
   "$schema": "../../iscwsa_schema/draft.json",
+  "_comment": "GENERATED from the ISCWSA-issued OWSG spreadsheet by welleng/errors/tools/owsg_to_json.py -- DO NOT EDIT BY HAND. Regenerate from the source xlsx. If a test needs different parameter values for validation, it must override them locally, never modify this shipped model. (test_iscwsa_json_generated.py enforces this.)",
   "metadata": {
     "schema_uuid": "00000000-0000-0000-0000-000000000000",
     "model_uuid": "a7531673-b97c-5e66-a879-d01bacb4787f",
@@ -27,7 +28,8 @@
   },
   "parameters": {
     "inc_min": 0,
-    "inc_max": 180
+    "inc_max": 180,
+    "XCLTortuosity": 0.000572614583987641
   },
   "terms": [
     {

--- a/welleng/errors/iscwsa_json/owsg_b/EMS+IFR1+SAG+MS_Fl.json
+++ b/welleng/errors/iscwsa_json/owsg_b/EMS+IFR1+SAG+MS_Fl.json
@@ -1,5 +1,6 @@
 {
   "$schema": "../../iscwsa_schema/draft.json",
+  "_comment": "GENERATED from the ISCWSA-issued OWSG spreadsheet by welleng/errors/tools/owsg_to_json.py -- DO NOT EDIT BY HAND. Regenerate from the source xlsx. If a test needs different parameter values for validation, it must override them locally, never modify this shipped model. (test_iscwsa_json_generated.py enforces this.)",
   "metadata": {
     "schema_uuid": "00000000-0000-0000-0000-000000000000",
     "model_uuid": "a7531673-b97c-5e66-a879-d01bacb4787f",
@@ -27,7 +28,8 @@
   },
   "parameters": {
     "inc_min": 0,
-    "inc_max": 180
+    "inc_max": 180,
+    "XCLTortuosity": 0.000572614583987641
   },
   "terms": [
     {

--- a/welleng/errors/iscwsa_json/owsg_b/EMS+IFR1+SAG.json
+++ b/welleng/errors/iscwsa_json/owsg_b/EMS+IFR1+SAG.json
@@ -1,5 +1,6 @@
 {
   "$schema": "../../iscwsa_schema/draft.json",
+  "_comment": "GENERATED from the ISCWSA-issued OWSG spreadsheet by welleng/errors/tools/owsg_to_json.py -- DO NOT EDIT BY HAND. Regenerate from the source xlsx. If a test needs different parameter values for validation, it must override them locally, never modify this shipped model. (test_iscwsa_json_generated.py enforces this.)",
   "metadata": {
     "schema_uuid": "00000000-0000-0000-0000-000000000000",
     "model_uuid": "4566ae53-aa85-55cd-8cec-32a460c6ca05",
@@ -27,7 +28,8 @@
   },
   "parameters": {
     "inc_min": 0,
-    "inc_max": 180
+    "inc_max": 180,
+    "XCLTortuosity": 0.000572614583987641
   },
   "terms": [
     {

--- a/welleng/errors/iscwsa_json/owsg_b/EMS+IFR1+SAG_Fl.json
+++ b/welleng/errors/iscwsa_json/owsg_b/EMS+IFR1+SAG_Fl.json
@@ -1,5 +1,6 @@
 {
   "$schema": "../../iscwsa_schema/draft.json",
+  "_comment": "GENERATED from the ISCWSA-issued OWSG spreadsheet by welleng/errors/tools/owsg_to_json.py -- DO NOT EDIT BY HAND. Regenerate from the source xlsx. If a test needs different parameter values for validation, it must override them locally, never modify this shipped model. (test_iscwsa_json_generated.py enforces this.)",
   "metadata": {
     "schema_uuid": "00000000-0000-0000-0000-000000000000",
     "model_uuid": "4566ae53-aa85-55cd-8cec-32a460c6ca05",
@@ -27,7 +28,8 @@
   },
   "parameters": {
     "inc_min": 0,
-    "inc_max": 180
+    "inc_max": 180,
+    "XCLTortuosity": 0.000572614583987641
   },
   "terms": [
     {

--- a/welleng/errors/iscwsa_json/owsg_b/EMS+LRGM+AX+SAG.json
+++ b/welleng/errors/iscwsa_json/owsg_b/EMS+LRGM+AX+SAG.json
@@ -1,5 +1,6 @@
 {
   "$schema": "../../iscwsa_schema/draft.json",
+  "_comment": "GENERATED from the ISCWSA-issued OWSG spreadsheet by welleng/errors/tools/owsg_to_json.py -- DO NOT EDIT BY HAND. Regenerate from the source xlsx. If a test needs different parameter values for validation, it must override them locally, never modify this shipped model. (test_iscwsa_json_generated.py enforces this.)",
   "metadata": {
     "schema_uuid": "00000000-0000-0000-0000-000000000000",
     "model_uuid": "79a572c1-3242-5157-a73b-25dd68dbc833",
@@ -27,7 +28,8 @@
   },
   "parameters": {
     "inc_min": 0,
-    "inc_max": 180
+    "inc_max": 180,
+    "XCLTortuosity": 0.000572614583987641
   },
   "terms": [
     {

--- a/welleng/errors/iscwsa_json/owsg_b/EMS+LRGM+AX+SAG_Fl.json
+++ b/welleng/errors/iscwsa_json/owsg_b/EMS+LRGM+AX+SAG_Fl.json
@@ -1,5 +1,6 @@
 {
   "$schema": "../../iscwsa_schema/draft.json",
+  "_comment": "GENERATED from the ISCWSA-issued OWSG spreadsheet by welleng/errors/tools/owsg_to_json.py -- DO NOT EDIT BY HAND. Regenerate from the source xlsx. If a test needs different parameter values for validation, it must override them locally, never modify this shipped model. (test_iscwsa_json_generated.py enforces this.)",
   "metadata": {
     "schema_uuid": "00000000-0000-0000-0000-000000000000",
     "model_uuid": "79a572c1-3242-5157-a73b-25dd68dbc833",
@@ -27,7 +28,8 @@
   },
   "parameters": {
     "inc_min": 0,
-    "inc_max": 180
+    "inc_max": 180,
+    "XCLTortuosity": 0.000572614583987641
   },
   "terms": [
     {

--- a/welleng/errors/iscwsa_json/owsg_b/EMS+LRGM+AX.json
+++ b/welleng/errors/iscwsa_json/owsg_b/EMS+LRGM+AX.json
@@ -1,5 +1,6 @@
 {
   "$schema": "../../iscwsa_schema/draft.json",
+  "_comment": "GENERATED from the ISCWSA-issued OWSG spreadsheet by welleng/errors/tools/owsg_to_json.py -- DO NOT EDIT BY HAND. Regenerate from the source xlsx. If a test needs different parameter values for validation, it must override them locally, never modify this shipped model. (test_iscwsa_json_generated.py enforces this.)",
   "metadata": {
     "schema_uuid": "00000000-0000-0000-0000-000000000000",
     "model_uuid": "5e7b0106-b629-56aa-a065-8b4ec01a9972",
@@ -27,7 +28,8 @@
   },
   "parameters": {
     "inc_min": 0,
-    "inc_max": 180
+    "inc_max": 180,
+    "XCLTortuosity": 0.000572614583987641
   },
   "terms": [
     {

--- a/welleng/errors/iscwsa_json/owsg_b/EMS+LRGM+AX_Fl.json
+++ b/welleng/errors/iscwsa_json/owsg_b/EMS+LRGM+AX_Fl.json
@@ -1,5 +1,6 @@
 {
   "$schema": "../../iscwsa_schema/draft.json",
+  "_comment": "GENERATED from the ISCWSA-issued OWSG spreadsheet by welleng/errors/tools/owsg_to_json.py -- DO NOT EDIT BY HAND. Regenerate from the source xlsx. If a test needs different parameter values for validation, it must override them locally, never modify this shipped model. (test_iscwsa_json_generated.py enforces this.)",
   "metadata": {
     "schema_uuid": "00000000-0000-0000-0000-000000000000",
     "model_uuid": "5e7b0106-b629-56aa-a065-8b4ec01a9972",
@@ -27,7 +28,8 @@
   },
   "parameters": {
     "inc_min": 0,
-    "inc_max": 180
+    "inc_max": 180,
+    "XCLTortuosity": 0.000572614583987641
   },
   "terms": [
     {

--- a/welleng/errors/iscwsa_json/owsg_b/EMS+LRGM+SAG.json
+++ b/welleng/errors/iscwsa_json/owsg_b/EMS+LRGM+SAG.json
@@ -1,5 +1,6 @@
 {
   "$schema": "../../iscwsa_schema/draft.json",
+  "_comment": "GENERATED from the ISCWSA-issued OWSG spreadsheet by welleng/errors/tools/owsg_to_json.py -- DO NOT EDIT BY HAND. Regenerate from the source xlsx. If a test needs different parameter values for validation, it must override them locally, never modify this shipped model. (test_iscwsa_json_generated.py enforces this.)",
   "metadata": {
     "schema_uuid": "00000000-0000-0000-0000-000000000000",
     "model_uuid": "bd8f738c-b763-5f54-a4f2-e16635fa2833",
@@ -27,7 +28,8 @@
   },
   "parameters": {
     "inc_min": 0,
-    "inc_max": 180
+    "inc_max": 180,
+    "XCLTortuosity": 0.000572614583987641
   },
   "terms": [
     {

--- a/welleng/errors/iscwsa_json/owsg_b/EMS+LRGM+SAG_Fl.json
+++ b/welleng/errors/iscwsa_json/owsg_b/EMS+LRGM+SAG_Fl.json
@@ -1,5 +1,6 @@
 {
   "$schema": "../../iscwsa_schema/draft.json",
+  "_comment": "GENERATED from the ISCWSA-issued OWSG spreadsheet by welleng/errors/tools/owsg_to_json.py -- DO NOT EDIT BY HAND. Regenerate from the source xlsx. If a test needs different parameter values for validation, it must override them locally, never modify this shipped model. (test_iscwsa_json_generated.py enforces this.)",
   "metadata": {
     "schema_uuid": "00000000-0000-0000-0000-000000000000",
     "model_uuid": "bd8f738c-b763-5f54-a4f2-e16635fa2833",
@@ -27,7 +28,8 @@
   },
   "parameters": {
     "inc_min": 0,
-    "inc_max": 180
+    "inc_max": 180,
+    "XCLTortuosity": 0.000572614583987641
   },
   "terms": [
     {

--- a/welleng/errors/iscwsa_json/owsg_b/EMS+LRGM.json
+++ b/welleng/errors/iscwsa_json/owsg_b/EMS+LRGM.json
@@ -1,5 +1,6 @@
 {
   "$schema": "../../iscwsa_schema/draft.json",
+  "_comment": "GENERATED from the ISCWSA-issued OWSG spreadsheet by welleng/errors/tools/owsg_to_json.py -- DO NOT EDIT BY HAND. Regenerate from the source xlsx. If a test needs different parameter values for validation, it must override them locally, never modify this shipped model. (test_iscwsa_json_generated.py enforces this.)",
   "metadata": {
     "schema_uuid": "00000000-0000-0000-0000-000000000000",
     "model_uuid": "0c424fca-fe08-583c-97c3-b4c3f7968588",
@@ -27,7 +28,8 @@
   },
   "parameters": {
     "inc_min": 0,
-    "inc_max": 180
+    "inc_max": 180,
+    "XCLTortuosity": 0.000572614583987641
   },
   "terms": [
     {

--- a/welleng/errors/iscwsa_json/owsg_b/EMS+LRGM_Fl.json
+++ b/welleng/errors/iscwsa_json/owsg_b/EMS+LRGM_Fl.json
@@ -1,5 +1,6 @@
 {
   "$schema": "../../iscwsa_schema/draft.json",
+  "_comment": "GENERATED from the ISCWSA-issued OWSG spreadsheet by welleng/errors/tools/owsg_to_json.py -- DO NOT EDIT BY HAND. Regenerate from the source xlsx. If a test needs different parameter values for validation, it must override them locally, never modify this shipped model. (test_iscwsa_json_generated.py enforces this.)",
   "metadata": {
     "schema_uuid": "00000000-0000-0000-0000-000000000000",
     "model_uuid": "0c424fca-fe08-583c-97c3-b4c3f7968588",
@@ -27,7 +28,8 @@
   },
   "parameters": {
     "inc_min": 0,
-    "inc_max": 180
+    "inc_max": 180,
+    "XCLTortuosity": 0.000572614583987641
   },
   "terms": [
     {

--- a/welleng/errors/iscwsa_json/owsg_b/FINDS.json
+++ b/welleng/errors/iscwsa_json/owsg_b/FINDS.json
@@ -1,5 +1,6 @@
 {
   "$schema": "../../iscwsa_schema/draft.json",
+  "_comment": "GENERATED from the ISCWSA-issued OWSG spreadsheet by welleng/errors/tools/owsg_to_json.py -- DO NOT EDIT BY HAND. Regenerate from the source xlsx. If a test needs different parameter values for validation, it must override them locally, never modify this shipped model. (test_iscwsa_json_generated.py enforces this.)",
   "metadata": {
     "schema_uuid": "00000000-0000-0000-0000-000000000000",
     "model_uuid": "964eb8de-e3c0-5fa0-add6-a7edfe4ed179",

--- a/welleng/errors/iscwsa_json/owsg_b/MWD+HRGM+AX+SAG.json
+++ b/welleng/errors/iscwsa_json/owsg_b/MWD+HRGM+AX+SAG.json
@@ -1,5 +1,6 @@
 {
   "$schema": "../../iscwsa_schema/draft.json",
+  "_comment": "GENERATED from the ISCWSA-issued OWSG spreadsheet by welleng/errors/tools/owsg_to_json.py -- DO NOT EDIT BY HAND. Regenerate from the source xlsx. If a test needs different parameter values for validation, it must override them locally, never modify this shipped model. (test_iscwsa_json_generated.py enforces this.)",
   "metadata": {
     "schema_uuid": "00000000-0000-0000-0000-000000000000",
     "model_uuid": "01c6a1cc-a02b-5264-84f9-523c9aca862d",
@@ -27,7 +28,8 @@
   },
   "parameters": {
     "inc_min": 0,
-    "inc_max": 180
+    "inc_max": 180,
+    "XCLTortuosity": 0.000572614583987641
   },
   "terms": [
     {

--- a/welleng/errors/iscwsa_json/owsg_b/MWD+HRGM+AX+SAG_Fl.json
+++ b/welleng/errors/iscwsa_json/owsg_b/MWD+HRGM+AX+SAG_Fl.json
@@ -1,5 +1,6 @@
 {
   "$schema": "../../iscwsa_schema/draft.json",
+  "_comment": "GENERATED from the ISCWSA-issued OWSG spreadsheet by welleng/errors/tools/owsg_to_json.py -- DO NOT EDIT BY HAND. Regenerate from the source xlsx. If a test needs different parameter values for validation, it must override them locally, never modify this shipped model. (test_iscwsa_json_generated.py enforces this.)",
   "metadata": {
     "schema_uuid": "00000000-0000-0000-0000-000000000000",
     "model_uuid": "01c6a1cc-a02b-5264-84f9-523c9aca862d",
@@ -27,7 +28,8 @@
   },
   "parameters": {
     "inc_min": 0,
-    "inc_max": 180
+    "inc_max": 180,
+    "XCLTortuosity": 0.000572614583987641
   },
   "terms": [
     {

--- a/welleng/errors/iscwsa_json/owsg_b/MWD+HRGM+AX.json
+++ b/welleng/errors/iscwsa_json/owsg_b/MWD+HRGM+AX.json
@@ -1,5 +1,6 @@
 {
   "$schema": "../../iscwsa_schema/draft.json",
+  "_comment": "GENERATED from the ISCWSA-issued OWSG spreadsheet by welleng/errors/tools/owsg_to_json.py -- DO NOT EDIT BY HAND. Regenerate from the source xlsx. If a test needs different parameter values for validation, it must override them locally, never modify this shipped model. (test_iscwsa_json_generated.py enforces this.)",
   "metadata": {
     "schema_uuid": "00000000-0000-0000-0000-000000000000",
     "model_uuid": "a3dab62c-0519-5be2-9fbc-9a52db9779d5",
@@ -27,7 +28,8 @@
   },
   "parameters": {
     "inc_min": 0,
-    "inc_max": 180
+    "inc_max": 180,
+    "XCLTortuosity": 0.000572614583987641
   },
   "terms": [
     {

--- a/welleng/errors/iscwsa_json/owsg_b/MWD+HRGM+AX_Fl.json
+++ b/welleng/errors/iscwsa_json/owsg_b/MWD+HRGM+AX_Fl.json
@@ -1,5 +1,6 @@
 {
   "$schema": "../../iscwsa_schema/draft.json",
+  "_comment": "GENERATED from the ISCWSA-issued OWSG spreadsheet by welleng/errors/tools/owsg_to_json.py -- DO NOT EDIT BY HAND. Regenerate from the source xlsx. If a test needs different parameter values for validation, it must override them locally, never modify this shipped model. (test_iscwsa_json_generated.py enforces this.)",
   "metadata": {
     "schema_uuid": "00000000-0000-0000-0000-000000000000",
     "model_uuid": "a3dab62c-0519-5be2-9fbc-9a52db9779d5",
@@ -27,7 +28,8 @@
   },
   "parameters": {
     "inc_min": 0,
-    "inc_max": 180
+    "inc_max": 180,
+    "XCLTortuosity": 0.000572614583987641
   },
   "terms": [
     {

--- a/welleng/errors/iscwsa_json/owsg_b/MWD+HRGM+SAG+MS.json
+++ b/welleng/errors/iscwsa_json/owsg_b/MWD+HRGM+SAG+MS.json
@@ -1,5 +1,6 @@
 {
   "$schema": "../../iscwsa_schema/draft.json",
+  "_comment": "GENERATED from the ISCWSA-issued OWSG spreadsheet by welleng/errors/tools/owsg_to_json.py -- DO NOT EDIT BY HAND. Regenerate from the source xlsx. If a test needs different parameter values for validation, it must override them locally, never modify this shipped model. (test_iscwsa_json_generated.py enforces this.)",
   "metadata": {
     "schema_uuid": "00000000-0000-0000-0000-000000000000",
     "model_uuid": "92fe010b-052f-5ba6-860d-cc5cc2a83215",
@@ -27,7 +28,8 @@
   },
   "parameters": {
     "inc_min": 0,
-    "inc_max": 180
+    "inc_max": 180,
+    "XCLTortuosity": 0.000572614583987641
   },
   "terms": [
     {

--- a/welleng/errors/iscwsa_json/owsg_b/MWD+HRGM+SAG+MS_Fl.json
+++ b/welleng/errors/iscwsa_json/owsg_b/MWD+HRGM+SAG+MS_Fl.json
@@ -1,5 +1,6 @@
 {
   "$schema": "../../iscwsa_schema/draft.json",
+  "_comment": "GENERATED from the ISCWSA-issued OWSG spreadsheet by welleng/errors/tools/owsg_to_json.py -- DO NOT EDIT BY HAND. Regenerate from the source xlsx. If a test needs different parameter values for validation, it must override them locally, never modify this shipped model. (test_iscwsa_json_generated.py enforces this.)",
   "metadata": {
     "schema_uuid": "00000000-0000-0000-0000-000000000000",
     "model_uuid": "92fe010b-052f-5ba6-860d-cc5cc2a83215",
@@ -27,7 +28,8 @@
   },
   "parameters": {
     "inc_min": 0,
-    "inc_max": 180
+    "inc_max": 180,
+    "XCLTortuosity": 0.000572614583987641
   },
   "terms": [
     {

--- a/welleng/errors/iscwsa_json/owsg_b/MWD+HRGM+SAG.json
+++ b/welleng/errors/iscwsa_json/owsg_b/MWD+HRGM+SAG.json
@@ -1,5 +1,6 @@
 {
   "$schema": "../../iscwsa_schema/draft.json",
+  "_comment": "GENERATED from the ISCWSA-issued OWSG spreadsheet by welleng/errors/tools/owsg_to_json.py -- DO NOT EDIT BY HAND. Regenerate from the source xlsx. If a test needs different parameter values for validation, it must override them locally, never modify this shipped model. (test_iscwsa_json_generated.py enforces this.)",
   "metadata": {
     "schema_uuid": "00000000-0000-0000-0000-000000000000",
     "model_uuid": "7484174d-1ff8-5f83-8f1c-0253f3606958",
@@ -27,7 +28,8 @@
   },
   "parameters": {
     "inc_min": 0,
-    "inc_max": 180
+    "inc_max": 180,
+    "XCLTortuosity": 0.000572614583987641
   },
   "terms": [
     {

--- a/welleng/errors/iscwsa_json/owsg_b/MWD+HRGM+SAG_Fl.json
+++ b/welleng/errors/iscwsa_json/owsg_b/MWD+HRGM+SAG_Fl.json
@@ -1,5 +1,6 @@
 {
   "$schema": "../../iscwsa_schema/draft.json",
+  "_comment": "GENERATED from the ISCWSA-issued OWSG spreadsheet by welleng/errors/tools/owsg_to_json.py -- DO NOT EDIT BY HAND. Regenerate from the source xlsx. If a test needs different parameter values for validation, it must override them locally, never modify this shipped model. (test_iscwsa_json_generated.py enforces this.)",
   "metadata": {
     "schema_uuid": "00000000-0000-0000-0000-000000000000",
     "model_uuid": "7484174d-1ff8-5f83-8f1c-0253f3606958",
@@ -27,7 +28,8 @@
   },
   "parameters": {
     "inc_min": 0,
-    "inc_max": 180
+    "inc_max": 180,
+    "XCLTortuosity": 0.000572614583987641
   },
   "terms": [
     {

--- a/welleng/errors/iscwsa_json/owsg_b/MWD+HRGM.json
+++ b/welleng/errors/iscwsa_json/owsg_b/MWD+HRGM.json
@@ -1,5 +1,6 @@
 {
   "$schema": "../../iscwsa_schema/draft.json",
+  "_comment": "GENERATED from the ISCWSA-issued OWSG spreadsheet by welleng/errors/tools/owsg_to_json.py -- DO NOT EDIT BY HAND. Regenerate from the source xlsx. If a test needs different parameter values for validation, it must override them locally, never modify this shipped model. (test_iscwsa_json_generated.py enforces this.)",
   "metadata": {
     "schema_uuid": "00000000-0000-0000-0000-000000000000",
     "model_uuid": "849f40aa-94c3-5b3f-a3da-83dbecbd3045",
@@ -27,7 +28,8 @@
   },
   "parameters": {
     "inc_min": 0,
-    "inc_max": 180
+    "inc_max": 180,
+    "XCLTortuosity": 0.000572614583987641
   },
   "terms": [
     {

--- a/welleng/errors/iscwsa_json/owsg_b/MWD+HRGM_Fl.json
+++ b/welleng/errors/iscwsa_json/owsg_b/MWD+HRGM_Fl.json
@@ -1,5 +1,6 @@
 {
   "$schema": "../../iscwsa_schema/draft.json",
+  "_comment": "GENERATED from the ISCWSA-issued OWSG spreadsheet by welleng/errors/tools/owsg_to_json.py -- DO NOT EDIT BY HAND. Regenerate from the source xlsx. If a test needs different parameter values for validation, it must override them locally, never modify this shipped model. (test_iscwsa_json_generated.py enforces this.)",
   "metadata": {
     "schema_uuid": "00000000-0000-0000-0000-000000000000",
     "model_uuid": "849f40aa-94c3-5b3f-a3da-83dbecbd3045",
@@ -27,7 +28,8 @@
   },
   "parameters": {
     "inc_min": 0,
-    "inc_max": 180
+    "inc_max": 180,
+    "XCLTortuosity": 0.000572614583987641
   },
   "terms": [
     {

--- a/welleng/errors/iscwsa_json/owsg_b/MWD+LRGM+AX+SAG.json
+++ b/welleng/errors/iscwsa_json/owsg_b/MWD+LRGM+AX+SAG.json
@@ -1,5 +1,6 @@
 {
   "$schema": "../../iscwsa_schema/draft.json",
+  "_comment": "GENERATED from the ISCWSA-issued OWSG spreadsheet by welleng/errors/tools/owsg_to_json.py -- DO NOT EDIT BY HAND. Regenerate from the source xlsx. If a test needs different parameter values for validation, it must override them locally, never modify this shipped model. (test_iscwsa_json_generated.py enforces this.)",
   "metadata": {
     "schema_uuid": "00000000-0000-0000-0000-000000000000",
     "model_uuid": "44abfc1e-b3b1-5175-bed2-45c55230c93a",
@@ -27,7 +28,8 @@
   },
   "parameters": {
     "inc_min": 0,
-    "inc_max": 180
+    "inc_max": 180,
+    "XCLTortuosity": 0.000572614583987641
   },
   "terms": [
     {

--- a/welleng/errors/iscwsa_json/owsg_b/MWD+LRGM+AX+SAG_Fl.json
+++ b/welleng/errors/iscwsa_json/owsg_b/MWD+LRGM+AX+SAG_Fl.json
@@ -1,5 +1,6 @@
 {
   "$schema": "../../iscwsa_schema/draft.json",
+  "_comment": "GENERATED from the ISCWSA-issued OWSG spreadsheet by welleng/errors/tools/owsg_to_json.py -- DO NOT EDIT BY HAND. Regenerate from the source xlsx. If a test needs different parameter values for validation, it must override them locally, never modify this shipped model. (test_iscwsa_json_generated.py enforces this.)",
   "metadata": {
     "schema_uuid": "00000000-0000-0000-0000-000000000000",
     "model_uuid": "44abfc1e-b3b1-5175-bed2-45c55230c93a",
@@ -27,7 +28,8 @@
   },
   "parameters": {
     "inc_min": 0,
-    "inc_max": 180
+    "inc_max": 180,
+    "XCLTortuosity": 0.000572614583987641
   },
   "terms": [
     {

--- a/welleng/errors/iscwsa_json/owsg_b/MWD+LRGM+AX.json
+++ b/welleng/errors/iscwsa_json/owsg_b/MWD+LRGM+AX.json
@@ -1,5 +1,6 @@
 {
   "$schema": "../../iscwsa_schema/draft.json",
+  "_comment": "GENERATED from the ISCWSA-issued OWSG spreadsheet by welleng/errors/tools/owsg_to_json.py -- DO NOT EDIT BY HAND. Regenerate from the source xlsx. If a test needs different parameter values for validation, it must override them locally, never modify this shipped model. (test_iscwsa_json_generated.py enforces this.)",
   "metadata": {
     "schema_uuid": "00000000-0000-0000-0000-000000000000",
     "model_uuid": "32457c7e-bb34-5019-b2ae-490af5dfdcc0",
@@ -27,7 +28,8 @@
   },
   "parameters": {
     "inc_min": 0,
-    "inc_max": 180
+    "inc_max": 180,
+    "XCLTortuosity": 0.000572614583987641
   },
   "terms": [
     {

--- a/welleng/errors/iscwsa_json/owsg_b/MWD+LRGM+AX_Fl.json
+++ b/welleng/errors/iscwsa_json/owsg_b/MWD+LRGM+AX_Fl.json
@@ -1,5 +1,6 @@
 {
   "$schema": "../../iscwsa_schema/draft.json",
+  "_comment": "GENERATED from the ISCWSA-issued OWSG spreadsheet by welleng/errors/tools/owsg_to_json.py -- DO NOT EDIT BY HAND. Regenerate from the source xlsx. If a test needs different parameter values for validation, it must override them locally, never modify this shipped model. (test_iscwsa_json_generated.py enforces this.)",
   "metadata": {
     "schema_uuid": "00000000-0000-0000-0000-000000000000",
     "model_uuid": "32457c7e-bb34-5019-b2ae-490af5dfdcc0",
@@ -27,7 +28,8 @@
   },
   "parameters": {
     "inc_min": 0,
-    "inc_max": 180
+    "inc_max": 180,
+    "XCLTortuosity": 0.000572614583987641
   },
   "terms": [
     {

--- a/welleng/errors/iscwsa_json/owsg_b/MWD+LRGM+SAG.json
+++ b/welleng/errors/iscwsa_json/owsg_b/MWD+LRGM+SAG.json
@@ -1,5 +1,6 @@
 {
   "$schema": "../../iscwsa_schema/draft.json",
+  "_comment": "GENERATED from the ISCWSA-issued OWSG spreadsheet by welleng/errors/tools/owsg_to_json.py -- DO NOT EDIT BY HAND. Regenerate from the source xlsx. If a test needs different parameter values for validation, it must override them locally, never modify this shipped model. (test_iscwsa_json_generated.py enforces this.)",
   "metadata": {
     "schema_uuid": "00000000-0000-0000-0000-000000000000",
     "model_uuid": "d2827659-cdcf-53d6-82db-f7dda5b96840",
@@ -27,7 +28,8 @@
   },
   "parameters": {
     "inc_min": 0,
-    "inc_max": 180
+    "inc_max": 180,
+    "XCLTortuosity": 0.000572614583987641
   },
   "terms": [
     {

--- a/welleng/errors/iscwsa_json/owsg_b/MWD+LRGM+SAG_Fl.json
+++ b/welleng/errors/iscwsa_json/owsg_b/MWD+LRGM+SAG_Fl.json
@@ -1,5 +1,6 @@
 {
   "$schema": "../../iscwsa_schema/draft.json",
+  "_comment": "GENERATED from the ISCWSA-issued OWSG spreadsheet by welleng/errors/tools/owsg_to_json.py -- DO NOT EDIT BY HAND. Regenerate from the source xlsx. If a test needs different parameter values for validation, it must override them locally, never modify this shipped model. (test_iscwsa_json_generated.py enforces this.)",
   "metadata": {
     "schema_uuid": "00000000-0000-0000-0000-000000000000",
     "model_uuid": "d2827659-cdcf-53d6-82db-f7dda5b96840",
@@ -27,7 +28,8 @@
   },
   "parameters": {
     "inc_min": 0,
-    "inc_max": 180
+    "inc_max": 180,
+    "XCLTortuosity": 0.000572614583987641
   },
   "terms": [
     {

--- a/welleng/errors/iscwsa_json/owsg_b/MWD+LRGM.json
+++ b/welleng/errors/iscwsa_json/owsg_b/MWD+LRGM.json
@@ -1,5 +1,6 @@
 {
   "$schema": "../../iscwsa_schema/draft.json",
+  "_comment": "GENERATED from the ISCWSA-issued OWSG spreadsheet by welleng/errors/tools/owsg_to_json.py -- DO NOT EDIT BY HAND. Regenerate from the source xlsx. If a test needs different parameter values for validation, it must override them locally, never modify this shipped model. (test_iscwsa_json_generated.py enforces this.)",
   "metadata": {
     "schema_uuid": "00000000-0000-0000-0000-000000000000",
     "model_uuid": "6050449c-7b6b-501b-ad23-de97242c4287",
@@ -27,7 +28,8 @@
   },
   "parameters": {
     "inc_min": 0,
-    "inc_max": 180
+    "inc_max": 180,
+    "XCLTortuosity": 0.000572614583987641
   },
   "terms": [
     {

--- a/welleng/errors/iscwsa_json/owsg_b/MWD+LRGM_Fl.json
+++ b/welleng/errors/iscwsa_json/owsg_b/MWD+LRGM_Fl.json
@@ -1,5 +1,6 @@
 {
   "$schema": "../../iscwsa_schema/draft.json",
+  "_comment": "GENERATED from the ISCWSA-issued OWSG spreadsheet by welleng/errors/tools/owsg_to_json.py -- DO NOT EDIT BY HAND. Regenerate from the source xlsx. If a test needs different parameter values for validation, it must override them locally, never modify this shipped model. (test_iscwsa_json_generated.py enforces this.)",
   "metadata": {
     "schema_uuid": "00000000-0000-0000-0000-000000000000",
     "model_uuid": "6050449c-7b6b-501b-ad23-de97242c4287",
@@ -27,7 +28,8 @@
   },
   "parameters": {
     "inc_min": 0,
-    "inc_max": 180
+    "inc_max": 180,
+    "XCLTortuosity": 0.000572614583987641
   },
   "terms": [
     {

--- a/welleng/errors/tool_errors.py
+++ b/welleng/errors/tool_errors.py
@@ -2,6 +2,7 @@ import numpy as np
 from numpy import sin, cos, tan, pi, sqrt
 from numpy.char import index
 import json
+import re
 import yaml
 import os
 from collections import OrderedDict
@@ -231,10 +232,22 @@ class ToolError:
         if 'Default Tortusity (rad/m)' in self.em['header']:
             self.tortuosity = self.em['header']['Default Tortusity (rad/m)']
         elif 'XCL Tortuosity' in self.em['header']:
-            # assuming that this is always 1 deg / 100 ft but this might not
-            # be the case
-            # TODO use pint to handle this string inputs
-            self.tortuosity = (np.radians(1.) / 100) * 3.281
+            # Parse the unit string (e.g. "1 deg / 100 ft") to rad/m, rather than
+            # assuming a fixed 1 deg/100 ft.
+            _raw = str(self.em['header']['XCL Tortuosity'])
+            _m = re.match(
+                r"^\s*(-?\d+(?:\.\d+)?)\s*deg\s*/\s*(-?\d+(?:\.\d+)?)\s*(ft|m)\s*$",
+                _raw, re.I,
+            )
+            if _m:
+                _deg, _len, _unit = (
+                    float(_m.group(1)), float(_m.group(2)), _m.group(3).lower()
+                )
+                _metres = _len * 0.3048 if _unit == "ft" else _len
+                self.tortuosity = np.radians(_deg) / _metres
+            else:
+                # Fallback: the ISCWSA/OWSG default tortuosity, 1 deg/100 ft.
+                self.tortuosity = (np.radians(1.) / 100) * 3.281
         else:
             self.tortuosity = None
 

--- a/welleng/errors/tool_errors.py
+++ b/welleng/errors/tool_errors.py
@@ -386,8 +386,10 @@ class ToolError:
             "AzTPrev": _prev(azt), "AzMPrev": _prev(azm), "AzPrev": _prev(azg),
             "TVD": np.asarray(survey.tvd, dtype=float),
             "Gfield": float(survey.header.G),
+            "GField": float(survey.header.G),   # casing alias: some sheet formulas (ABIXY) use GField
             "Dip": float(survey.header.dip),
             "BField": float(survey.header.b_total or 50000.0),
+            "Bfield": float(survey.header.b_total or 50000.0),   # casing alias: MFI formulas use Bfield
             "EarthRate": earth_rate,
             "Latitude": np.radians(float(survey.header.latitude or 0.0)),
             "NoiseReductionFactor": nrf,

--- a/welleng/errors/tool_errors.py
+++ b/welleng/errors/tool_errors.py
@@ -1149,12 +1149,17 @@ class ToolError:
         """Map weight-function name -> implementation.
 
         Update when error functions are added/removed. A ``# Needs QAQC`` flag marks
-        a function not yet validated against ISCWSA reference data. After the
-        2026-06-29 audit these are the extended axial-interference / IFR-correction
-        terms (ASIXY/ABIXY/MBIXY/MSIXY/MDI/MFI/AMID/CNA/CNI/ABIZ/ASIZ) that the
-        standard ISCWSA test wells do NOT exercise, so there is no in-repo reference
-        to validate them against -- they need the extended-model workbooks (see
-        docs/dev/ERROR_MODEL_ENGINE.md S6). The base-model terms that DO have
+        a function not yet validated. After the 2026-06-29 audit these are all
+        **OWSG-specific** terms, outside the base ISCWSA standard model -- so the
+        ISCWSA standard test wells legitimately do NOT exercise them and there is no
+        in-repo ISCWSA reference to validate against; they would need OWSG
+        (extended-model) reference data:
+          - MDI, MFI, AMID, ABIZ, ASIZ, MSIXY: only in the OWSG ``+AX``/``+IFR``
+            axial-interference-correction models (MWD+IFR1+AX, MWD+SRGM+AX, ...).
+          - CNA, CNI: only in the BLIND/UNKNOWN/FINDS/TREND special models
+            (gyro "Linear Cone").
+          - ASIXY, ABIXY, MBIXY: in no current JSON model at all -- legacy-only.
+        See docs/dev/ERROR_MODEL_ENGINE.md S6. The base-ISCWSA terms that DO have
         reference data (XYM3E/XYM4E/DBHR) are validated per-source to 5e-5 by
         tests/test_iscwsa_mwd_error.py and are no longer flagged.
         """

--- a/welleng/errors/tool_errors.py
+++ b/welleng/errors/tool_errors.py
@@ -1101,9 +1101,12 @@ class ToolError:
             try:
                 val = evaluate_formula(f, bindings)
             except Exception:
-                # Singular weight references a variable the interpreter can't
-                # bind (e.g. XCLTortuosity) -- a documented schema gap; the
-                # component contributes zero, same as the main eval path.
+                # Defensive fallback: a singular weight whose formula fails to
+                # evaluate (a variable not in scope, a malformed expression)
+                # contributes zero rather than crashing -- the main eval path does
+                # the same. XCLTortuosity and the prev-station vars (MDPrev, ...) are
+                # now bound, so XCL's singular weight evaluates; this only guards a
+                # genuinely unbound/malformed term.
                 return np.zeros(n)
             return np.broadcast_to(
                 np.asarray(val, dtype=float), (n,)

--- a/welleng/errors/tool_errors.py
+++ b/welleng/errors/tool_errors.py
@@ -1146,9 +1146,17 @@ class ToolError:
         return e_NEV, e_NEV_star
 
     def _initiate_func_dict(self):
-        """
-        This dictionary will need to be updated if/when additional error
-        functions are added to the model.
+        """Map weight-function name -> implementation.
+
+        Update when error functions are added/removed. A ``# Needs QAQC`` flag marks
+        a function not yet validated against ISCWSA reference data. After the
+        2026-06-29 audit these are the extended axial-interference / IFR-correction
+        terms (ASIXY/ABIXY/MBIXY/MSIXY/MDI/MFI/AMID/CNA/CNI/ABIZ/ASIZ) that the
+        standard ISCWSA test wells do NOT exercise, so there is no in-repo reference
+        to validate them against -- they need the extended-model workbooks (see
+        docs/dev/ERROR_MODEL_ENGINE.md S6). The base-model terms that DO have
+        reference data (XYM3E/XYM4E/DBHR) are validated per-source to 5e-5 by
+        tests/test_iscwsa_mwd_error.py and are no longer flagged.
         """
         self.func_dict = {
             'ABXY_TI1': ABXY_TI1,
@@ -1177,13 +1185,13 @@ class ToolError:
             'XYM3': XYM3,
             'XYM4': XYM4,
             'SAGE': SAGE,
-            'XCL': XCL,  # requires an exception
+            'XCL': XCL,  # dispatcher dummy -> XCLA/XCLH (workbook lists XCL as one term)
             'XYM3L': XYM3L,
             'XYM4L': XYM4L,
             'XCLA': XCLA,
             'XCLH': XCLH,
-            'XYM3E': XYM3E,  # Needs QAQC
-            'XYM4E': XYM4E,  # Need QAQC
+            'XYM3E': XYM3E,  # validated: test_iscwsa_mwd_error (per-source, 5e-5)
+            'XYM4E': XYM4E,  # validated: test_iscwsa_mwd_error (per-source, 5e-5)
             'ASIXY_TI1': ASIXY_TI1,  # Needs QAQC
             'ASIXY_TI2': ASIXY_TI2,  # Needs QAQC
             'ASIXY_TI3': ASIXY_TI3,  # Needs QAQC
@@ -1205,7 +1213,7 @@ class ToolError:
             'MSIXY_TI1': MSIXY_TI1,  # Needs QAQC
             'MSIXY_TI2': MSIXY_TI2,  # Needs QAQC
             'MSIXY_TI3': MSIXY_TI3,  # Needs QAQC
-            'DBHR': DBHR,  # Needs QAQC
+            'DBHR': DBHR,  # validated: test_iscwsa_mwd_error (per-source, 5e-5)
             'AMID': AMID,  # Needs QAQC
             'CNA': CNA,  # Needs QAQC
             'CNI': CNI,  # Needs QAQC

--- a/welleng/errors/tool_errors.py
+++ b/welleng/errors/tool_errors.py
@@ -112,9 +112,11 @@ def _json_to_em_adapter(model: dict) -> dict:
         "Inclination Range Max": f"{inc_max_deg} deg",
         "Revision No": md.get("revision_number", ""),
         "Revision Date": md.get("revision_date", ""),
-        # Required for the legacy code path to be happy when JSON tool
-        # carries no tortuosity (we synthesise a default).
-        "Default Tortusity (rad/m)": 0.000572615,
+        # XCL tortuosity for the legacy/native path (self.tortuosity reads this
+        # key). Sourced from the JSON parameters block (parsed by owsg_to_json from
+        # the sheet's "XCL Tortuosity" cell); falls back to 1 deg/100 ft if a tool
+        # carries none.
+        "Default Tortusity (rad/m)": pp.get("XCLTortuosity", 0.000572615),
     }
     # Continuous / stationary gyro tool parameters. The ISCWSA Rev5 gyro
     # weight functions (GXY-GD/GRW running integral, GXY-RN noise, and the
@@ -389,6 +391,15 @@ class ToolError:
         }
         if hdr.get("GXYRunningSpeed") is not None:
             bindings["GXYRunningSpeed"] = float(hdr["GXYRunningSpeed"])
+        # XCL (extended course length, Codling SPE-187249-MS): the XCLA/XCLH weight
+        # formulas reference `XCLTortuosity` (rad/m). Its per-model value comes from
+        # the JSON parameters block (owsg_to_json parses the sheet's "XCL Tortuosity"
+        # cell) via the header key above; bind it so the interpreter path evaluates
+        # XCL identically to the native path. Without the binding the formula throws
+        # and XCL silently contributes zero.
+        _xcl_tort = hdr.get("Default Tortusity (rad/m)")
+        if _xcl_tort is not None:
+            bindings["XCLTortuosity"] = float(_xcl_tort)
 
         # Recurrence terms (continuous gyro): the azimuth formula references
         # its own accumulated state from the previous station

--- a/welleng/errors/tools/owsg_to_json.py
+++ b/welleng/errors/tools/owsg_to_json.py
@@ -30,6 +30,7 @@ from __future__ import annotations
 
 import argparse
 import json
+import math
 import os
 import re
 import uuid
@@ -153,6 +154,77 @@ def _parse_inc_range(raw: Any) -> int | None:
     return int(round(float(m.group(1))))
 
 
+def _parse_tortuosity(raw: Any) -> float | None:
+    """Parse an OWSG "XCL Tortuosity" cell to rad/m; None if absent.
+
+    The sheet stores it as a unit string, e.g. "1 deg / 100 ft". The XCLA/XCLH
+    weight formulas reference the variable ``XCLTortuosity`` (rad/m), so surface it
+    into the JSON ``parameters`` under that name (else XCL silently evaluates to 0).
+    """
+    if _is_nanish(raw):
+        return None
+    s = str(raw).strip().lower().replace(" ", "")
+    m = re.match(r"^(-?\d+(?:\.\d+)?)deg/(-?\d+(?:\.\d+)?)(ft|m)$", s)
+    if not m:
+        return None
+    deg, length, unit = float(m.group(1)), float(m.group(2)), m.group(3)
+    metres = length * 0.3048 if unit == "ft" else length
+    return (deg * math.pi / 180.0) / metres
+
+
+def _parse_deg(raw: Any) -> float | None:
+    """Parse a "<n> deg" cell to radians; None if absent/unparseable."""
+    if _is_nanish(raw):
+        return None
+    if isinstance(raw, (int, float)):
+        return float(raw) * math.pi / 180.0
+    m = re.match(r"^(-?\d+(?:\.\d+)?)\s*deg$", str(raw).strip(), re.I)
+    return float(m.group(1)) * math.pi / 180.0 if m else None
+
+
+def _parse_number(raw: Any) -> float | None:
+    """Parse the leading number from a cell ("2743.2 m/hr", "0.4082", 0.5) -> float."""
+    if _is_nanish(raw):
+        return None
+    if isinstance(raw, (int, float)):
+        return float(raw)
+    m = re.match(r"^(-?\d+(?:\.\d+)?)", str(raw).strip())
+    return float(m.group(1)) if m else None
+
+
+def _extract_gyro_params(df: pd.DataFrame) -> dict[str, float]:
+    """Section-aware capture of the per-tool gyro Tool-Parameters the interpreter
+    binds, FROM THE SHEET: gxy_running_speed (m/hr), xy_static_gyro_end_inc (rad,
+    the static->continuous gate), noise_reduction_factor. "End Inc" appears under
+    both the static and continuous sections, so track which section we're in.
+    Returns only the params present (empty for non-gyro tools)."""
+    out: dict[str, float] = {}
+    section: str | None = None
+    for i in range(len(df)):
+        label = df.iloc[i, COL_LABEL]
+        if _is_nanish(label):
+            continue
+        key = str(label).strip().rstrip(":").strip()
+        val = df.iloc[i, COL_LABEL_VAL]
+        if key == "XY Static Gyro":
+            section = "static"
+        elif key == "XY Continuous Gyro":
+            section = "continuous"
+        if section == "static" and key == "End Inc":
+            v = _parse_deg(val)
+            if v is not None:
+                out["xy_static_gyro_end_inc"] = v
+        elif section == "continuous" and key == "Running Speed":
+            v = _parse_number(val)
+            if v is not None:
+                out["gxy_running_speed"] = v
+        elif key == "Noise Reduction Factor":
+            v = _parse_number(val)
+            if v is not None:
+                out["noise_reduction_factor"] = v
+    return out
+
+
 def _to_iso_date(x: Any) -> str:
     if isinstance(x, (date, datetime)):
         return x.strftime("%Y-%m-%d")
@@ -264,6 +336,17 @@ def convert_sheet(
     }
 
     parameters = {"inc_min": int(inc_min), "inc_max": int(inc_max)}
+    # XCL "extended course length" tortuosity (Codling SPE-187249-MS): the XCLA/XCLH
+    # weight formulas reference the variable XCLTortuosity (rad/m). The sheet carries
+    # its per-model value in the "XCL Tortuosity" cell (a unit string). Surface it so
+    # the interpreter can bind it; without it XCL silently evaluates to zero.
+    _xcl = _parse_tortuosity(kv.get("XCL Tortuosity"))
+    if _xcl is not None:
+        parameters["XCLTortuosity"] = _xcl
+    # Per-tool gyro calibration (running speed, static-gyro gate, noise reduction)
+    # that the continuous-gyro recurrence terms bind -- captured from the sheet's
+    # "Tool Parameters" section so they are never hand-overridden post-generation.
+    parameters.update(_extract_gyro_params(df))
 
     terms: list[dict] = []
     for i in _term_rows(df):
@@ -323,6 +406,13 @@ def convert_sheet(
 
     out = {
         "$schema": "../../iscwsa_schema/draft.json",
+        "_comment": (
+            "GENERATED from the ISCWSA-issued OWSG spreadsheet by "
+            "welleng/errors/tools/owsg_to_json.py -- DO NOT EDIT BY HAND. Regenerate "
+            "from the source xlsx. If a test needs different parameter values for "
+            "validation, it must override them locally, never modify this shipped "
+            "model. (test_iscwsa_json_generated.py enforces this.)"
+        ),
         "metadata": metadata,
         "parameters": parameters,
         "terms": terms,

--- a/welleng/survey.py
+++ b/welleng/survey.py
@@ -681,9 +681,15 @@ class Survey:
             well bore coordinate system (high side, lateral, along
             hole).
         error_model: str (default: None)
-            If specified, this model is used to calculate the
-            covariance matrices if they are not present. Currently,
-            only the "ISCWSA_MWD" model is provided.
+            Name of the survey-tool error model used to compute the position
+            covariance. Leave as None for no uncertainty calculation. The
+            recommended/standard model is ``"ISCWSA MWD Rev5.11"`` (the validated
+            ISCWSA standard); ``"ISCWSA MWD Rev4"`` is the legacy model. The OWSG
+            toolcode library (``"MWD+SRGM"``, ``+SAG``, ``+AX``, ``+IFR``, gyro
+            stacks ``"GYRO-NS"`` / ``"GYRO-NS-CT"`` / ``"GYRO-MWD"``, ...) is also
+            selectable. List every available name with
+            ``welleng.error.get_error_models()``; switch by passing a different
+            name. Raises if the name is unrecognised.
         start_xyz: (,3) list or array of floats (default: [0,0,0])
             The start position of the well bore in (x,y,z) coordinates.
         start_nev: (,3) list or array of floats (default: [0,0,0])

--- a/welleng/survey.py
+++ b/welleng/survey.py
@@ -436,7 +436,7 @@ class SurveyHeader:
                     altitude=self.altitude,
                     date=self.survey_date
                 )
-            except:
+            except Exception:
                 try:
                     result = calculator.calculate(
                         latitude=self.latitude,
@@ -444,9 +444,12 @@ class SurveyHeader:
                         altitude=self.altitude,
                         date=self._get_date(date=None)
                     )
-                except:  # prevents crashing if there's no connection to the internet - need to have a log that captures when this occurs.
-                    # TODO: log when no internet connection prvents updating the result var
-                    pass
+                except Exception as exc:
+                    warnings.warn(
+                        f"Magnetic-field lookup failed ({exc}); using the header's "
+                        "default magnetic parameters (no connection to the BGS "
+                        "service?)."
+                    )
 
         if self.b_total is None:
             self.b_total = result['field-value']['total-intensity']['value']

--- a/welleng/survey.py
+++ b/welleng/survey.py
@@ -758,8 +758,7 @@ class Survey:
         self._min_curve(vec)
         self._get_toolface_and_rates()
 
-        # initialize errors
-        # TODO: read this from a yaml file in errors
+        # initialize errors (ERROR_MODELS is derived from errors/tool_index.yaml)
         error_models = ERROR_MODELS
         if error_model is not None:
             assert error_model in error_models, "Unrecognized error model"

--- a/welleng/survey.py
+++ b/welleng/survey.py
@@ -8,6 +8,7 @@ coordinate transformations.
 """
 import numpy as np
 import math
+import warnings
 import pandas as pd
 from copy import copy
 try:
@@ -183,9 +184,19 @@ class SurveyParameters(Proj):
                     altitude=0 if altitude is None else altitude,
                     date=date
                 )
-            except Exception:
+            except Exception as exc:
+                warnings.warn(
+                    f"Magnetic-field lookup failed ({exc}); declination, dip and "
+                    "field intensity set to None (no connection to the BGS service?)."
+                )
                 result_magnetic = None
         else:
+            warnings.warn(
+                "Magnetic-field parameters (declination, dip, field intensity) need "
+                "the optional 'magnetic_field_calculator' package -- install with "
+                "`pip install welleng[all]` (or `pip install magnetic_field_calculator`). "
+                "Returning None for those fields."
+            )
             result_magnetic = None
 
         data = dict(


### PR DESCRIPTION
## ISCWSA error-model integrity fixes

A sweep of the OWSG JSON error models surfaced a class of **silent-zero** bugs — terms whose formula referenced a variable the interpreter never bound, so they were caught and contributed **zero covariance**, silently:

- **XCL** (`XCLTortuosity`) — the whole survey-interval term, across the MWD models. Root cause: `owsg_to_json` dropped the sheet's "Tool Parameters" section. Now parsed from the ISCWSA-issued OWSG spreadsheet (incl. the per-tool gyro calibration), which also **reverted a gyro hijack** — `GYRO-NS-CT.json` had been hand-overwritten with SPE-90408 paper values instead of its ISCWSA sheet values.
- **GField / Bfield** — casing mismatches that zeroed the ABIXY / MFI axial-interference terms in ~32 models each. Fixed in all three binding sites (tool_errors / conformance / copsegrove_validate).

**New CI guard** — `tests/test_iscwsa_json_bindings.py` sweeps every formula axis of all 100 shipped models and fails on any unbound variable, so this class can't regress.

Plus:
- **Generated-JSON safeguards** — `_comment` marker, `.gitattributes` (linguist-generated), CODEOWNERS, and `test_iscwsa_json_generated` (regen == committed) stop any future hand-edit / hijack of the generated models.
- **Geomag → graceful optional dep** — `get_factors_from_x_y` warns (install/offline) instead of returning `None` silently; `test_known_location` now runs deterministically (stubbed) instead of skipping.
- **func_dict QAQC audit** — dropped 3 stale flags (validated vs the MWD test), kept + documented the OWSG-specific ones.
- **Docs** — a clear "Selecting an error model" section, Rev5.11 the default; fixed a stale `"ISCWSA MWD Rev5"` alias claim (it actually raises).

All 333 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LmC8qDNLexfqYjEP5tibPn
