### PR TITLE
feat(edm): streaming EDM reader with covariance + per-interval tool resolution

### DIFF
--- a/tests/test_edm.py
+++ b/tests/test_edm.py
@@ -1,0 +1,308 @@
+"""Tests for the streaming EDM parser (welleng.exchange.edm_stream) plus the
+back-compat / mutable-default fixes in welleng.exchange.edm.
+"""
+import warnings
+
+import numpy as np
+import pytest
+
+from welleng.exchange.edm_stream import (
+    EDMReader,
+    classify_tool,
+    ToolKind,
+    SurveyTool,
+    Wellbore,
+    SurveyStation,
+    FEET_TO_METERS,
+)
+
+# A small synthetic EDM export exercising the key tables. Mirrors the real
+# Volve layout: the CD_* rows are *direct* children of <export>, with a nested
+# <TOPLEVEL> holding some non-survey (TU_*) rows -- so both the streaming
+# reader (depth-agnostic, matches by tag) and the legacy DOM EDM (iterates the
+# root's direct children) see the same CD_* data.
+#   project / well / two wellbores (parent + sidetrack) /
+#   raw survey header (+ tie) with raw stations /
+#   definitive survey headers (ACTUAL + PLAN) with covariance stations /
+#   survey program (two tool intervals: gyro then mwd) / two tools.
+SYNTHETIC_EDM = """<?xml version="1.0" standalone="no"?>
+<export>
+<TOPLEVEL>
+<TU_TEMP_DERATION_SCHED schedule_name="ignored" temp_deration_sched_id="X1" />
+</TOPLEVEL>
+<CD_PROJECT project_id="P1" project_name="TEST" />
+<CD_SITE site_id="S1" project_id="P1" site_name="TestSite" />
+<CD_WELL well_id="W1" site_id="S1" well_common_name="T-1" />
+<CD_WELLBORE well_id="W1" wellbore_id="WB0" wellbore_name="T-1 main" />
+<CD_WELLBORE well_id="W1" wellbore_id="WB1" wellbore_name="T-1 ST1" parent_wellbore_id="WB0" />
+<CD_SURVEY_TOOL survey_tool_id="TG" tool_name="Keeper, cont" description="Gyro Tool from SDC" tool_type="0" />
+<CD_SURVEY_TOOL survey_tool_id="TM" tool_name="Magnetic, std, non-mag" description="Magnetic Tools (MWD, EMS)" tool_type="0" />
+<CD_SURVEY_HEADER well_id="W1" wellbore_id="WB0" survey_header_id="SH0" phase="ACTUAL" survey_name="root raw" md_min="0" md_max="100" />
+<CD_SURVEY_HEADER well_id="W1" wellbore_id="WB1" survey_header_id="SH1" phase="ACTUAL" survey_name="st raw" tie_survey_header_id="SH0" survey_tool_id="TM" md_min="100" md_max="200" />
+<CD_SURVEY_STATION well_id="W1" wellbore_id="WB0" survey_header_id="SH0" md="0" inclination="0" azimuth="0" tvd="0" offset_north="0" offset_east="0" dogleg_severity="0" sequence_no="0" />
+<CD_SURVEY_STATION well_id="W1" wellbore_id="WB0" survey_header_id="SH0" md="100" inclination="5" azimuth="10" tvd="99" offset_north="4" offset_east="1" dogleg_severity="1.5" sequence_no="1" />
+<CD_SURVEY_STATION well_id="W1" wellbore_id="WB1" survey_header_id="SH1" md="150" inclination="20" azimuth="30" tvd="145" offset_north="20" offset_east="12" dogleg_severity="2.0" sequence_no="0" />
+<CD_DEFINITIVE_SURVEY_HEADER well_id="W1" wellbore_id="WB1" def_survey_header_id="DH1" phase="ACTUAL" name="Wellpath" tie_survey_header_id="SH0" />
+<CD_DEFINITIVE_SURVEY_HEADER well_id="W1" wellbore_id="WB1" def_survey_header_id="DH2" phase="PLAN" name="Plan" />
+<CD_DEFINITIVE_SURVEY_STATION well_id="W1" wellbore_id="WB1" def_survey_header_id="DH1" md="50" inclination="2" azimuth="5" tvd="49.9" offset_north="2" offset_east="1" dogleg_severity="0.5" sequence_no="0" covariance_xx="4" covariance_xy="1" covariance_xz="2" covariance_yy="9" covariance_yz="3" covariance_zz="16" ellipse_north="1" ellipse_east="2" ellipse_vertical="3" />
+<CD_DEFINITIVE_SURVEY_STATION well_id="W1" wellbore_id="WB1" def_survey_header_id="DH1" md="150" inclination="20" azimuth="30" tvd="145" offset_north="20" offset_east="12" dogleg_severity="2.0" sequence_no="1" covariance_xx="8" covariance_xy="0" covariance_xz="0" covariance_yy="18" covariance_yz="0" covariance_zz="32" ellipse_north="1" ellipse_east="2" ellipse_vertical="3" />
+<CD_DEFINITIVE_SURVEY_STATION well_id="W1" wellbore_id="WB1" def_survey_header_id="DH1" md="190" inclination="35" azimuth="40" tvd="180" offset_north="30" offset_east="22" dogleg_severity="1.0" sequence_no="2" covariance_xx="12" covariance_xy="0" covariance_xz="0" covariance_yy="24" covariance_yz="0" covariance_zz="40" ellipse_north="1" ellipse_east="2" ellipse_vertical="3" />
+<CD_DEFINITIVE_SURVEY_STATION well_id="W1" wellbore_id="WB1" def_survey_header_id="DH2" md="0" inclination="0" azimuth="0" tvd="0" offset_north="0" offset_east="0" dogleg_severity="0" sequence_no="0" covariance_xx="1" covariance_xy="0" covariance_xz="0" covariance_yy="1" covariance_yz="0" covariance_zz="1" />
+<CD_SURVEY_PROGRAM well_id="W1" wellbore_id="WB1" def_survey_header_id="DH1" survey_program_id="PR0" survey_header_id="SH0" survey_tool_id="TG" md_top="0" md_base="100" sequence_no="0" not_in_use="0" />
+<CD_SURVEY_PROGRAM well_id="W1" wellbore_id="WB1" def_survey_header_id="DH1" survey_program_id="PR1" survey_header_id="SH1" survey_tool_id="TM" md_top="100" md_base="200" sequence_no="1" not_in_use="0" />
+<!-- a non-survey table that must be skipped by the streaming index -->
+<CD_PORE_PRESSURE well_id="W1" pore_pressure_id="PP1" tvd="1000" pore_pressure="1.2" />
+</export>
+"""
+
+
+@pytest.fixture
+def edm_file(tmp_path):
+    p = tmp_path / "synthetic.xml"
+    p.write_text(SYNTHETIC_EDM)
+    return str(p)
+
+
+@pytest.fixture
+def reader(edm_file):
+    return EDMReader.open(edm_file)
+
+
+# --------------------------------------------------------------------------
+# classify_tool
+# --------------------------------------------------------------------------
+@pytest.mark.parametrize("name,desc,expected", [
+    ("Gyro, cont", "Other Gyro Tools", ToolKind.GYRO),
+    ("Keeper, cont", "Gyro Tool from SDC", ToolKind.GYRO),
+    ("Wellbore Surveyor, stat", "Gyro Tool from GD", ToolKind.GYRO),
+    ("RIGS, cont", "Inertial Tool from BHI", ToolKind.GYRO),
+    # gyro-while-drilling: gyro sensor wins over the MWD conveyance
+    ("MWD gyro, Gyrodata, GWD70", "Gyrodata's MWD gyro service GWD70",
+     ToolKind.GYRO),
+    ("Magnetic, std, non-mag", "Magnetic Tools (MWD, EMS)", ToolKind.MWD),
+    ("Magn, IFR, mag-corr, dual incl", "Magnetic Tools (MWD, EMS)",
+     ToolKind.MWD),
+    ("Inclination Only", "Inclination only surveys, vertical wells",
+     ToolKind.INCLINATION_ONLY),
+    ("Definitive combined", "", ToolKind.DEFINITIVE),
+    ("Blind Drilling", "No survey recorded - blind drilling", ToolKind.OTHER),
+    ("Dummy Tool", "", ToolKind.OTHER),
+    (None, None, ToolKind.OTHER),
+    ("", "", ToolKind.OTHER),
+])
+def test_classify_tool(name, desc, expected):
+    assert classify_tool(name, desc) is expected
+
+
+def test_classify_tool_is_pure():
+    # no exceptions on odd input; deterministic
+    assert classify_tool("gyro") is ToolKind.GYRO
+    assert classify_tool("GYRO") is ToolKind.GYRO  # case-insensitive
+
+
+# --------------------------------------------------------------------------
+# index sweep
+# --------------------------------------------------------------------------
+def test_index_counts(reader):
+    assert len(reader.projects) == 1
+    assert len(reader.sites) == 1
+    assert len(reader.wells) == 1
+    assert len(reader.wellbores) == 2
+    assert len(reader.tools) == 2
+    # 2 raw headers + 2 definitive headers
+    assert len(reader.headers) == 4
+    assert set(reader.wellbore_name_to_id) == {"T-1 main", "T-1 ST1"}
+
+
+def test_index_skips_non_survey_tables(reader):
+    # CD_PORE_PRESSURE must not be materialised anywhere in the index
+    for attr in ("projects", "sites", "wells"):
+        for row in getattr(reader, attr).values():
+            assert "pore_pressure" not in row
+
+
+def test_tool_classification_on_index(reader):
+    assert reader.tools["TG"].kind is ToolKind.GYRO
+    assert reader.tools["TM"].kind is ToolKind.MWD
+
+
+def test_station_counts_on_headers(reader):
+    hdr = reader.headers["DH1"]
+    assert hdr.kind == "definitive"
+    assert hdr.n_stations == 3
+    assert reader.headers["SH1"].kind == "raw"
+    assert reader.headers["SH1"].n_stations == 1
+
+
+# --------------------------------------------------------------------------
+# survey assembly + covariance
+# --------------------------------------------------------------------------
+def test_definitive_survey_covariance_3x3(reader):
+    s = reader.survey("T-1 ST1", kind="definitive", phase="ACTUAL")
+    assert len(s) == 3
+    assert s.has_covariance
+    st = s.stations[0]  # md=50
+    assert st.covariance.shape == (3, 3)
+    # native order [[xx,xy,xz],[xy,yy,yz],[xz,yz,zz]]
+    expected = np.array([[4, 1, 2], [1, 9, 3], [2, 3, 16]], dtype=float)
+    np.testing.assert_array_equal(st.covariance, expected)
+    assert np.allclose(st.covariance, st.covariance.T)
+
+
+def test_definitive_survey_sorted_by_md(reader):
+    s = reader.survey("T-1 ST1", kind="definitive", phase="ACTUAL")
+    mds = [st.md for st in s.stations]
+    assert mds == sorted(mds)
+    assert mds == [50.0, 150.0, 190.0]
+
+
+def test_raw_survey_has_no_covariance(reader):
+    s = reader.survey("T-1 ST1", kind="raw", phase="ACTUAL")
+    assert not s.has_covariance
+    assert all(st.covariance is None for st in s.stations)
+
+
+# --------------------------------------------------------------------------
+# tool resolution per interval (SURVEY_PROGRAM)
+# --------------------------------------------------------------------------
+def test_tool_resolution_per_interval(reader):
+    s = reader.survey("T-1 ST1", kind="definitive", phase="ACTUAL")
+    # md=50 falls in [0,100] -> gyro; md=150,190 fall in [100,200] -> mwd
+    by_md = {st.md: st for st in s.stations}
+    assert by_md[50].tool.kind is ToolKind.GYRO
+    assert by_md[50].tool.name == "Keeper, cont"
+    assert by_md[150].tool.kind is ToolKind.MWD
+    assert by_md[190].tool.kind is ToolKind.MWD
+
+
+def test_raw_survey_single_tool_from_header(reader):
+    # SH1 header carries survey_tool_id="TM" -> all raw stations get it
+    s = reader.survey("T-1 ST1", kind="raw", phase="ACTUAL")
+    assert all(st.tool is not None and st.tool.kind is ToolKind.MWD
+               for st in s.stations)
+
+
+# --------------------------------------------------------------------------
+# phase filtering + header selection
+# --------------------------------------------------------------------------
+def test_phase_filtering(reader):
+    actual = reader.survey_headers("T-1 ST1", kind="definitive",
+                                   phase="ACTUAL")
+    plan = reader.survey_headers("T-1 ST1", kind="definitive", phase="PLAN")
+    assert [h.header_id for h in actual] == ["DH1"]
+    assert [h.header_id for h in plan] == ["DH2"]
+
+
+def test_default_header_is_most_stations(reader):
+    # no phase filter: DH1 (3 stations) should sort ahead of DH2 (1 station)
+    hdrs = reader.survey_headers("T-1 ST1", kind="definitive")
+    assert hdrs[0].header_id == "DH1"
+    assert hdrs[0].n_stations >= hdrs[-1].n_stations
+
+
+def test_missing_survey_raises(reader):
+    with pytest.raises(LookupError):
+        reader.survey("T-1 main", kind="definitive", phase="ACTUAL")
+
+
+# --------------------------------------------------------------------------
+# feet -> meters conversion
+# --------------------------------------------------------------------------
+def test_to_welleng_feet_to_meters(reader):
+    s = reader.survey("T-1 ST1", kind="definitive", phase="ACTUAL")
+    sv = s.to_welleng(units="meters")
+    # depths scaled by 0.3048
+    assert np.isclose(sv.md[-1], 190.0 * FEET_TO_METERS)
+    assert np.isclose(sv.md[0], 50.0 * FEET_TO_METERS)
+    assert len(sv.md) == 3
+
+
+def test_to_welleng_covariance_reordered_and_scaled(reader):
+    s = reader.survey("T-1 ST1", kind="definitive", phase="ACTUAL")
+    sv = s.to_welleng(units="meters")
+    assert sv.cov_nev is not None
+    assert sv.cov_nev.shape == (3, 3, 3)
+    # native (x=E,y=N,z=V) -> NEV: nn=yy, ne=xy, nv=yz, ee=xx, ev=xz, vv=zz
+    scale = FEET_TO_METERS ** 2
+    expected_nev = np.array(
+        [[9, 1, 3], [1, 4, 2], [3, 2, 16]], dtype=float
+    ) * scale
+    np.testing.assert_allclose(sv.cov_nev[0], expected_nev)
+
+
+def test_as_arrays_native_units(reader):
+    s = reader.survey("T-1 ST1", kind="definitive", phase="ACTUAL")
+    arr = s.as_arrays()
+    # native feet, unconverted
+    np.testing.assert_array_equal(arr["md"], [50.0, 150.0, 190.0])
+    assert arr["covariance"].shape == (3, 3, 3)
+    assert arr["tool_kind"][0] is ToolKind.GYRO
+
+
+# --------------------------------------------------------------------------
+# sidetrack + tie chains, and no mutable-default leakage across calls
+# --------------------------------------------------------------------------
+def test_sidetrack_chain(reader):
+    chain = reader.sidetrack_chain("T-1 ST1")
+    assert [wb.wellbore_id for wb in chain] == ["WB0", "WB1"]
+
+
+def test_tie_chain(reader):
+    chain = reader.tie_chain("SH1")
+    assert [h.header_id for h in chain] == ["SH0", "SH1"]
+
+
+def test_chains_no_mutable_default_leak(reader):
+    # repeated calls must return identical results (no accumulation)
+    first = [wb.wellbore_id for wb in reader.sidetrack_chain("T-1 ST1")]
+    second = [wb.wellbore_id for wb in reader.sidetrack_chain("T-1 ST1")]
+    third = [wb.wellbore_id for wb in reader.sidetrack_chain("T-1 ST1")]
+    assert first == second == third == ["WB0", "WB1"]
+
+    t1 = [h.header_id for h in reader.tie_chain("SH1")]
+    t2 = [h.header_id for h in reader.tie_chain("SH1")]
+    assert t1 == t2 == ["SH0", "SH1"]
+
+
+def test_sidetrack_chain_cycle_guard(reader):
+    # induce a self-cycle; must terminate, not recurse forever
+    reader.wellbores["WB0"].parent_wellbore_id = "WB0"
+    chain = reader.sidetrack_chain("WB0")
+    assert [wb.wellbore_id for wb in chain] == ["WB0"]
+
+
+# --------------------------------------------------------------------------
+# back-compat: old DOM EDM still works + mutable-default fixes
+# --------------------------------------------------------------------------
+def test_old_edm_still_imports_and_parses(edm_file):
+    from welleng.exchange.edm import EDM
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", DeprecationWarning)
+        edm = EDM(edm_file)
+    assert "T-1 main" in edm.wellbore_name_to_id
+    assert edm.wellbore_id_to_name["WB1"] == "T-1 ST1"
+
+
+def test_old_edm_emits_deprecation_warning(edm_file):
+    from welleng.exchange.edm import EDM
+    with pytest.warns(DeprecationWarning):
+        EDM(edm_file)
+
+
+def test_old_edm_get_parents_no_mutable_default_leak(edm_file):
+    from welleng.exchange.edm import EDM
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", DeprecationWarning)
+        edm = EDM(edm_file)
+    first = edm.get_parents("WB1")
+    second = edm.get_parents("WB1")
+    # the pre-fix bug would return ["WB0", "WB0"] on the second call
+    assert first == ["WB0"]
+    assert second == ["WB0"]
+
+
+def test_edm_open_returns_streaming_reader(edm_file):
+    from welleng.exchange.edm import EDM
+    r = EDM.open(edm_file)
+    assert isinstance(r, EDMReader)
+    assert len(r.wellbores) == 2

