### PR TITLE
feat(units): fast generic Units boundary converter

### DIFF
--- a/benchmarks/BENCHMARK_LOG.md
+++ b/benchmarks/BENCHMARK_LOG.md
@@ -11,6 +11,23 @@ finding that motivated it.
 
 ---
 
+## 2026-07-18 · `feat/units-converter` · Python 3.12, dev machine
+
+`welleng.units.Units` — the generic, cross-module boundary converter (canonical-SI
+internals; user I/O at the edge; performance-critical callers bypass it entirely):
+
+| operation | Units | pint `Quantity.to()` | speedup |
+|---|---|---|---|
+| scalar convert (ft→m) | **0.24 µs** | 12.1 µs | ~50× |
+
+Design: pint computes the affine `(factor, offset)` per unit pair ONCE at first use
+and caches it; conversion is then pure numpy arithmetic (`value * factor (+ offset)`),
+scalar or array, with **no pint on the hot path**. For 1M-element arrays pint's own
+`.to()` is already numpy-backed (~3 ms, comparable), so the win is on the common
+scalar / small-input boundary case (a header datum, a single DLS) — 50×. Affine units
+(temperature) carry the offset; multiplicative units skip it. Same-unit convert is an
+identity no-op.
+
 ## 2026-07-18 · `feat/mincurve-phase1` · Python 3.12, dev machine
 
 `MinCurve` construction (it becomes the foundational geometry kernel — Survey

--- a/tests/test_units_converter.py
+++ b/tests/test_units_converter.py
@@ -1,0 +1,79 @@
+"""Tests for the fast, generic Units boundary converter (welleng.units.Units)."""
+import math
+
+import numpy as np
+import pytest
+
+from welleng.units import Units, CANONICAL, ureg
+
+
+def test_to_and_from_canonical_roundtrip():
+    u = Units(length="ft", angle="degree", pressure="psi")
+    for quantity, val in [("length", 1234.5), ("angle", 42.0), ("pressure", 5000.0)]:
+        canon = u.to_canonical(val, quantity)
+        assert u.from_canonical(canon, quantity) == pytest.approx(val)
+
+
+def test_canonical_values_are_si():
+    u = Units(length="ft", angle="degree")
+    assert u.to_canonical(1000.0, "length") == pytest.approx(304.8)        # ft -> m
+    assert u.to_canonical(180.0, "angle") == pytest.approx(math.pi)        # deg -> rad
+    assert u.from_canonical(math.pi, "angle") == pytest.approx(180.0)      # rad -> deg
+
+
+def test_generic_convert_pair():
+    u = Units()
+    assert u.convert(1.0, "bar", "pascal") == pytest.approx(1e5)
+    assert u.convert(1.0, "inch", "mm") == pytest.approx(25.4)
+    assert u.convert(1.0, "ppg", "kg/m**3") == pytest.approx(119.826, abs=1e-2)
+
+
+def test_affine_temperature_offset():
+    """Temperature is affine (non-zero offset), not a pure scale."""
+    u = Units()
+    assert u.convert(32.0, "degF", "K") == pytest.approx(273.15)
+    assert u.convert(0.0, "degC", "K") == pytest.approx(273.15)
+    # a pure-scale converter would give 0 K for 32 degF -> guard against that
+    assert u.convert(32.0, "degF", "K") != pytest.approx(0.0)
+
+
+def test_array_conversion_vectorises():
+    u = Units(length="ft")
+    arr = np.array([100.0, 1000.0, 2500.0])
+    out = u.to_canonical(arr, "length")
+    assert isinstance(out, np.ndarray)
+    assert np.allclose(out, arr * 0.3048)
+
+
+def test_same_unit_is_noop_identity():
+    u = Units()
+    x = np.array([1.0, 2.0, 3.0])
+    assert u.convert(x, "meter", "meter") is x        # no copy, no work
+
+
+def test_default_system_is_si_lengths_metric_angles_degrees():
+    u = Units()
+    assert u.system["length"] == "meter"
+    assert u.system["angle"] == "degree"
+    # length already SI -> to_canonical is a passthrough
+    assert u.to_canonical(500.0, "length") == 500.0
+
+
+def test_matches_pint_ground_truth():
+    """The cached-factor result equals a direct pint conversion."""
+    u = Units()
+    for src, dst, val in [("ft", "m", 3280.0), ("psi", "bar", 145.0),
+                          ("degF", "K", 100.0), ("ppg", "sg", 8.345)]:
+        assert u.convert(val, src, dst) == pytest.approx(
+            ureg.Quantity(val, src).to(dst).magnitude
+        )
+
+
+def test_factor_offset_is_cached():
+    u = Units()
+    u.convert(1.0, "ft", "m")
+    assert ("ft", "m") in u._cache
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/welleng/units.py
+++ b/welleng/units.py
@@ -20,12 +20,16 @@ Examples
 >>> round(units.to_rad(units.deg(180)), 6)
 3.141593
 """
-from typing import Union
+from typing import Tuple, Union
 
+import numpy as np
 import pint
 
 ureg: pint.UnitRegistry = pint.UnitRegistry()
 Q_ = ureg.Quantity
+
+# scalar or array value moving through the boundary converter
+Numeric = Union[float, np.ndarray]
 
 # --- custom units -------------------------------------------------------------
 # TODO import custom units from file instead of defining here
@@ -155,3 +159,86 @@ def mud_weight_from_gradient(
 ) -> pint.Quantity:
     """Equivalent mud weight (density) of a hydrostatic gradient, ρ = (dP/dz)/g."""
     return (gradient_q / ureg('standard_gravity')).to(unit)
+
+
+# --- fast boundary converter --------------------------------------------------
+# Canonical SI unit per named quantity. welleng engines compute in these; the
+# `Units` boundary converts user I/O to/from them. Performance-critical callers
+# work in canonical units directly and skip the converter entirely (zero cost);
+# a single-well / interactive user pays one trivial conversion at each edge.
+CANONICAL: dict = {
+    "length": "meter",
+    "angle": "radian",
+    "pressure": "pascal",
+    "density": "kilogram / meter ** 3",
+    "force": "newton",
+    "torque": "newton * meter",
+    "temperature": "kelvin",
+}
+
+# Default user system (metric-ish field defaults); override per-quantity.
+_DEFAULT_SYSTEM: dict = {
+    "length": "meter",
+    "angle": "degree",
+    "pressure": "pascal",
+    "density": "kilogram / meter ** 3",
+    "force": "newton",
+    "torque": "newton * meter",
+    "temperature": "kelvin",
+}
+
+
+class Units:
+    """Fast, generic unit-conversion boundary — pint at setup, numpy at runtime.
+
+    welleng engines compute in canonical SI (see :data:`CANONICAL`). This converts
+    user inputs to canonical on ingest and canonical to user units on output, and
+    ONLY there — performance-critical callers use the canonical core directly and
+    bypass this entirely.
+
+    Speed: the affine ``(factor, offset)`` for each unit pair is computed ONCE via
+    pint and cached; conversion is then pure numpy arithmetic (``value * factor
+    (+ offset)``), scalar or array, with no pint on the hot path. Affine units
+    (e.g. temperature) carry a non-zero offset; multiplicative units do not.
+
+    Generic + reusable across welleng modules (survey, drilling, kick, api).
+
+    Examples
+    --------
+    >>> u = Units(length="ft", angle="degree")
+    >>> round(u.to_canonical(1000.0, "length"), 4)        # ft -> m
+    304.8
+    >>> round(u.from_canonical(3.14159265, "angle"), 3)   # rad -> deg
+    180.0
+    >>> round(u.convert(100.0, "psi", "bar"), 6)          # generic pair
+    6.894757
+    """
+
+    def __init__(self, **system: str) -> None:
+        self.system: dict = {**_DEFAULT_SYSTEM, **system}
+        self._cache: dict = {}
+
+    def _factor_offset(self, src: UnitLike, dst: UnitLike) -> Tuple[float, float]:
+        key = (str(src), str(dst))
+        fo = self._cache.get(key)
+        if fo is None:
+            zero = float(ureg.Quantity(0.0, src).to(dst).magnitude)
+            one = float(ureg.Quantity(1.0, src).to(dst).magnitude)
+            fo = (one - zero, zero)   # affine: y = x * factor + offset
+            self._cache[key] = fo
+        return fo
+
+    def convert(self, value: Numeric, src: UnitLike, dst: UnitLike) -> Numeric:
+        """Convert ``value`` (scalar or ndarray) from ``src`` to ``dst`` units."""
+        if str(src) == str(dst):
+            return value
+        factor, offset = self._factor_offset(src, dst)
+        return value * factor + offset if offset else value * factor
+
+    def to_canonical(self, value: Numeric, quantity: str) -> Numeric:
+        """User-units ``value`` -> canonical SI for the named ``quantity``."""
+        return self.convert(value, self.system[quantity], CANONICAL[quantity])
+
+    def from_canonical(self, value: Numeric, quantity: str) -> Numeric:
+        """Canonical-SI ``value`` -> the user's units for the named ``quantity``."""
+        return self.convert(value, CANONICAL[quantity], self.system[quantity])


### PR DESCRIPTION
The reusable, cross-module unit-conversion boundary for the canonical-SI architecture.

## Contract
welleng engines compute in **canonical SI**; `Units` converts user I/O to/from canonical **only at the edge**. Performance-critical callers use the canonical core directly and **bypass** it (zero cost); interactive/single-well users pay one trivial conversion. Build one `Units` instance for your system and **inject it into calls** (`units=` param) — increment C wires that into Survey.

## Speed
pint computes the affine `(factor, offset)` per unit pair **once** and caches it; conversion is then **pure numpy** (`value * factor (+ offset)`), scalar or array — **no pint on the hot path**. ~**50×** faster than a pint `Quantity` for the common scalar case (0.24 µs vs 12.1 µs). Affine units (temperature) carry the offset; same-unit is an identity no-op.

## Scope
- `Units(**system)` — `to_canonical`/`from_canonical` (named quantities) + generic `convert(value, src, dst)`.
- Generic + reusable across modules (survey, drilling, kick, api).
- Fully typed (strict override), `tests/test_units_converter.py` (9), benchmarked. `pytest tests/` → **715 passed**.

Part of the MinCurve/canonical-SI program (independent of #251). Next: datum→header + header transform (B), then canonical internals + `Units` injection into Survey methods (C).

🤖 Generated with [Claude Code](https://claude.com/claude-code)