### PR TITLE
docs(readme): author affiliation + ORCID in Citation section

### DIFF
--- a/README.md
+++ b/README.md
@@ -299,6 +299,8 @@ The ISCWSA standard set of well paths for evaluating clearance scenarios have be
 
 ## Citation
 
+**Author:** Jonathan Corcutt — Corcutt Beheer B.V., Wassenaar, Netherlands · ORCID [0009-0008-1953-7760](https://orcid.org/0009-0008-1953-7760).
+
 If welleng supports your work, please cite the **software** (the concept DOI always resolves to the latest version):
 
 > Corcutt, J. *welleng: open-source well-engineering tools.* Zenodo. <https://doi.org/10.5281/zenodo.20968887>


### PR DESCRIPTION
Adds the author attribution line (Jonathan Corcutt — Corcutt Beheer B.V. · ORCID 0009-0008-1953-7760) to the README Citation section. CITATION.cff already carries author + ORCID + affiliation + both paper DOIs (gyro + anti-collision). Citation/attribution only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LmC8qDNLexfqYjEP5tibPn