### PR TITLE
fix(survey): revert azi_reference default to true (input frame) [0.19.0]

### DIFF
--- a/welleng/survey.py
+++ b/welleng/survey.py
@@ -305,7 +305,7 @@ class SurveyHeader:
         dip: Optional[float] = None,
         declination: Optional[float] = None,
         convergence: float = 0,
-        azi_reference: str = "grid",
+        azi_reference: str = "true",
         vertical_inc_limit: float = 0.0001,
         deg: bool = True,
         depth_unit: str = 'meters',
@@ -361,11 +361,14 @@ class SurveyHeader:
         convergence: float (default: 0)
             The angle of convergence between the projection meridian and
             the line from true north through the location of the well.
-        azi_reference: string (default: 'grid')
-            The reference system for the azimuth angles in the survey data,
-            either "true", "magnetic" or "grid". Default is "grid" -- the
-            engine's canonical frame (positions are computed in grid); it equals
-            "true" when convergence is 0 (the default). Note that survey
+        azi_reference: string (default: 'true')
+            The reference system the INPUT azimuths are given in -- "true",
+            "magnetic" or "grid". This is the input frame, NOT the engine's
+            internal geometry frame: positions are always computed in grid (the
+            canonical frame), converting the input via convergence/declination.
+            A magnetic MWD survey MUST set "magnetic" so declination is applied
+            (and its magnetic error terms are framed correctly); the default
+            "true" assumes true-north input. Note that survey
             calculations are performed in the "grid" reference and
             converted to and from the other systems.
         vertical_inc_limit: float (default 0.0001)


### PR DESCRIPTION
Increment B conflated the engine's internal geometry frame (grid -- correct) with the default INPUT frame. Defaulting the *input* azi_reference to grid assumes grid-referenced input azimuths -- wrong for the common magnetic/true-input surveys, silently skipping declination -> wrong positions + mis-framed magnetic error terms.

Revert the default to `"true"`. Geometry stays grid-canonical internally via conversion. Docstring clarified (azi_reference is the INPUT frame; magnetic surveys must set `"magnetic"`). `pytest tests/` -> **709 passed**. Part of 0.19.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)