### PR TITLE
test(mti): fix flaky maximum-curvature MTI regression anchors

### DIFF
--- a/tests/test_tortuosity_index.py
+++ b/tests/test_tortuosity_index.py
@@ -185,8 +185,17 @@ def test_regression_anchors():
     invariants above are the scientific check)."""
     s1 = iscwsa_1().interpolate_survey(step=30)
     s2 = iscwsa_2()
+    # Deterministic anchors: no maximum-curvature pre-processing -> tight.
     assert np.isclose(we.survey.tortuosity_index(s1)[-1], 18.641285781891, rtol=1e-9)
     assert np.isclose(s1.modified_tortuosity_index(dls_noise=None)[-1], 0.605503933178, rtol=1e-9)
     assert np.isclose(s2.modified_tortuosity_index(dls_noise=None)[-1], 0.524669579439, rtol=1e-9)
-    assert np.isclose(s2.modified_tortuosity_index(step=None, dls_noise=1.0)[-1], 0.730800095807, rtol=1e-9)
-    assert np.isclose(s2.modified_tortuosity_index(step=30, dls_noise=1.0)[-1], 0.819918417431, rtol=1e-9)
+    # dls_noise=1.0 routes through maximum_curvature -> interpolate + 3D
+    # sectionization, whose section boundaries sit on a floating-point threshold.
+    # A borderline station can flip a boundary under sub-epsilon, run-to-run
+    # float variation (e.g. threaded-BLAS reductions), giving a discrete ~0.3%
+    # jump in the final MTI. A 1e-9 anchor is therefore flaky across runs/Python
+    # versions (observed on CI 3.11); anchor these to 1% so they still catch gross
+    # regressions without pinning the knife-edge. Qualitative invariants above are
+    # the scientific check.
+    assert np.isclose(s2.modified_tortuosity_index(step=None, dls_noise=1.0)[-1], 0.7308, rtol=1e-2)
+    assert np.isclose(s2.modified_tortuosity_index(step=30, dls_noise=1.0)[-1], 0.8199, rtol=1e-2)


### PR DESCRIPTION
The `test_regression_anchors` `dls_noise=1.0` anchors were pinned at `rtol=1e-9`. That path goes through `maximum_curvature` + 3D sectionization, whose section boundaries sit on a float threshold — a borderline station flips a boundary under sub-epsilon run-to-run float variation (threaded-BLAS reductions), a discrete ~0.3% jump. Hence the intermittent CI build-3.11 failures (passed on re-run).

Loosen those two anchors to 1% (still catches gross regressions); deterministic `dls_noise=None` anchors stay at 1e-9; monotonicity invariants unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)