--- a/welleng/__init__.py
+++ b/welleng/__init__.py
@@ -12,6 +12,19 @@ import welleng.exchange.csv
 import welleng.target
 import welleng.connector
 import welleng.exchange.edm
+import welleng.exchange.edm_stream
+from welleng.exchange.edm_stream import (
+    EDMReader,
+    open_edm,
+    classify_tool,
+    ToolKind,
+    SurveyTool,
+    Wellbore,
+    SurveyHeader as EDMSurveyHeader,
+    ProgramInterval,
+    SurveyStation,
+    WellboreSurvey,
+)
 import welleng.fluid
 import welleng.node
 import welleng.architecture

--- a/welleng/exchange/edm.py
+++ b/welleng/exchange/edm.py
@@ -1,3 +1,4 @@
+import warnings
 import xml.etree.ElementTree as ET
 from collections import OrderedDict
 import numpy as np
@@ -14,15 +15,54 @@ class EDM:
         """
         Initiate an instance of an EDM object.
 
+        .. deprecated::
+            ``EDM`` loads the entire EDM XML into a DOM, which is impractical
+            for large exports (the Volve file is ~211 MB). Prefer the streaming
+            :class:`welleng.exchange.edm_stream.EDMReader` (also reachable via
+            :meth:`EDM.open`), which indexes the file with bounded memory and
+            returns typed surveys with per-station covariance and resolved
+            survey tools. ``EDM`` is retained for the torque & drag / case
+            workflows the streaming reader does not (yet) cover.
+
         Parameters
         ----------
             filename: str
                 The path and filename of the EDM file to be imported.
         """
