### PR TITLE
fix(#133): fix 5 latent bugs surfaced by the typing pass

### DIFF
--- a/tests/test_latent_bugs_133.py
+++ b/tests/test_latent_bugs_133.py
@@ -1,0 +1,70 @@
+"""Regression tests for the latent bugs surfaced while typing for issue #133.
+
+Each test pins a bug that was found (and flagged in-comment) during the
+survey/connector type-annotation pass and then fixed.
+"""
+from datetime import datetime
+
+import numpy as np
+import pytest
+
+from welleng.node import Node
+from welleng.survey import Survey, SurveyHeader, get_node
+import welleng.connector as connector
+
+
+def test_node_without_angles_sets_azi_deg_none():
+    """node.py: the all-None branch used to set azi_rad twice and never set
+    azi_deg, so accessing .azi_deg raised AttributeError."""
+    node = Node()  # no inc/azi/vec
+    assert node.inc_rad is None
+    assert node.inc_deg is None
+    assert node.azi_rad is None
+    assert node.azi_deg is None  # previously AttributeError
+
+
+def test_node_interpolated_is_first_class():
+    """node.py: `interpolated` is now a declared attribute with a default."""
+    assert Node().interpolated is False
+    assert Node(interpolated=True).interpolated is True
+
+
+def test_get_node_propagates_interpolated():
+    """survey.get_node passes `interpolated` through to the Node."""
+    s = Survey(
+        md=[0.0, 100.0, 200.0],
+        inc=[0.0, 5.0, 10.0],
+        azi=[10.0, 15.0, 20.0],
+    )
+    assert get_node(s, 0, interpolated=True).interpolated is True
+    assert get_node(s, 0).interpolated is False
+
+
+def test_get_date_fallback_uses_today():
+    """SurveyHeader._get_date sets survey_date; the magnetic-lookup fallback
+    now reads that attribute instead of the function's (None) return value."""
+    header = SurveyHeader.__new__(SurveyHeader)
+    header._get_date(date=None)
+    assert header.survey_date == datetime.today().strftime('%Y-%m-%d')
+
+
+def test_survey_to_plan_dead_code_removed():
+    """connector.survey_to_plan / _get_section were dead + broken (called a
+    non-existent Connector.survey); they have been removed."""
+    assert not hasattr(connector, "survey_to_plan")
+    assert not hasattr(connector, "_get_section")
+
+
+def test_transform_coordinates_still_works():
+    """transform_coordinates no longer forwards *args (the pyproj itransform
+    direction= collision); the documented call still works."""
+    from welleng.survey import SurveyParameters
+    calc = SurveyParameters('EPSG:23031')
+    result = calc.transform_coordinates(
+        coords=[(588319.02, 5770571.03)], to_projection='EPSG:32631'
+    )
+    assert np.asarray(result).shape[-1] == 2
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/welleng/connector.py
+++ b/welleng/connector.py
@@ -9,13 +9,12 @@ closed form via Sawaryn (2021, SPE-204111-PA) — see ``welleng.sawaryn_analytic
 """
 
 import warnings
-from copy import copy, deepcopy
+from copy import copy
 from typing import Any, Optional, Union
 
 import numpy as np
 from numpy.typing import ArrayLike
 from scipy.optimize import minimize
-from scipy.spatial import distance
 
 from .node import Node, get_node_params
 from .sawaryn_analytical import max_radius, solve_clc
@@ -1936,131 +1935,6 @@ def connect_points(
         connections.append(c)
 
     return connections
-
-
-def survey_to_plan(
-    survey: Any, tolerance: float = 0.2, dls_design: float = 1.,
-    step: float = 30.
-) -> list:
-    """Extracts a minimal well plan from a drilled survey.
-
-    Identifies the minimum number of control points (start/end of hold
-    or build/turn sections) needed to reproduce the survey trajectory
-    within the given tolerance.
-
-    Parameters
-    ----------
-    survey : Survey
-        A welleng Survey object representing the drilled well.
-    tolerance : float
-        Fit tolerance. Higher values produce fewer control
-        points but a looser fit.
-    dls_design : float
-        Minimum design DLS in deg/30m for the planned trajectory.
-    step : float
-        Desired MD step interval for the output survey.
-
-    Returns
-    -------
-    list
-        A list of Connector objects representing the planned sections.
-
-    Raises
-    ------
-    AssertionError
-        If dls_design is not greater than 0.
-    """
-    assert dls_design > 0., "dls_design must be greater than 0"
-
-    idx = [0]
-    end = len(survey.md) - 1
-    md = survey.md[0]
-    node = None
-    sections = []
-
-    while True:
-        section, i = _get_section(
-            survey=survey,
-            start=idx[-1],
-            md=md,
-            node=node,
-            tolerance=tolerance,
-            dls_design=dls_design
-        )
-        sections.append(section)
-        idx.append(i)
-        if idx[-1] >= end:
-            break
-        node = section.node_end
-
-    # data = interpolate_well(sections, step=step)
-
-    return sections
-
-
-def _get_section(
-    survey: Any, start: int, tolerance: float, dls_design: float = 1.,
-    md: float = 0., node: Optional[Node] = None
-) -> tuple:
-    idx = start + 2
-    nev = survey.get_nev_arr()
-
-    if idx > len(nev):
-        idx = len(nev) - 1
-
-    if node is None:
-        node_1 = Node(
-            pos=nev[start],
-            vec=survey.vec_nev[start],
-            md=md
-        )
-    else:
-        node_1 = node
-
-    scores = [0.]
-    delta_scores = []
-    c_old = None
-
-    for i, (p, v) in enumerate(zip(nev[idx:], survey.vec_nev[idx:])):
-        node_2 = Node(
-            pos=p,
-            vec=v,
-        )
-        c = Connector(
-            node1=node_1,
-            node2=node_2,
-            dls_design=dls_design
-        )
-        s = c.survey(step=1.)  # type: ignore[attr-defined]  # legacy survey_to_plan path: Connector.survey not implemented (pre-existing)
-        if c_old is None:
-            c_old = deepcopy(c)
-        nev_new = s.get_nev_arr()
-
-        distances = distance.cdist(
-            nev[start: idx + i],
-            nev_new
-        )
-
-        score = np.sum(np.amin(distances, axis=1)) / (s.md[-1] - s.md[0])
-
-        delta_scores.append(score - scores[-1])
-        scores.append(score)
-
-        if all((
-            abs(delta_scores[-1]) >= tolerance,
-            idx + i < len(nev) - 2
-        )):
-            break
-        elif idx + i == len(nev) - 1:
-            c_old = deepcopy(c)
-            break
-        else:
-            c_old = deepcopy(c)
-
-    return (
-        c_old,
-        idx + i - 1 if idx + i != len(nev) - 1 else idx + i
-    )
 
 
 def drop_off(

--- a/welleng/node.py
+++ b/welleng/node.py
@@ -55,6 +55,7 @@ class Node:
     md: Optional[float]
     unit: str
     cov_nev: np.ndarray
+    interpolated: bool
 
     def __init__(
         self,
@@ -67,6 +68,7 @@ class Node:
         degrees: bool = True,
         nev: bool = True,
         cov_nev: Optional[np.ndarray] = None,
+        interpolated: bool = False,
         **kwargs: Any
     ) -> None:
         """Initialize a Node with position and direction.
@@ -94,6 +96,9 @@ class Node:
             otherwise XYZ.
         cov_nev : ndarray, optional
             Covariance matrix (1, 3, 3). Defaults to zeros.
+        interpolated : bool
+            True if this node was interpolated between survey stations
+            (default False).
         **kwargs
             Additional attributes set on the instance.
         """
@@ -102,6 +107,7 @@ class Node:
         self.md = md
         self.unit = unit
         self.cov_nev = np.zeros(shape=(1, 3, 3)) if cov_nev is None else cov_nev
+        self.interpolated = interpolated
 
         for k, v in kwargs.items():
             setattr(self, k, v)
@@ -120,7 +126,7 @@ class Node:
             self.inc_rad = None
             self.inc_deg = None
             self.azi_rad = None
-            self.azi_rad = None
+            self.azi_deg = None
             return
         elif vec is None:
             assert inc is not None and azi is not None, (

--- a/welleng/survey.py
+++ b/welleng/survey.py
@@ -238,7 +238,7 @@ class SurveyParameters(Proj):
     def transform_coordinates(
         self, coords: ArrayLike, to_projection: str,
         altitude: Optional[float] = None,
-        *args: Any, **kwargs: Any
+        **kwargs: Any
     ) -> ArrayLike:
         """Transforms coordinates from instance's projection to another
         projection.
@@ -273,12 +273,12 @@ class SurveyParameters(Proj):
             self.crs, CRS(to_projection)
         )
         _coords = np.array(coords)
