### PR TITLE
feat(kick-tolerance): batch + sweep entry points (P1)

### DIFF
--- a/benchmarks/BENCHMARK_LOG.md
+++ b/benchmarks/BENCHMARK_LOG.md
@@ -11,6 +11,24 @@ finding that motivated it.
 
 ---
 
+## 2026-07-18 · `feat/kt-batch` · Python 3.12, dev machine
+
+Batch / sweep KT (Phase 1). `sweep_analytical_kick_tolerance` over a 30-point
+design curve (methane / Hall-Yarborough, no CoolProp table):
+
+| operation | result |
+|---|---|
+| 30-case analytical sweep | **199 ms total (6.6 ms/case)**, 30/30 ok |
+
+This is exactly welleng-api's design-curve builder (30 FP-offset re-solves) that it
+currently hand-rolls app-side with a **3 s** time budget — now ~0.2 s in core, so the
+budget/truncation can go. Serial by design (per TA1 steer: no core multiprocessing;
+the API owns the worker pool). The real amortization for CoolProp mixtures is the
+**shared `fluid_table`**: the ZTable (~seconds to build) is built ONCE for the batch
+instead of per case — pass a prebuilt `fluid_table` to `batch_analytical_kick_tolerance`
+/ `sweep_analytical_kick_tolerance`. Per-case error isolation adds no measurable
+overhead (a try/except per case).
+
 ## 2026-07-18 · `fix/kt-unconstrained-closedform` · Python 3.12, dev machine
 
 `analytical_kick_tolerance` on the `open_hole_unconstrained` regime (TWO_SECTION,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -167,7 +167,7 @@ no_implicit_optional = true
 
 # Fully-annotated modules — tighten these as coverage grows.
 [[tool.mypy.overrides]]
-module = ["welleng.node", "welleng.survey", "welleng.connector", "welleng.units"]
+module = ["welleng.node", "welleng.survey", "welleng.connector", "welleng.units", "welleng.kick_tolerance.batch"]
 disallow_incomplete_defs = true
 
 [dependency-groups]

--- a/tests/test_kick_batch.py
+++ b/tests/test_kick_batch.py
@@ -1,0 +1,88 @@
+"""Tests for the batch / sweep kick-tolerance entry points (Phase 1)."""
+import numpy as np
+import pytest
+
+from welleng.kick_tolerance import (
+    KickInputs, drill_kick, analytical_kick_tolerance, WellSection,
+    solve_batch, batch_analytical_kick_tolerance, sweep_analytical_kick_tolerance,
+    BatchCaseResult,
+)
+from welleng.kick_tolerance.geometry import annular_capacity
+
+GAS = (None, 302.0 + 460.0, None, None)
+COMMON = dict(bhp_psi=6402.0, rho_mud_ppg=12.0, gas_bh_state=GAS)
+PP = (np.array([0.0, 10500.0]), np.array([10.5, 11.0]))
+FP_UNIFORM = (np.array([0.0, 10500.0]), np.array([14.0, 14.0]))
+TWO_SECTION = [WellSection(0.0, 6500.0, 0.066, False),
+               WellSection(6500.0, 10500.0, 0.046, True)]
+
+
+def _inputs(pp: float) -> KickInputs:
+    return KickInputs(
+        rho_mud=11.9, PP=pp, kick_intensity=1.1, P_lot=16.0, P_apl=210.0,
+        D_td=10500.0, D_lot=6500.0, T_s=212.0, T_td=302.0,
+        V_dpa=annular_capacity(6.125, 4.0), kt_threshold=25.0,
+    )
+
+
+# --- closed-form batch -------------------------------------------------------
+def test_solve_batch_matches_single_calls_in_order():
+    cases = [_inputs(p) for p in (11.0, 11.5, 12.0)]
+    out = solve_batch(cases, kind="drill")
+    assert [r.index for r in out] == [0, 1, 2]
+    assert all(r.ok for r in out)
+    for i, c in enumerate(cases):
+        assert out[i].result == drill_kick(c)      # bit-identical to the single call
+
+
+def test_solve_batch_isolates_errors():
+    bad = "not-a-KickInputs"                          # drill_kick(bad) raises -> isolated
+    out = solve_batch([_inputs(11.5), bad, _inputs(12.0)], kind="drill")
+    assert out[0].ok and out[2].ok
+    assert not out[1].ok and out[1].result is None and out[1].error
+
+
+def test_solve_batch_bad_kind():
+    with pytest.raises(ValueError):
+        solve_batch([_inputs(11.5)], kind="nope")
+
+
+# --- analytical batch --------------------------------------------------------
+def _acase(fp_top: float) -> dict:
+    fp = (np.array([0.0, 10500.0]), np.array([fp_top, fp_top]))
+    return dict(sections=TWO_SECTION, pp=PP, fp=fp,
+                gas_density_mode="conservative", **COMMON)
+
+
+def test_batch_analytical_matches_single_calls():
+    cases = [_acase(fp) for fp in (13.5, 14.0, 14.5)]
+    out = batch_analytical_kick_tolerance(cases)
+    assert [r.index for r in out] == [0, 1, 2]
+    assert all(r.ok for r in out)
+    for i, c in enumerate(cases):
+        single = analytical_kick_tolerance(**c)
+        assert out[i].result.max_influx_bbl == single.max_influx_bbl   # deterministic
+
+
+def test_batch_analytical_isolates_errors():
+    good = _acase(14.0)
+    bad = dict(good)
+    bad.pop("bhp_psi")                                # missing required kwarg -> TypeError
+    out = batch_analytical_kick_tolerance([good, bad])
+    assert out[0].ok
+    assert not out[1].ok and "TypeError" in out[1].error
+
+
+# --- sweep -------------------------------------------------------------------
+def test_sweep_matches_manual_batch():
+    base = _acase(14.0)
+    vals = [6200.0, 6402.0, 6600.0]
+    swept = sweep_analytical_kick_tolerance(base, "bhp_psi", vals)
+    assert [r.index for r in swept] == [0, 1, 2]
+    for i, v in enumerate(vals):
+        single = analytical_kick_tolerance(**{**base, "bhp_psi": v})
+        assert swept[i].result.max_influx_bbl == single.max_influx_bbl
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/welleng/kick_tolerance/__init__.py
+++ b/welleng/kick_tolerance/__init__.py
@@ -106,6 +106,14 @@ from .migration import (
 # Analytical (breakpoint) kick-tolerance solver: the migration-form KT evaluated
 # only at the breakpoints of P(gas position) -- the exact worst position, no march.
 from .analytical import analytical_kick_tolerance, AnalyticalKickTolerance
+# Batch / sweep entry points (paid API feature): serial + shared-ZTable amortization
+# + per-case error isolation. See batch.py.
+from .batch import (
+    BatchCaseResult,
+    solve_batch,
+    batch_analytical_kick_tolerance,
+    sweep_analytical_kick_tolerance,
+)
 # Catalogue-backed geometry: true annular capacity (bore - string), casing IDs
 # from the API-5CT catalogue. catalog is imported lazily inside the builders.
 from .geometry import annular_capacity, cased_section, open_hole_section
@@ -152,6 +160,10 @@ __all__ = [
     "linear_temp_profile",
     "analytical_kick_tolerance",
     "AnalyticalKickTolerance",
+    "BatchCaseResult",
+    "solve_batch",
+    "batch_analytical_kick_tolerance",
+    "sweep_analytical_kick_tolerance",
     "annular_capacity",
     "cased_section",
     "open_hole_section",

--- a/welleng/kick_tolerance/batch.py
+++ b/welleng/kick_tolerance/batch.py
@@ -1,0 +1,161 @@
+"""Batch / sweep entry points for kick tolerance (Phase 1).
+
+Runs many kick-tolerance cases through the existing solvers with **per-case error
+isolation** and **shared real-gas table amortization**, so scripted sweeps (LOT
+grids, depth matrices, design curves) don't pay per-call setup N times.
+
+Design (TA1 steer, 2026-07-18):
+
+* **Serial** loops in core -- deterministic, `batch[i]` is bit-identical to the
+  single call for case ``i`` (same function, same inputs, no cross-case state).
+  Core does **not** spawn processes/threads: concurrency belongs to the caller's
+  worker pool (the solvers are stateless for reads and a built :class:`ZTable`
+  is read-only, so sharing across threads is safe).
+* **Amortization**: pass one prebuilt ``fluid_table`` (:class:`ZTable`) and it is
+  shared across every analytical case -- the CoolProp grid is built once, not per
+  case. Common well geometry/profile is parsed per case by the solver; hand it the
+  same objects to reuse them.
+* **Isolation**: one bad case never fails the batch -- each result carries either a
+  value or an error string, in input order.
+
+The API layer (welleng-api) exposes these as a paid batch/sweep endpoint; core owns
+only the loop + amortization + isolation.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Callable, Mapping, Optional, Sequence
+
+from .analytical import AnalyticalKickTolerance, analytical_kick_tolerance
+from .core import KickInputs, KickResult, drill_kick, swab_kick
+
+
+@dataclass
+class BatchCaseResult:
+    """One case's outcome in a batch. Exactly one of ``result``/``error`` is set.
+
+    Attributes
+    ----------
+    index : int
+        Position of this case in the input sequence (results are returned in
+        input order, so ``index`` also equals the list position).
+    result : object or None
+        The solver result (:class:`KickResult` or
+        :class:`AnalyticalKickTolerance`) if the case succeeded, else ``None``.
+    error : str or None
+        ``"<ExceptionType>: <message>"`` if the case raised, else ``None``.
+    """
+    index: int
+    result: Optional[Any] = None
+    error: Optional[str] = None
+
+    @property
+    def ok(self) -> bool:
+        """True if the case produced a result (no error)."""
+        return self.error is None
+
+
+_CLOSED_FORM: dict[str, Callable[[KickInputs], KickResult]] = {
+    "drill": drill_kick,
+    "swab": swab_kick,
+}
+
+
+def solve_batch(
+    inputs: Sequence[KickInputs], *, kind: str = "drill"
+) -> list[BatchCaseResult]:
+    """Closed-form kick tolerance over a batch of cases (``drill`` or ``swab``).
+
+    Each case runs :func:`~welleng.kick_tolerance.core.drill_kick` (or
+    ``swab_kick``) with per-case error isolation, in input order.
+
+    Parameters
+    ----------
+    inputs : sequence of KickInputs
+        The cases to solve.
+    kind : {"drill", "swab"}
+        Which closed-form solver to apply to every case.
+
+    Returns
+    -------
+    list of BatchCaseResult
+        One entry per input, in order; each holds a :class:`KickResult` or an error.
+    """
+    if kind not in _CLOSED_FORM:
+        raise ValueError(f"kind must be one of {sorted(_CLOSED_FORM)}, got {kind!r}")
+    fn = _CLOSED_FORM[kind]
+    out: list[BatchCaseResult] = []
+    for i, inp in enumerate(inputs):
+        try:
+            out.append(BatchCaseResult(i, result=fn(inp)))
+        except Exception as exc:  # per-case isolation: one bad case never fails the batch
+            out.append(BatchCaseResult(i, error=f"{type(exc).__name__}: {exc}"))
+    return out
+
+
+def batch_analytical_kick_tolerance(
+    cases: Sequence[Mapping[str, Any]], *, fluid_table: Any = None
+) -> list[BatchCaseResult]:
+    """Analytical kick tolerance over a batch of cases, sharing one real-gas table.
+
+    Each case is a mapping of keyword arguments for
+    :func:`~welleng.kick_tolerance.analytical.analytical_kick_tolerance` (``sections``,
+    ``pp``, ``fp``, ``bhp_psi``, ``rho_mud_ppg``, ``gas_bh_state``, ...). Cases run
+    serially in input order with per-case error isolation.
+
+    Parameters
+    ----------
+    cases : sequence of mapping
+        Per-case keyword arguments for ``analytical_kick_tolerance``.
+    fluid_table : ZTable, optional
+        A prebuilt real-gas table shared across every case (the amortization: the
+        CoolProp grid is built once, not per case). If a case already specifies its
+        own ``fluid_table`` it is left untouched.
+
+    Returns
+    -------
+    list of BatchCaseResult
+        One entry per case, in order; each holds an
+        :class:`AnalyticalKickTolerance` or an error.
+    """
+    out: list[BatchCaseResult] = []
+    for i, case in enumerate(cases):
+        try:
+            kwargs = dict(case)
+            if fluid_table is not None and kwargs.get("fluid_table") is None:
+                kwargs["fluid_table"] = fluid_table
+            result: AnalyticalKickTolerance = analytical_kick_tolerance(**kwargs)
+            out.append(BatchCaseResult(i, result=result))
+        except Exception as exc:  # per-case isolation
+            out.append(BatchCaseResult(i, error=f"{type(exc).__name__}: {exc}"))
+    return out
+
+
+def sweep_analytical_kick_tolerance(
+    base: Mapping[str, Any], param: str, values: Sequence[Any], *, fluid_table: Any = None
+) -> list[BatchCaseResult]:
+    """Analytical kick tolerance sweeping one parameter of a base case over a grid.
+
+    Convenience over :func:`batch_analytical_kick_tolerance`: expands ``base`` into
+    one case per value of ``param`` (e.g. sweeping ``bhp_psi`` or ``fp``), sharing the
+    ``fluid_table`` across the whole sweep. This is the design-curve / paid-sweep
+    primitive -- one base well parsed against one shared real-gas table.
+
+    Parameters
+    ----------
+    base : mapping
+        Keyword arguments for ``analytical_kick_tolerance`` common to every point.
+    param : str
+        The keyword to vary.
+    values : sequence
+        The grid of values for ``param``; one case is solved per value, in order.
+    fluid_table : ZTable, optional
+        Shared real-gas table (see :func:`batch_analytical_kick_tolerance`).
+
+    Returns
+    -------
+    list of BatchCaseResult
+        One entry per value in ``values``, in order.
+    """
+    cases = [{**base, param: v} for v in values]
+    return batch_analytical_kick_tolerance(cases, fluid_table=fluid_table)


### PR DESCRIPTION
TA0-directed engine work for welleng-api's paid batch/sweep KT feature (spec 2026-07-18). Launch traffic loops 34–88 sequential single-case calls; core now batches them.

## API
- `solve_batch(inputs, kind="drill"|"swab")` — closed-form batch.
- `batch_analytical_kick_tolerance(cases, *, fluid_table=None)` — analytical batch; a prebuilt `ZTable` is **shared across all cases** (build the CoolProp grid once, not per case).
- `sweep_analytical_kick_tolerance(base, param, values, *, fluid_table=None)` — vary one param over a grid on one shared table (= welleng-api's design-curve builder).
- `BatchCaseResult(index, result, error, ok)` — per-case error isolation, input order, `batch[i]` bit-identical to the single call.

## Design (TA1 steer)
**Serial, no core multiprocessing** — solvers are stateless for reads + a built ZTable is read-only, so the API's worker pool parallelizes safely across threads; a library-level process pool would fight FastAPI's and break embedded use.

## Results
- 30-case design-curve sweep: **199 ms** (6.6 ms/case) vs the app's 3 s budget. Benchmarked + logged.
- `tests/test_kick_batch.py` (6): determinism, per-case isolation, sweep, bad-kind. Fully typed (strict mypy override).
- `pytest tests/` → **693 passed**.

Phase 2 (later): P-T-box auto-sizing for `gas_composition` batches. API endpoint is welleng-api's side.

🤖 Generated with [Claude Code](https://claude.com/claude-code)