+        warnings.warn(
+            "welleng.exchange.edm.EDM loads the whole file into a DOM and is "
+            "deprecated for large exports; use the streaming "
+            "welleng.exchange.edm_stream.EDMReader (or EDM.open) instead.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
         self.tree = ET.parse(filename)
         self.root = self.tree.getroot()
         self._wellbore_id_to_name()
         self._wellbore_id_to_well_id()
+
+    @classmethod
+    def open(cls, filename, source_units="feet"):
+        """Open an EDM file with the streaming reader.
+
+        Returns a :class:`welleng.exchange.edm_stream.EDMReader` -- the
+        memory-bounded replacement for the DOM-based :class:`EDM`. This does
+        *not* build an :class:`EDM` instance and does not emit the deprecation
+        warning.
+
+        Parameters
+        ----------
+        filename : str
+            Path to the EDM XML file.
+        source_units : str, {"feet", "meters"}
+            Units of the stored depth/offset values (default ``"feet"``).
+
+        Returns
+        -------
+        welleng.exchange.edm_stream.EDMReader
+        """
+        from .edm_stream import EDMReader
+        return EDMReader.open(filename, source_units=source_units)
 
     def get_attributes(self, tags=None, attributes={}, logic='AND'):
         """
@@ -174,7 +214,9 @@ class EDM:
 
         return attributes
 
-    def get_parents(self, wellbore_id, predecessors=[]):
+    def get_parents(self, wellbore_id, predecessors=None):
+        if predecessors is None:
+            predecessors = []
         for child in self.root:
             if (
                 child.tag == "CD_WELLBORE"
@@ -399,7 +441,9 @@ class Well:
                 survey[item[0]] = sorted(survey[item[0]], key=lambda k: float(k['md']))
         case.survey = survey
 
-    def get_parent_surveys(self, survey_header_id, data=OrderedDict()):
+    def get_parent_surveys(self, survey_header_id, data=None):
+        if data is None:
+            data = OrderedDict()
         for sh in self.well_data['CD_SURVEY_HEADER']:
             if (
                 sh['survey_header_id'] == survey_header_id

--- a/welleng/exchange/edm_stream.py
+++ b/welleng/exchange/edm_stream.py
@@ -1,0 +1,737 @@
+"""Streaming Landmark EDM (COMPASS export) parser.
+
+This module provides a memory-bounded, streaming alternative to the DOM-based
+:class:`welleng.exchange.edm.EDM` class. A Landmark ``EDM``/COMPASS export is a
+single, flat XML file (``<export><TOPLEVEL>...`` where every ``CD_*``/``TU_*``
+element is a table row and *all* data lives in element attributes). These files
+are routinely hundreds of megabytes (the public Volve export is ~211 MB), which
+makes ``xml.etree.ElementTree.parse`` (full DOM) impractical.
+
+:class:`EDMReader` performs a single ``iterparse`` sweep to build a lightweight,
+typed index of the (small) metadata tables and the (larger) survey-station
+tables, deliberately skipping the huge non-survey tables (pore/frac pressure,
+real-time configuration, torque & drag, etc.). Surveys are then assembled
+lazily and returned as typed :class:`WellboreSurvey` objects that carry per
+station covariance and the resolved survey tool for each measured-depth
+interval.
+
+Design notes / assumptions
+--------------------------
+* **Units.** Stored depth/offset values carry no per-field unit-of-measure. The
+  public Volve export is in **feet** (confirmed empirically), so the reader's
+  ``source_units`` defaults to ``"feet"``. This is exposed as a constructor
+  parameter -- it is *not* hard-coded globally. Angles are always degrees.
+  Covariance is in ``source_units**2``.
+* **Covariance axes.** ``CD_DEFINITIVE_SURVEY_STATION`` stores the total
+  accumulated position covariance as ``covariance_{xx,xy,xz,yy,yz,zz}`` in a
+  local Cartesian frame. Consistent with the validated ``examples/volve_wells``
+  mapping, this module treats ``x -> East``, ``y -> North``, ``z -> Vertical``.
+  :attr:`SurveyStation.covariance` is stored in that native ``(x, y, z)`` order;
+  :meth:`WellboreSurvey.to_welleng` re-orders it to welleng's ``NEV`` frame.
+* **Error models.** Survey tools are *classified* (see :func:`classify_tool`)
+  and surfaced with their name/interval, but deliberately **not** mapped to an
+  ISCWSA error model -- pre-ISCWSA COMPASS tool models were frequently bespoke.
+"""
+
+from __future__ import annotations
+
+import xml.etree.ElementTree as ET
+from dataclasses import dataclass, field
+from enum import Enum
+from typing import Dict, Iterator, List, Optional, Tuple
+
+import numpy as np
+
+FEET_TO_METERS = 0.3048
+
+# Tables materialised during the index sweep. Everything else is skipped.
+_METADATA_TAGS = frozenset({
+    "CD_PROJECT", "CD_SITE", "CD_WELL", "CD_WELLBORE", "CD_DATUM",
+    "CD_SURVEY_TOOL", "CD_SURVEY_HEADER", "CD_DEFINITIVE_SURVEY_HEADER",
+    "CD_SURVEY_PROGRAM",
+})
+_STATION_TAGS = frozenset({
+    "CD_SURVEY_STATION", "CD_DEFINITIVE_SURVEY_STATION",
+})
+_WANTED_TAGS = _METADATA_TAGS | _STATION_TAGS
+
+
+class ToolKind(str, Enum):
+    """Best-effort classification of a COMPASS survey tool."""
+
+    GYRO = "gyro"
+    MWD = "mwd"
+    DEFINITIVE = "definitive"
+    INCLINATION_ONLY = "inclination_only"
+    OTHER = "other"
+
+
+# Keyword tables for :func:`classify_tool`. Order of the checks matters:
+# "MWD gyro" tools are gyros, so gyro indicators are tested before magnetic ones.
+_GYRO_KEYWORDS = (
+    "gyro", "keeper", "wellbore surveyor", "inertial", "rigs",
+    "north seek", "north-seek", "sdc",
+)
+_INC_ONLY_KEYWORDS = ("inclination only", "inc only", "inc-only")
+_DEFINITIVE_KEYWORDS = ("definitive", "combined")
+_MWD_KEYWORDS = ("mwd", "magnetic", "magn", "ems", "measurement while")
+
+
+def classify_tool(
+    name: Optional[str], description: Optional[str] = None
+) -> ToolKind:
+    """Classify a survey tool from its name and (optional) description.
+
+    Pure function -- no I/O, no side effects. Matching is case-insensitive and
+    considers the concatenation of ``name`` and ``description``.
+
+    Parameters
+    ----------
+    name : str or None
+        The ``tool_name`` attribute of a ``CD_SURVEY_TOOL`` row.
+    description : str, optional
+        The ``description`` attribute of the same row.
+
+    Returns
+    -------
+    ToolKind
+
+    Notes
+    -----
+    Gyro-while-drilling tools (e.g. ``"MWD gyro, Gyrodata, GWD70"``) are
+    classified as :attr:`ToolKind.GYRO` -- the gyro sensor governs the error
+    behaviour even though the tool is conveyed on an MWD string.
+    """
+    text = " ".join(t for t in (name, description) if t).lower().strip()
+    if not text:
+        return ToolKind.OTHER
+    if any(k in text for k in _GYRO_KEYWORDS):
+        return ToolKind.GYRO
+    if any(k in text for k in _INC_ONLY_KEYWORDS):
+        return ToolKind.INCLINATION_ONLY
+    if any(k in text for k in _DEFINITIVE_KEYWORDS):
+        return ToolKind.DEFINITIVE
+    if any(k in text for k in _MWD_KEYWORDS):
+        return ToolKind.MWD
+    return ToolKind.OTHER
+
+
+# ---------------------------------------------------------------------------
+# Typed records
+# ---------------------------------------------------------------------------
+
+@dataclass
+class SurveyTool:
+    """A ``CD_SURVEY_TOOL`` row (a survey tool definition)."""
+
+    tool_id: str
+    name: str
+    description: str = ""
+    kind: ToolKind = ToolKind.OTHER
+    raw: Dict[str, str] = field(default_factory=dict, repr=False)
+
+
+@dataclass
+class Wellbore:
+    """A ``CD_WELLBORE`` row."""
+
+    wellbore_id: str
+    name: str
+    well_id: str
+    parent_wellbore_id: Optional[str] = None
+    well_legal_name: Optional[str] = None
+    raw: Dict[str, str] = field(default_factory=dict, repr=False)
+
+
+@dataclass
+class SurveyHeader:
+    """A survey header (``CD_SURVEY_HEADER`` or ``CD_DEFINITIVE_SURVEY_HEADER``).
+
+    ``kind`` is ``"raw"`` for control-point survey headers and ``"definitive"``
+    for the accumulated/blended definitive survey headers.
+    """
+
+    header_id: str
+    wellbore_id: str
+    kind: str  # "raw" | "definitive"
+    phase: Optional[str] = None  # PLAN | ACTUAL | PROTOTYPE
+    name: Optional[str] = None
+    tie_survey_header_id: Optional[str] = None
+    survey_tool_id: Optional[str] = None
+    n_stations: int = 0
+    raw: Dict[str, str] = field(default_factory=dict, repr=False)
+
+
+@dataclass
+class ProgramInterval:
+    """A ``CD_SURVEY_PROGRAM`` row: a per-interval tool assignment.
+
+    Joins a definitive survey header to a (raw) survey header + survey tool over
+    the measured-depth range ``[md_top, md_base]``.
+    """
+
+    def_survey_header_id: Optional[str]
+    survey_header_id: Optional[str]
+    survey_tool_id: Optional[str]
+    md_top: Optional[float]
+    md_base: Optional[float]
+    sequence_no: Optional[int]
+    tool: Optional[SurveyTool] = None
+
+    def contains(self, md: float) -> bool:
+        top = -np.inf if self.md_top is None else self.md_top
+        base = np.inf if self.md_base is None else self.md_base
+        return top <= md <= base
+
+
+@dataclass
+class SurveyStation:
+    """A single assembled survey station.
+
+    ``covariance`` (when present) is a symmetric ``3x3`` array in the file's
+    native ``(x, y, z)`` axes, i.e. ``x=East, y=North, z=Vertical`` (see the
+    module docstring), in ``source_units**2``.
+    """
+
+    md: Optional[float]
+    inc: Optional[float]
+    azi: Optional[float]
+    tvd: Optional[float] = None
+    north: Optional[float] = None
+    east: Optional[float] = None
+    dls: Optional[float] = None
+    sequence_no: Optional[int] = None
+    covariance: Optional[np.ndarray] = None
+    ellipse: Optional[Tuple[float, float, float]] = None  # (n, e, v)
+    tool: Optional[SurveyTool] = None
+
+
+@dataclass
+class WellboreSurvey:
+    """An assembled survey for a wellbore.
+
+    Attributes
+    ----------
+    wellbore : Wellbore
+    header : SurveyHeader
+    stations : list of SurveyStation
+    source_units : str
+        Units of the stored depths/offsets (e.g. ``"feet"``).
+    """
+
+    wellbore: Wellbore
+    header: SurveyHeader
+    stations: List[SurveyStation]
+    source_units: str = "feet"
+
+    def __len__(self) -> int:
+        return len(self.stations)
+
+    @property
+    def has_covariance(self) -> bool:
+        return bool(self.stations) and all(
+            s.covariance is not None for s in self.stations
+        )
+
+    def as_arrays(self) -> dict:
+        """Return the survey as a dict of numpy arrays (native source units).
+
+        Keys: ``md, inc, azi, tvd, north, east, dls, covariance,
+        tool_name, tool_kind``. ``covariance`` is an ``(n, 3, 3)`` array (with
+        ``nan`` blocks where a station lacks covariance), or ``None`` if no
+        station has covariance.
+        """
+        def col(attr):
+            return np.array(
+                [getattr(s, attr) if getattr(s, attr) is not None else np.nan
+                 for s in self.stations],
+                dtype=float,
+            )
+
+        if any(s.covariance is not None for s in self.stations):
+            cov = np.array([
+                s.covariance if s.covariance is not None
+                else np.full((3, 3), np.nan)
+                for s in self.stations
+            ])
+        else:
+            cov = None
+
+        return {
+            "md": col("md"),
+            "inc": col("inc"),
+            "azi": col("azi"),
+            "tvd": col("tvd"),
+            "north": col("north"),
+            "east": col("east"),
+            "dls": col("dls"),
+            "covariance": cov,
+            "tool_name": [
+                s.tool.name if s.tool is not None else None
+                for s in self.stations
+            ],
+            "tool_kind": [
+                s.tool.kind if s.tool is not None else None
+                for s in self.stations
+            ],
+        }
+
+    def to_welleng(self, units: str = "meters", azi_reference: str = "grid"):
+        """Build a :class:`welleng.survey.Survey` from this survey.
+
+        Parameters
+        ----------
+        units : str, {"meters", "feet"}
+            Target units. Depths/offsets are converted from ``source_units``.
+        azi_reference : str
+            Passed to the survey header (default ``"grid"`` -- COMPASS offsets
+            are grid-referenced).
+
+        Returns
+        -------
+        welleng.survey.Survey
+        """
+        from ..survey import Survey, SurveyHeader as WeSurveyHeader
+        from ..utils import make_long_cov
+
+        units = units.lower()
+        if units not in ("meters", "feet"):
+            raise ValueError("units must be 'meters' or 'feet'")
+        src = self.source_units.lower()
+        if src in ("feet", "ft") and units == "meters":
+            length = FEET_TO_METERS
+        elif src in ("meters", "m", "metres") and units == "feet":
+            length = 1.0 / FEET_TO_METERS
+        else:
+            length = 1.0
+
+        arrays = self.as_arrays()
+        md = arrays["md"] * length
+        tvd = arrays["tvd"] * length
+        north = arrays["north"] * length
+        east = arrays["east"] * length
+
+        cov_nev = None
+        if self.has_covariance:
+            # native (x, y, z) with x=East, y=North, z=Vertical -> welleng NEV.
+            # make_long_cov consumes columns [nn, ne, nv, ee, ev, vv].
+            xx = np.array([s.covariance[0, 0] for s in self.stations])
+            xy = np.array([s.covariance[0, 1] for s in self.stations])
+            xz = np.array([s.covariance[0, 2] for s in self.stations])
+            yy = np.array([s.covariance[1, 1] for s in self.stations])
+            yz = np.array([s.covariance[1, 2] for s in self.stations])
+            zz = np.array([s.covariance[2, 2] for s in self.stations])
+            cov_nev = make_long_cov(
+                np.array([yy, xy, yz, xx, xz, zz]).T
+            ) * (length ** 2)
+
+        header = WeSurveyHeader(
+            name=self.header.name or self.header.header_id,
+            azi_reference=azi_reference,
+        )
+        return Survey(
+            md=md,
+            inc=arrays["inc"],
+            azi=arrays["azi"],
+            n=north,
+            e=east,
+            tvd=tvd,
+            header=header,
+            cov_nev=cov_nev,
+            unit=units,
+        )
+
+
+# ---------------------------------------------------------------------------
+# Streaming reader
+# ---------------------------------------------------------------------------
+
+def _f(attrib: Dict[str, str], key: str) -> Optional[float]:
+    v = attrib.get(key)
+    if v is None or v == "":
+        return None
+    try:
+        return float(v)
+    except (TypeError, ValueError):
+        return None
+
+
+def _i(attrib: Dict[str, str], key: str) -> Optional[int]:
+    f = _f(attrib, key)
+    return None if f is None else int(f)
+
+
+def _iter_rows(path: str) -> Iterator[Tuple[str, Dict[str, str]]]:
+    """Yield ``(tag, attrib)`` for wanted rows with bounded memory.
+
+    The EDM file is flat (``<export><TOPLEVEL><CD_.../>...``). ``iterparse``
+    otherwise accumulates every parsed child under its parent element; we clear
+    both the element and its parent on each ``end`` event so peak memory stays
+    proportional to a single row rather than the whole file.
+    """
+    stack: List[ET.Element] = []
+    context = ET.iterparse(path, events=("start", "end"))
+    for event, elem in context:
+        if event == "start":
+            stack.append(elem)
+            continue
+        # end event
+        stack.pop()
+        if elem.tag in _WANTED_TAGS:
+            yield elem.tag, dict(elem.attrib)
+        elem.clear()
+        # Drop already-parsed siblings held by the parent (TOPLEVEL) so it
+        # doesn't grow to hold every row in the file.
+        if stack:
+            stack[-1].clear()
+
+
+class EDMReader:
+    """Streaming reader for a Landmark EDM/COMPASS XML export.
+
+    Build with :meth:`open` (or the constructor). One ``iterparse`` sweep
+    indexes the metadata + survey-station tables; surveys are assembled lazily
+    via :meth:`survey`.
+
+    Parameters
+    ----------
+    path : str
+        Path to the EDM XML file.
+    source_units : str, {"feet", "meters"}
+        Units of the stored depth/offset values (default ``"feet"`` -- the
+        Volve export). Angles are always degrees.
+    """
+
+    def __init__(self, path: str, source_units: str = "feet"):
+        self.path = path
+        self.source_units = source_units.lower()
+
+        self.projects: Dict[str, Dict[str, str]] = {}
+        self.sites: Dict[str, Dict[str, str]] = {}
+        self.wells: Dict[str, Dict[str, str]] = {}
+        self.wellbores: Dict[str, Wellbore] = {}
+        self.datums: Dict[str, List[Dict[str, str]]] = {}  # by well_id
+        self.tools: Dict[str, SurveyTool] = {}
+        self.headers: Dict[str, SurveyHeader] = {}  # raw + definitive by id
+        self.programs: Dict[str, List[ProgramInterval]] = {}  # by def hdr id
+
+        # station records grouped by header id (parsed floats)
+        self._raw_stations: Dict[str, List[dict]] = {}
+        self._def_stations: Dict[str, List[dict]] = {}
+
+        # name -> id lookups (built after sweep)
+        self.wellbore_name_to_id: Dict[str, str] = {}
+
+        self._index()
+
+    # -- construction --------------------------------------------------------
+    @classmethod
+    def open(cls, path: str, source_units: str = "feet") -> "EDMReader":
+        """Open and index an EDM file. Alias for the constructor."""
+        return cls(path, source_units=source_units)
+
+    def _index(self) -> None:
+        for tag, a in _iter_rows(self.path):
+            if tag == "CD_PROJECT":
+                self.projects[a["project_id"]] = a
+            elif tag == "CD_SITE":
+                self.sites[a["site_id"]] = a
+            elif tag == "CD_WELL":
+                self.wells[a["well_id"]] = a
+            elif tag == "CD_WELLBORE":
+                self.wellbores[a["wellbore_id"]] = Wellbore(
+                    wellbore_id=a["wellbore_id"],
+                    name=a.get("wellbore_name", a["wellbore_id"]),
+                    well_id=a.get("well_id", ""),
+                    parent_wellbore_id=a.get("parent_wellbore_id"),
+                    well_legal_name=a.get("well_legal_name"),
+                    raw=a,
+                )
+            elif tag == "CD_DATUM":
+                self.datums.setdefault(a.get("well_id", ""), []).append(a)
+            elif tag == "CD_SURVEY_TOOL":
+                self.tools[a["survey_tool_id"]] = SurveyTool(
+                    tool_id=a["survey_tool_id"],
+                    name=a.get("tool_name", ""),
+                    description=a.get("description", ""),
+                    kind=classify_tool(
+                        a.get("tool_name"), a.get("description")
+                    ),
+                    raw=a,
+                )
+            elif tag == "CD_SURVEY_HEADER":
+                self.headers[a["survey_header_id"]] = SurveyHeader(
+                    header_id=a["survey_header_id"],
+                    wellbore_id=a.get("wellbore_id", ""),
+                    kind="raw",
+                    phase=a.get("phase"),
+                    name=a.get("survey_name"),
+                    tie_survey_header_id=a.get("tie_survey_header_id"),
+                    survey_tool_id=a.get("survey_tool_id"),
+                    raw=a,
+                )
+            elif tag == "CD_DEFINITIVE_SURVEY_HEADER":
+                self.headers[a["def_survey_header_id"]] = SurveyHeader(
+                    header_id=a["def_survey_header_id"],
+                    wellbore_id=a.get("wellbore_id", ""),
+                    kind="definitive",
+                    phase=a.get("phase"),
+                    name=a.get("name"),
+                    tie_survey_header_id=a.get("tie_survey_header_id"),
+                    survey_tool_id=a.get("survey_tool_id"),
+                    raw=a,
+                )
+            elif tag == "CD_SURVEY_PROGRAM":
+                did = a.get("def_survey_header_id")
+                self.programs.setdefault(did, []).append(ProgramInterval(
+                    def_survey_header_id=did,
+                    survey_header_id=a.get("survey_header_id"),
+                    survey_tool_id=a.get("survey_tool_id"),
+                    md_top=_f(a, "md_top"),
+                    md_base=_f(a, "md_base"),
+                    sequence_no=_i(a, "sequence_no"),
+                ))
+            elif tag == "CD_SURVEY_STATION":
+                self._raw_stations.setdefault(
+                    a["survey_header_id"], []
+                ).append({
+                    "md": _f(a, "md"), "inc": _f(a, "inclination"),
+                    "azi": _f(a, "azimuth"), "tvd": _f(a, "tvd"),
+                    "north": _f(a, "offset_north"),
+                    "east": _f(a, "offset_east"),
+                    "dls": _f(a, "dogleg_severity"),
+                    "sequence_no": _i(a, "sequence_no"),
+                })
+            elif tag == "CD_DEFINITIVE_SURVEY_STATION":
+                self._def_stations.setdefault(
+                    a["def_survey_header_id"], []
+                ).append({
+                    "md": _f(a, "md"), "inc": _f(a, "inclination"),
+                    "azi": _f(a, "azimuth"), "tvd": _f(a, "tvd"),
+                    "north": _f(a, "offset_north"),
+                    "east": _f(a, "offset_east"),
+                    "dls": _f(a, "dogleg_severity"),
+                    "sequence_no": _i(a, "sequence_no"),
+                    "cov": (
+                        _f(a, "covariance_xx"), _f(a, "covariance_xy"),
+                        _f(a, "covariance_xz"), _f(a, "covariance_yy"),
+                        _f(a, "covariance_yz"), _f(a, "covariance_zz"),
+                    ),
+                    "ellipse": (
+                        _f(a, "ellipse_north"), _f(a, "ellipse_east"),
+                        _f(a, "ellipse_vertical"),
+                    ),
+                })
+
+        # finalise: station counts, name lookups, resolve program tools
+        for hid, header in self.headers.items():
+            if header.kind == "raw":
+                header.n_stations = len(self._raw_stations.get(hid, []))
+            else:
+                header.n_stations = len(self._def_stations.get(hid, []))
+        for wb in self.wellbores.values():
+            self.wellbore_name_to_id[wb.name] = wb.wellbore_id
+        for intervals in self.programs.values():
+            for iv in intervals:
+                if iv.survey_tool_id is not None:
+                    iv.tool = self.tools.get(iv.survey_tool_id)
+
+    # -- lookups -------------------------------------------------------------
+    def _resolve_wellbore(self, wellbore) -> Wellbore:
+        if isinstance(wellbore, Wellbore):
+            return wellbore
+        if wellbore in self.wellbores:
+            return self.wellbores[wellbore]
+        if wellbore in self.wellbore_name_to_id:
+            return self.wellbores[self.wellbore_name_to_id[wellbore]]
+        raise KeyError(f"unknown wellbore: {wellbore!r}")
+
+    def find_wellbores(self, substring: str) -> List[Wellbore]:
+        """Return wellbores whose name contains ``substring`` (case-insensitive)."""
+        s = substring.lower()
+        return [
+            wb for wb in self.wellbores.values() if s in wb.name.lower()
+        ]
+
+    def survey_headers(
+        self,
+        wellbore,
+        kind: str = "definitive",
+        phase: Optional[str] = None,
+    ) -> List[SurveyHeader]:
+        """Return the survey headers for a wellbore, filtered by kind/phase.
+
+        Sorted by station count (descending), so the first entry is the
+        sensible default selection.
+        """
+        wb = self._resolve_wellbore(wellbore)
+        out = [
+            h for h in self.headers.values()
+            if h.wellbore_id == wb.wellbore_id
+            and h.kind == kind
+            and (phase is None or h.phase == phase)
+        ]
+        out.sort(key=lambda h: h.n_stations, reverse=True)
+        return out
+
+    # -- survey assembly -----------------------------------------------------
+    def survey(
+        self,
+        wellbore,
+        kind: str = "definitive",
+        phase: Optional[str] = "ACTUAL",
+        header_id: Optional[str] = None,
+    ) -> WellboreSurvey:
+        """Assemble a typed :class:`WellboreSurvey`.
+
+        Parameters
+        ----------
+        wellbore : str or Wellbore
+            Wellbore id, wellbore name, or a :class:`Wellbore`.
+        kind : str, {"definitive", "raw"}
+            ``"definitive"`` returns the accumulated survey with covariance and
+            per-interval tools resolved from ``CD_SURVEY_PROGRAM``; ``"raw"``
+            returns the control-point survey.
+        phase : str, optional
+            ``PLAN`` / ``ACTUAL`` / ``PROTOTYPE``. Default ``"ACTUAL"``.
+        header_id : str, optional
+            Select a specific header. If omitted, the header with the most
+            stations (matching ``kind``/``phase``) is used.
+
+        Returns
+        -------
+        WellboreSurvey
+        """
+        wb = self._resolve_wellbore(wellbore)
+        if header_id is not None:
+            header = self.headers.get(header_id)
+            if header is None:
+                raise KeyError(f"unknown survey header: {header_id!r}")
+        else:
+            candidates = self.survey_headers(wb, kind=kind, phase=phase)
+            if not candidates:
+                raise LookupError(
+                    f"no {kind} survey (phase={phase}) for wellbore "
+                    f"{wb.name!r}"
+                )
+            header = candidates[0]
+
+        if header.kind == "definitive":
+            stations = self._assemble_definitive(header)
+        else:
+            stations = self._assemble_raw(header)
+
+        return WellboreSurvey(
+            wellbore=wb,
+            header=header,
+            stations=stations,
+            source_units=self.source_units,
+        )
+
+    def _tool_for_md(
+        self, intervals: List[ProgramInterval], md: Optional[float]
+    ) -> Optional[SurveyTool]:
+        if md is None or not intervals:
+            return None
+        for iv in intervals:
+            if iv.contains(md):
+                return iv.tool
+        return None
+
+    def _assemble_definitive(
+        self, header: SurveyHeader
+    ) -> List[SurveyStation]:
+        records = sorted(
+            self._def_stations.get(header.header_id, []),
+            key=lambda r: (r["md"] if r["md"] is not None else np.inf),
+        )
+        intervals = sorted(
+            self.programs.get(header.header_id, []),
+            key=lambda iv: (
+                iv.sequence_no if iv.sequence_no is not None else 0
+            ),
+        )
+        stations = []
+        for r in records:
+            cov = None
+            if all(c is not None for c in r["cov"]):
+                xx, xy, xz, yy, yz, zz = r["cov"]
+                cov = np.array([
+                    [xx, xy, xz],
+                    [xy, yy, yz],
+                    [xz, yz, zz],
+                ])
+            stations.append(SurveyStation(
+                md=r["md"], inc=r["inc"], azi=r["azi"], tvd=r["tvd"],
+                north=r["north"], east=r["east"], dls=r["dls"],
+                sequence_no=r["sequence_no"], covariance=cov,
+                ellipse=r["ellipse"],
+                tool=self._tool_for_md(intervals, r["md"]),
+            ))
+        return stations
+
+    def _assemble_raw(self, header: SurveyHeader) -> List[SurveyStation]:
+        records = sorted(
+            self._raw_stations.get(header.header_id, []),
+            key=lambda r: (r["md"] if r["md"] is not None else np.inf),
+        )
+        # ACTUAL raw headers may carry a single tool for the whole survey.
+        tool = (
+            self.tools.get(header.survey_tool_id)
+            if header.survey_tool_id else None
+        )
+        return [
+            SurveyStation(
+                md=r["md"], inc=r["inc"], azi=r["azi"], tvd=r["tvd"],
+                north=r["north"], east=r["east"], dls=r["dls"],
+                sequence_no=r["sequence_no"], tool=tool,
+            )
+            for r in records
+        ]
+
+    # -- graph traversal -----------------------------------------------------
+    def sidetrack_chain(self, wellbore) -> List[Wellbore]:
+        """Return the parent-wellbore chain, root-first, ending at ``wellbore``.
+
+        Follows ``parent_wellbore_id``. Uses a local accumulator (no mutable
+        default argument) and guards against cycles.
+        """
+        wb = self._resolve_wellbore(wellbore)
+        chain: List[Wellbore] = []
+        seen = set()
+        current: Optional[Wellbore] = wb
+        while current is not None and current.wellbore_id not in seen:
+            chain.append(current)
+            seen.add(current.wellbore_id)
+            pid = current.parent_wellbore_id
+            current = self.wellbores.get(pid) if pid else None
+        chain.reverse()
+        return chain
+
+    def tie_chain(self, header) -> List[SurveyHeader]:
+        """Return the tie-on header chain, root-first, ending at ``header``.
+
+        Follows ``tie_survey_header_id``. No mutable default argument; cycle
+        guarded.
+        """
+        if isinstance(header, SurveyHeader):
+            hdr: Optional[SurveyHeader] = header
+        else:
+            hdr = self.headers.get(header)
+            if hdr is None:
+                raise KeyError(f"unknown survey header: {header!r}")
+        chain: List[SurveyHeader] = []
+        seen = set()
+        current = hdr
+        while current is not None and current.header_id not in seen:
+            chain.append(current)
+            seen.add(current.header_id)
+            tid = current.tie_survey_header_id
+            current = self.headers.get(tid) if tid else None
+        chain.reverse()
+        return chain
+
+
+def open_edm(path: str, source_units: str = "feet") -> EDMReader:
+    """Convenience factory mirroring :meth:`EDMReader.open`."""
+    return EDMReader.open(path, source_units=source_units)


### PR DESCRIPTION
Additive streaming Landmark EDM parser (`welleng/exchange/edm_stream.py`, `EDMReader`) — replaces the whole-DOM approach for the survey path while keeping the legacy `EDM`/`Well`/`Case` API working.

**What it adds (the old parser ignored these):**
- **Definitive-survey covariance** — the full 3×3 per station (`covariance_{xx…zz}`), mapped to welleng NEV (consistent with `volve_wells.py`).
- **Per-interval tool resolution** via `CD_SURVEY_PROGRAM` → each station tagged gyro | mwd | definitive | inclination_only | other (tool exposed, error model **not** assumed — COMPASS models live in separate IPM files).
- **Phase-aware** plan/actual, directed sidetrack/tie chains, feet→m (`source_units` param, not hardcoded).

**Streaming:** `data/Volve.xml` (211 MB) indexed in **1.4 s @ ~182 MB peak** (vs ~604 MB DOM). Real extraction: `15/9-F-11 A` definitive ACTUAL = 319 stations with covariance, and it's a genuine **gyro+MWD combined survey** (`Keeper, cont` + `Magn, IFR` intervals) — a `SurveyComposition` validation target.

**Back-compat:** legacy `EDM`/`Well`/`Case` retained (`EDM.__init__` now warns; `EDM.open()` added); both mutable-default-arg bugs (`edm.py:177`, `:402`) fixed. `extract_torque_drag.py` + `volve_wells.py` verified still working.

**Tests:** `tests/test_edm.py` (37) on a synthetic fixture — classify_tool, index/skip, covariance assembly, phase filter, feet→m, chain no-leak, legacy back-compat. Full suite **376 passed**. 211 MB file not added to the repo.

Ships in 0.15.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)