-        result = list(transformer.itransform(  # type: ignore[misc]  # LATENT BUG: *args can collide with the direction= keyword (pyproj itransform)
+        result = list(transformer.itransform(
             (
                 _coords.tolist() if len(_coords.shape) > 1
                 else _coords.reshape((1, -1)).tolist()
             ),
-            direction=TransformDirection('FORWARD'), *args, **kwargs
+            direction=TransformDirection('FORWARD'), **kwargs
         ))
 
         return np.array(result)
@@ -444,11 +444,13 @@ class SurveyHeader:
                 )
             except Exception:
                 try:
+                    # retry with today's date (sets self.survey_date, then use it)
+                    self._get_date(date=None)
                     result = calculator.calculate(
                         latitude=self.latitude,
                         longitude=self.longitude,
                         altitude=self.altitude,
-                        date=self._get_date(date=None)  # type: ignore[func-returns-value]  # LATENT BUG: _get_date only sets self.survey_date and returns None; its value is used here
+                        date=self.survey_date
                     )
                 except Exception as exc:
                     warnings.warn(
@@ -3670,7 +3672,7 @@ def interpolate_survey_tvd(
     ordered = [nodes_by_md[key] for key in sorted(nodes_by_md)]
 
     md, inc, azi, interpolated = np.array([
-        [n.md, n.inc_rad, n.azi_rad, n.interpolated]  # type: ignore[attr-defined]  # LATENT BUG: Node.interpolated is a dynamic (kwargs) attribute, not declared on Node
+        [n.md, n.inc_rad, n.azi_rad, n.interpolated]
         for n in ordered
     ]).T
 


### PR DESCRIPTION
Follow-up to #241. Type-annotating `survey.py`/`connector.py` exposed five genuine pre-existing bugs (flagged in-comment there); this fixes them and removes the `LATENT BUG` ignore markers.

## Fixes

1. **`node.py` — `azi_deg` never set.** The no-`inc`/`azi`/`vec` branch set `azi_rad = None` twice and never set `azi_deg` → `AttributeError` on `.azi_deg`. Now sets it.
2. **`node.py` — `interpolated` promoted to a first-class typed attribute** (`interpolated: bool = False`), was only ever set via `**kwargs`.
3. **`survey.py` — magnetic-lookup fallback.** Called `_get_date(date=None)` (returns `None`) and passed that as the date; now calls `_get_date` then uses `self.survey_date` (today), as intended.
4. **`survey.py` — `transform_coordinates`.** Forwarded `*args` into pyproj `itransform` alongside a fixed `direction=` keyword ("multiple values for keyword direction"); dropped the fragile `*args` (kept `**kwargs`).
5. **`connector.py` — removed dead+broken `survey_to_plan`/`_get_section`** (unreferenced; called a non-existent `Connector.survey()`) + now-unused `deepcopy`/`scipy.spatial.distance` imports.

## Test plan

- New `tests/test_latent_bugs_133.py` pins each fix (6 tests).
- `pytest tests/` → **673 passed**, 7 skipped, 3 xfailed.
- `mypy welleng/node.py welleng/survey.py welleng/connector.py` → **0 errors**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)