### PR TITLE
feat(survey): Survey.highside_vec_nev() high-side accessor

### DIFF
--- a/tests/test_highside.py
+++ b/tests/test_highside.py
@@ -1,0 +1,48 @@
+"""Tests for Survey.highside_vec_nev (welleng-api wellpath-designer high-side lock)."""
+import numpy as np
+import pytest
+
+from welleng.survey import Survey
+from welleng.utils import get_transform
+
+
+def _survey():
+    return Survey(
+        md=[0.0, 500.0, 1000.0, 1500.0, 2000.0],
+        inc=[0.0, 15.0, 45.0, 90.0, 90.0],
+        azi=[0.0, 30.0, 120.0, 210.0, 300.0],
+    )
+
+
+def test_highside_is_unit_length():
+    hs = _survey().highside_vec_nev()
+    assert np.allclose(np.linalg.norm(hs, axis=1), 1.0)
+
+
+def test_highside_perpendicular_to_axis():
+    """High side is perpendicular to the wellbore axis (unit direction vector)."""
+    s = _survey()
+    hs = s.highside_vec_nev()
+    axis = s.vec_nev                      # (n, 3) unit axis vectors in NEV
+    dots = np.einsum('ij,ij->i', hs, axis)
+    assert np.allclose(dots, 0.0, atol=1e-9)
+
+
+def test_highside_points_up_when_horizontal():
+    """A horizontal well's high side points straight up: V-component = -1."""
+    s = _survey()
+    hs = s.highside_vec_nev()
+    # stations 3 and 4 are inc=90 deg
+    assert hs[3] == pytest.approx([0.0, 0.0, -1.0], abs=1e-9)
+    assert hs[4] == pytest.approx([0.0, 0.0, -1.0], abs=1e-9)
+
+
+def test_highside_matches_hla_transform_row():
+    """It is exactly the H (high-side) row of the NEV->HLA transform."""
+    s = _survey()
+    trans = get_transform(s.survey_rad)   # (n, 3, 3); row 0 is the H basis in NEV
+    assert np.allclose(s.highside_vec_nev(), trans[:, 0, :])
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/welleng/survey.py
+++ b/welleng/survey.py
@@ -1158,6 +1158,25 @@ class Survey:
             self.tvd
         ]).T.reshape(-1, 3)
 
+    def highside_vec_nev(self) -> np.ndarray:
+        """Unit high-side vector at each station, as an (n, 3) [N, E, V] array.
+
+        The high side is perpendicular to the wellbore axis, in the vertical
+        plane containing it, pointing to the high side of the hole (up-dip). It
+        is the high-side (H) basis vector of the NEV->HLA transform, expressed in
+        NEV, using the grid azimuth (consistent with :meth:`get_nev_arr`). For a
+        horizontal well it points straight up ([0, 0, -1]); for a vertical well
+        the high side is undefined and this returns the azimuth direction.
+
+        Returns
+        -------
+        ndarray
+            Array of shape (n, 3) of unit high-side vectors in [N, E, V].
+        """
+        ci, si = np.cos(self.inc_rad), np.sin(self.inc_rad)
+        ca, sa = np.cos(self.azi_grid_rad), np.sin(self.azi_grid_rad)
+        return np.stack([ci * ca, ci * sa, -si], axis=-1)
+
     def save(self, filename: str) -> None:
         """
         Saves a minimal (control points) survey listing as a .csv file,


### PR DESCRIPTION
Adds `Survey.highside_vec_nev() -> (n, 3)` — the per-station high-side unit vector in `[N, E, V]`, for welleng-api's wellpath-designer high-side plane lock (so it uses core's, not a re-derivation).

It's the high-side (H) basis of the NEV→HLA transform expressed in NEV, using the grid azimuth (consistent with `get_nev_arr`). Horizontal → straight up `[0,0,-1]`; vertical → azimuth direction.

Tests (`tests/test_highside.py`): unit length, perpendicular to the axis vector, points up when horizontal, exactly matches the HLA transform's H row. Fully typed.

Part of welleng-api's designer asks; `solve_nodes(nodes[])` (the MinCurve/MultiSection split) is scoped separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)