### PR TITLE
refactor(clc): pull batch/sweep/grid to welleng-api (closed) [0.19.0 breaking]

### DIFF
--- a/tests/test_sawaryn_analytical.py
+++ b/tests/test_sawaryn_analytical.py
@@ -15,8 +15,8 @@ import pytest
 from welleng.sawaryn_analytical import (
     tangent, _scalars, forward, subtended_angles, solve_clc_analytical, eq15,
     solve_clc_resultant,
-    _eq15_coeffs, solve_clc, solve_clc_batch, solve_clc_2d, max_radius,
-    solve_clc_landing, solve_clc_r_sweep, solve_clc_r_grid, _build_r_scales,
+    _eq15_coeffs, solve_clc, solve_clc_2d, max_radius,
+    solve_clc_landing,
 )
 
 P1 = np.array([8000.0, 8000.0, 6000.0])
@@ -140,39 +140,12 @@ def test_corrected_eq15_vanishes_at_example2_roots():
         assert abs(np.polyval(co[::-1], beta / L)) < 1e-4 * scale
 
 
-def test_solve_clc_batch_reproduces_example2():
-    out = solve_clc_batch(P1[None], T1[None], P4[None], T4[None], R1, R2,
-                          return_all=True)
-    betas = sorted(out['beta'][0][out['valid'][0]])
-    assert len(betas) == 4
-    for got, exp in zip(betas, [1072.6, 1630.2, 1789.95, 2356.9]):
-        assert got == pytest.approx(exp, abs=0.2)
-
-
 def test_solve_clc_default_returns_shortest():
     shortest = solve_clc(P1, T1, P4, T4, R1, R2)                 # default
     allsol = solve_clc(P1, T1, P4, T4, R1, R2, return_all=True)
     assert len(allsol) == 4
     assert shortest['total_md'] == pytest.approx(min(s['total_md'] for s in allsol))
     assert shortest['beta'] == pytest.approx(1072.6, abs=0.2)
-
-
-def test_solve_clc_batch_constructed_recovery():
-    # build CLC paths, the solver must return the build tangent length for each.
-    rng = np.random.default_rng(2024)
-    N = 60
-    P4s, T4s, truth = [], [], []
-    for _ in range(N):
-        dl1, tf1, dl2, tf2, d = (rng.uniform(0.3, 2.0), rng.uniform(-np.pi, np.pi),
-                                 rng.uniform(0.3, 2.0), rng.uniform(-np.pi, np.pi),
-                                 rng.uniform(0.3, 1.5))
-        p3, v3 = _build_clc(dl1, tf1, dl2, tf2, d)
-        P4s.append(p3); T4s.append(v3); truth.append(d)
-    O = np.zeros((N, 3)); V = np.tile([0, 0, 1.], (N, 1))
-    out = solve_clc_batch(O, V, np.array(P4s), np.array(T4s), 1.0, 1.0, return_all=True)
-    rec = sum(bool(np.any(out['valid'][i] & (np.abs(out['beta'][i] - truth[i]) < 1e-2)))
-              for i in range(N))
-    assert rec == N
 
 
 def test_solve_clc_2d_handles_planar_and_parallel():
@@ -271,10 +244,6 @@ def test_r2_defaults_to_r1():
     a = solve_clc(O, V, p4, t4, R1, return_all=True)
     b = solve_clc(O, V, p4, t4, R1, R1, return_all=True)
     assert [round(s['beta'], 6) for s in a] == [round(s['beta'], 6) for s in b]
-    P, T = np.array([[0., 0, 0]]), np.array([[0., 0, 1.]])
-    d = solve_clc_batch(P, T, p4[None], t4[None], R1)
-    e = solve_clc_batch(P, T, p4[None], t4[None], R1, R1)
-    assert np.allclose(d['total_md'], e['total_md'], equal_nan=True)
 
 
 def test_max_radius_gentlest_feasible():
@@ -342,17 +311,6 @@ def test_parallel_and_antiparallel_tangents_handled():
         s = solve_clc(O, t1, p4, t4, 1.0, 1.0)                # must not raise
         assert s is not None
         assert recon(t1, t4, p4, s) < 1e-6
-        fb = solve_clc_batch([O], [t1], [p4], [t4], 1.0, 1.0)  # batch must not raise
-        assert fb['found'][0]
-        assert abs(fb['total_md'][0] - s['total_md']) < 1e-6
-    # a mixed batch (antiparallel + general) must not crash on the degenerate row
-    mb = solve_clc_batch(
-        np.array([[0., 0, 0], [8000., 8000, 6000]]),
-        np.array([[0., 0, 1.], tangent(75, 15)]),
-        np.array([[1.5, 0, -1.], [9500., 8800, 6500]]),
-        np.array([[0., 0, -1.], tangent(85, 30)]),
-        np.array([1.0, 1250.]), np.array([1.0, 1750.]))
-    assert mb['found'][0] and mb['found'][1]
 
 
 def test_max_radius_parallel_tangents():
@@ -393,103 +351,3 @@ def test_landing_reproduces_example4():
     assert np.allclose(s['p4'], [533.30, -194.11, 3280.8], atol=0.15)
 
 
-def test_build_r_scales_snaps_design():
-    # linspace of scale factors, with the design (1.0) snapped in when bracketed
-    s = _build_r_scales(0.9, 1.1, 11)
-    assert len(s) == 11
-    assert s[0] == 0.9 and s[-1] == 1.1
-    assert np.any(s == 1.0)                              # design radius present
-    # range not bracketing 1.0 -> no snap
-    assert not np.any(_build_r_scales(1.1, 1.3, 5) == 1.0)
-
-
-def test_r_sweep_feature():
-    # a feature (not new maths): the fixed-radius solver run over a radius range
-    # (given as scale factors on the design radii) in one batched call. The
-    # design radius is always in the sweep; feasible up to max_radius.
-    R1d, R2d = 1250., 1750.
-    sw = solve_clc_r_sweep(P1, T1, P4, T4, R1d, R2d,
-                           scale_min=0.9, scale_max=1.1, n_steps=11)
-    di = sw['design_index']
-    # design row: scale 1.0, actual design radii, matches a direct solve
-    assert sw['scale'][di] == 1.0
-    assert sw['radius1'][di] == R1d and sw['radius2'][di] == R2d
-    s0 = solve_clc(P1, T1, P4, T4, R1d, R2d)
-    assert abs(s0['total_md'] - sw['total_md'][di]) < 1e-6
-    # R2/R1 ratio preserved across the sweep
-    assert np.allclose(sw['radius2'] / sw['radius1'], R2d / R1d)
-    # gentler curve costs MD (monotone in scale); doglegs renderable (<= pi)
-    assert np.all(sw['feasible'])
-    assert np.all(np.diff(sw['total_md']) > 0)
-    assert np.all(sw['alpha1'] <= np.pi + 1e-9)
-    assert np.all(sw['alpha2'] <= np.pi + 1e-9)
-    # every feasible row matches a direct solve at that radius
-    for i in range(len(sw['scale'])):
-        s = solve_clc(P1, T1, P4, T4, sw['radius1'][i], sw['radius2'][i])
-        assert abs(s['total_md'] - sw['total_md'][i]) < 1e-6
-
-    # explicit `values` path: full range incl R=0 and past the critical radius
-    Rmax = max_radius(P1, T1, P4, T4)['radius']
-    chord = np.linalg.norm(P4 - P1)
-    swv = solve_clc_r_sweep(P1, T1, P4, T4, 1250.,
-                            values=[0.0, 500., Rmax * 0.98, Rmax * 1.03])
-    # R = 0 -> pure tangent: beta = MD = chord (arcs collapse to instant turns)
-    assert swv['feasible'][0]
-    assert abs(swv['beta'][0] - chord) < 1e-9
-    assert abs(swv['total_md'][0] - chord) < 1e-9
-    # feasible below the critical radius, infeasible above it
-    assert swv['feasible'][:-1].all()
-    assert not swv['feasible'][-1]
-    assert np.isnan(swv['total_md'][-1])
-
-    # scales and values are mutually exclusive
-    with pytest.raises(ValueError):
-        solve_clc_r_sweep(P1, T1, P4, T4, 1250., scales=[1.0], values=[1250.])
-
-
-def test_r_sweep_planar_vertical_s_trap():
-    # Parallel-tangent (|mu|=1) vertical S: the general form is singular, so the
-    # batch must route these rows to solve_clc_2d (else the sweep wrongly reports
-    # infeasible). And the operational trap: a clean 90/90 S at the design radius
-    # becomes INFEASIBLE if the radius is raised ~10% (the drillable S vanishes;
-    # only >pi loops remain), while reducing R keeps it feasible and simpler.
-    O = np.array([0., 0., 0.]); t1 = np.array([1., 0., 0.]); t4 = np.array([1., 0., 0.])
-    p4 = np.array([2., 0., 3.])                          # a 90/90 S at R = 1.0
-    assert abs(t1 @ t4) == 1.0                           # exactly parallel (mu=1)
-
-    # the singular row is handled, not skipped: batch agrees with the 2D solver
-    fb = solve_clc_batch([O], [t1], [p4], [t4], 1.0, 1.0)
-    s2 = solve_clc_2d(O, t1, p4, t4, 1.0, 1.0)
-    assert fb['found'][0] and s2 is not None
-    assert abs(fb['total_md'][0] - s2['total_md']) < 1e-6
-    assert abs(np.degrees(fb['alpha1'][0]) - 90.0) < 0.5
-
-    sw = solve_clc_r_sweep(O, t1, p4, t4, 1.0, values=[0.8, 1.0, 1.1])
-    # reduce R -> feasible and gentler; design -> feasible ~90 deg
-    assert sw['feasible'][0] and sw['feasible'][1]
-    assert np.degrees(sw['alpha1'][0]) < np.degrees(sw['alpha1'][1])  # smaller R, smaller dogleg
-    assert abs(np.degrees(sw['alpha1'][1]) - 90.0) < 0.5
-    # raise R ~10% -> no drillable S (only >pi loops); the trap
-    assert not sw['feasible'][2]
-    assert np.isnan(sw['total_md'][2])
-
-
-def test_r_grid_independent_axes():
-    # independent R1 x R2 sweep: a 2D grid, one batched solve, design cell exact.
-    R1d, R2d = 1250., 1750.
-    g = solve_clc_r_grid(P1, T1, P4, T4, R1d, R2d,
-                         scale_min=0.8, scale_max=1.2, n_steps=9)
-    i, j = g['design_index']
-    K1, K2 = len(g['r1_scales']), len(g['r2_scales'])
-    assert g['feasible'].shape == (K1, K2) == g['total_md'].shape
-    # design cell = (1.0, 1.0) -> the design radii, matching a direct solve
-    assert g['r1_scales'][i] == 1.0 and g['r2_scales'][j] == 1.0
-    assert g['radius1'][i] == R1d and g['radius2'][j] == R2d
-    s = solve_clc(P1, T1, P4, T4, R1d, R2d)
-    assert g['feasible'][i, j]
-    assert abs(g['total_md'][i, j] - s['total_md']) < 1e-6
-    # axis 0 is R1, axis 1 is R2: an off-diagonal cell matches its direct solve
-    assert abs(g['total_md'][0, -1] -
-               solve_clc(P1, T1, P4, T4, g['radius1'][0], g['radius2'][-1])['total_md']) < 1e-6
-    # NaN exactly where infeasible
-    assert np.all(np.isnan(g['total_md'][~g['feasible']]))

--- a/welleng/sawaryn_analytical.py
+++ b/welleng/sawaryn_analytical.py
@@ -28,10 +28,8 @@ retained only to document that trap (see ``test_eq15_is_trapped``).
 The correct degree-10 coefficients were re-derived by replicating Sawaryn's own
 surd-elimination (Appendix B: the half-angle quadratics B-15/B-16 and the
 bilinear constraint B-19), eliminating the surds symbolically (``_eq15_coeffs``).
-These power the vectorised closed-form solvers ``solve_clc`` (single pair) and
-``solve_clc_batch`` (batched, ~0.02 ms/solve via companion-matrix eigenvalues),
-which return *every* CLC solution and reproduce Example 2 of SPE-204111-PA
-exactly. Subtended angles are reported as the true dogleg in [0, 2*pi) so the
+These power the vectorised closed-form solver ``solve_clc``, which returns
+*every* CLC solution and reproduces Example 2 of SPE-204111-PA exactly. Subtended angles are reported as the true dogleg in [0, 2*pi) so the
 measured depth ranks solutions correctly. Planar (eta14 ~ 0) and parallel-
 tangent (|mu| = 1) cases are handled by ``solve_clc_2d`` (the paper's biquadratic
 2D form). Forward-verified solvers (``solve_clc_analytical`` scan,
@@ -44,8 +42,8 @@ that welleng's ``Connector`` inherits.
 Citation
 --------
 Use of this work requires citation. Cite Sawaryn (2021, SPE-204111-PA) for the
-underlying mathematics, and — for any use of *this* (welleng's) implementation,
-its corrected coefficients, or its sweep/feasibility tooling — you must also cite
+underlying mathematics, and — for any use of *this* (welleng's) implementation
+or its corrected coefficients — you must also cite
 welleng (software concept DOI 10.5281/zenodo.20968887) and the welleng
 analytical-CLC paper:
 
@@ -229,8 +227,8 @@ def eq15(beta, psi2, eta1, eta4, eta14, mu, R1, R2):
 def solve_clc_resultant(p1, t1, p4, t4, R1, R2=None):
     """Complete CLC solve via per-instance resultant elimination.
 
-    Independent cross-check for the vectorised ``solve_clc`` / ``solve_clc_batch``
-    (exercised in the test suite); not on welleng's hot path.
+    Independent cross-check for the vectorised ``solve_clc`` (exercised in the
+    test suite); not on welleng's hot path.
 
     Eliminates the two half-angle tangents from Sawaryn's clean forward
     equations (11-13) by exact-rational resultants -> a polynomial in beta whose
@@ -253,7 +251,7 @@ def solve_clc_resultant(p1, t1, p4, t4, R1, R2=None):
         raise ImportError(
             "solve_clc_resultant needs python-flint with rational multivariate "
             "polynomials (flint.fmpq_mpoly_ctx); this build lacks it. It is only an "
-            "independent cross-check — use solve_clc / solve_clc_batch to solve.")
+            "independent cross-check — use solve_clc to solve.")
     flint.ctx.prec = 400
     psi2, eta1, eta4, eta14, mu = _scalars(p1, t1, p4, t4)
     L = np.sqrt(psi2)                              # characteristic length -> O(1) coeffs
@@ -450,60 +448,6 @@ def _clc_solutions(P1, T1, P4, T4, R1, R2):
     a2b = a2b % (2 * np.pi)
     md = R1b * a1b + b + R2b * a2b
     return b, a1b, a2b, md, valid
-
-
-def solve_clc_batch(P1, T1, P4, T4, R1, R2=None, return_all=False):
-    """Vectorised CLC point-to-target solve via the corrected Eq. 15 closed form.
-
-    Batched over N station pairs, no Python loop: invariants (einsum) ->
-    Eq. 15 coefficients -> roots (batched companion eigvals) -> forward-verify.
-    ~0.02 ms/solve, the only solver here that vectorises.
-
-    Parameters
-    ----------
-    P1, T1, P4, T4 : (N, 3) — kickoff/target positions and unit tangents.
-    R1, R2 : float or (N,) — first/second arc radii (``R2`` defaults to ``R1``).
-    return_all : bool, default False
-        False -> the SHORTEST (min total-MD) solution per pair.
-        True  -> every valid CLC solution per pair.
-
-    Returns
-    -------
-    dict of numpy arrays:
-        return_all=False : ``beta, alpha1, alpha2, total_md`` each (N,), plus
-            ``found`` (N,) bool (False where no CLC exists).
-        return_all=True  : ``beta, alpha1, alpha2, total_md`` each (N, 10), plus
-            ``valid`` (N, 10) bool.
-
-    Assumes the general case ``|mu| < 1``, ``eta14 != 0``; route degenerate
-    (planar / parallel-tangent) pairs to :func:`solve_clc_2d`.
-    """
-    R2 = R1 if R2 is None else R2
-    P1, T1, P4, T4 = (np.asarray(a, float) for a in (P1, T1, P4, T4))
-    N = len(P1)
-    R1a = np.broadcast_to(np.asarray(R1, float), (N,))
-    R2a = np.broadcast_to(np.asarray(R2, float), (N,))
-    b, a1, a2, md, valid = _clc_solutions(P1, T1, P4, T4, R1a, R2a)
-    # Parallel / antiparallel tangents (|mu| = 1) make the general form singular
-    # (it carries a 1/sqrt(1 - mu^2)); route those rows to the planar 2D solver
-    # and splice them in, so batched callers (e.g. solve_clc_r_sweep) handle the
-    # common planar vertical-S case rather than reporting it infeasible.
-    mu = np.einsum('ij,ij->i', T1, T4)
-    for i in np.nonzero(np.abs(mu) > 1 - 1e-9)[0]:
-        b[i], a1[i], a2[i], md[i], valid[i] = 0.0, 0.0, 0.0, 0.0, False
-        for s_idx, s in enumerate(solve_clc_2d(P1[i], T1[i], P4[i], T4[i],
-                                               R1a[i], R2a[i], return_all=True)[:10]):
-            b[i, s_idx], a1[i, s_idx] = s['beta'], s['alpha1']
-            a2[i, s_idx], md[i, s_idx] = s['alpha2'], s['total_md']
-            valid[i, s_idx] = True
-    if return_all:
-        return dict(beta=b, alpha1=a1, alpha2=a2, total_md=md, valid=valid)
-    mdm = np.where(valid, md, np.inf)
-    j = np.argmin(mdm, axis=1)                       # shortest valid per pair
-    take = lambda X: np.take_along_axis(X, j[:, None], 1)[:, 0]
-    found = np.isfinite(take(mdm))
-    return dict(beta=take(b), alpha1=take(a1), alpha2=take(a2),
-                total_md=take(md), found=found)
 
 
 # TODO (max-radius solver): when no renderable CLC exists at the given radii,
@@ -807,181 +751,3 @@ def solve_clc_landing(p1, t1, p0, t4, R1, R2=None, return_all=False):
     return feas[0] if feas else None
 
 
-def _build_r_scales(scale_min, scale_max, n_steps):
-    """Linspace of scale factors with the nearest value snapped to exactly 1.0.
-
-    Snapping guarantees the *design* radius (scale 1.0) is one of the swept
-    values whenever the range brackets it.
-    """
-    if n_steps <= 1 or scale_min == scale_max:
-        return np.array([float(scale_min)])
-    scales = np.linspace(float(scale_min), float(scale_max), int(n_steps))
-    if scale_min <= 1.0 <= scale_max:
-        scales[int(np.argmin(np.abs(scales - 1.0)))] = 1.0
-    return scales
-
-
-def solve_clc_r_sweep(p1, t1, p4, t4, R1, R2=None,
-                      scale_min=0.75, scale_max=1.25, n_steps=11,
-                      scales=None, values=None):
-    """Sweep the design radius: the min-MD CLC over a range of radii, batched.
-
-    A convenience *feature* (not new mathematics): the fixed-radius solver of
-    :func:`solve_clc` evaluated over a range of radii in ONE vectorised
-    :func:`solve_clc_batch` call (only the radii change). Both arc radii are
-    scaled by a common factor, so ``R2/R1`` is preserved and the sweep is 1-D in
-    the design radius. Per radius it returns the shortest solution whose two arc
-    doglegs are both ``<= pi`` (the renderable one), or marks it infeasible; the
-    feasible range is bounded above by :func:`max_radius`.
-
-    The range is a set of *scale factors* on the design radii — as
-    ``(scale_min, scale_max, n_steps)`` (a linspace), or explicit ``scales``, or
-    explicit radius ``values`` (converted to scales of ``R1``). The **design
-    radii (scale 1.0) are always included** when the range brackets them
-    (snap-to-1.0), so the sweep always contains the as-designed solution;
-    ``design_index`` locates it. Unlike a per-instance solver there is no
-    per-radius frame normalisation — the batch solves every radius in the world
-    frame at once.
-
-    Lets a caller trade dogleg severity against measured depth, or recover a
-    feasible radius when the design DLS fails.
-
-    Parameters
-    ----------
-    p1, t1, p4, t4 : (3,) array_like
-        Kickoff / target positions and unit tangents (N, E, V).
-    R1 : float
-        Design arc-1 radius.
-    R2 : float, optional
-        Design arc-2 radius; defaults to ``R1``.
-    scale_min, scale_max : float
-        Range of scale factors applied to the design radii (default 0.75 .. 1.25,
-        the typical +/-25% design spread).
-    n_steps : int
-        Number of scale steps, linspace endpoints inclusive (default 11).
-    scales : array_like, optional
-        Explicit scale factors (overrides ``scale_min/max/n_steps``).
-    values : array_like, optional
-        Explicit ``R1`` radius values (overrides ``scales``; converted to scales
-        ``R/R1`` so ``R2`` tracks at the design ratio). Mutually exclusive with
-        ``scales``.
-
-    Returns
-    -------
-    dict of ndarrays (one entry per swept radius)
-        ``scale``, ``radius1`` (R1*scale), ``radius2`` (R2*scale),
-        ``design_index`` (int — the scale==1.0 row, or nearest), ``feasible``
-        (bool), and ``beta``, ``alpha1``, ``alpha2``, ``total_md`` (NaN where
-        infeasible). ``R = 0`` collapses to the straight tangent
-        (``beta = total_md = chord``). Parallel-tangent (``|mu| = 1``) rows — the
-        planar vertical S — are routed to :func:`solve_clc_2d` by the batch, so
-        they are handled, not skipped.
-    """
-    R2 = R1 if R2 is None else R2
-    if scales is not None and values is not None:
-        raise ValueError("scales and values are mutually exclusive")
-    if values is not None:
-        scales = np.asarray(values, float) / R1
-    elif scales is not None:
-        scales = np.asarray(scales, float)
-    else:
-        scales = _build_r_scales(scale_min, scale_max, n_steps)
-    scales = np.atleast_1d(scales)
-    R1s, R2s = R1 * scales, R2 * scales
-    n = len(scales)
-    P1 = np.broadcast_to(np.asarray(p1, float), (n, 3))
-    T1 = np.broadcast_to(np.asarray(t1, float), (n, 3))
-    P4 = np.broadcast_to(np.asarray(p4, float), (n, 3))
-    T4 = np.broadcast_to(np.asarray(t4, float), (n, 3))
-    R1b = np.where(R1s > 1e-12, R1s, 1e-12)              # keep R=0 out of the batch
-    R2b = np.where(R2s > 1e-12, R2s, 1e-12)
-    res = solve_clc_batch(P1, T1, P4, T4, R1b, R2b, return_all=True)
-    b, a1, a2, md, valid = (res['beta'], res['alpha1'], res['alpha2'],
-                            res['total_md'], res['valid'])
-    pi = np.pi + 1e-9
-    ok = valid & (a1 <= pi) & (a2 <= pi)                 # renderable (<= pi) roots
-    mdm = np.where(ok, md, np.inf)
-    j = np.argmin(mdm, axis=1)                           # shortest renderable per R
-    take = lambda X: np.take_along_axis(X, j[:, None], 1)[:, 0]
-    feasible = np.isfinite(take(mdm))
-    nan_if = lambda X: np.where(feasible, take(X), np.nan)
-    out = dict(scale=scales, radius1=R1s, radius2=R2s,
-               design_index=int(np.argmin(np.abs(scales - 1.0))),
-               feasible=feasible.copy(),
-               beta=nan_if(b), alpha1=nan_if(a1), alpha2=nan_if(a2),
-               total_md=nan_if(md))
-    # R = 0 collapses to a pure tangent: zero-length arcs (instant turns), the
-    # straight line p1->p4. beta = chord, MD = chord, arc doglegs = the turns.
-    zero = R1s <= 1e-12
-    if zero.any():
-        dp = np.asarray(p4, float) - np.asarray(p1, float)
-        chord = float(np.linalg.norm(dp))
-        dph = dp / chord if chord > 0 else dp
-        a1z = float(np.arccos(np.clip(np.asarray(t1, float) @ dph, -1, 1)))
-        a2z = float(np.arccos(np.clip(dph @ np.asarray(t4, float), -1, 1)))
-        for key, val in (('feasible', True), ('beta', chord), ('total_md', chord),
-                         ('alpha1', a1z), ('alpha2', a2z)):
-            out[key][zero] = val
-    return out
-
-
-def solve_clc_r_grid(p1, t1, p4, t4, R1, R2=None,
-                     scale_min=0.75, scale_max=1.25, n_steps=11,
-                     r1_scales=None, r2_scales=None):
-    """Sweep ``R1`` and ``R2`` *independently* — the min-MD CLC over a 2D grid.
-
-    The general case of :func:`solve_clc_r_sweep`: instead of scaling both radii
-    together, ``R1`` and ``R2`` are swept on independent axes, giving the full
-    ``K1 x K2`` reachability picture (e.g. asymmetry can buy back feasibility a
-    coupled sweep misses). No new mathematics — the closed form already solves
-    asymmetric radii; this is one batched :func:`solve_clc_batch` call over the
-    flattened grid (mu=1 rows routed to the 2D solver automatically).
-
-    Parameters
-    ----------
-    p1, t1, p4, t4 : (3,) array_like
-        Kickoff / target positions and unit tangents (N, E, V).
-    R1 : float
-        Design arc-1 radius. ``R2`` defaults to ``R1``.
-    R2 : float, optional
-        Design arc-2 radius.
-    scale_min, scale_max, n_steps : float, float, int
-        Scale-factor range applied to BOTH axes when explicit scales are not
-        given (default 0.75 .. 1.25, 11 steps; design 1.0 snapped in per axis).
-    r1_scales, r2_scales : array_like, optional
-        Explicit per-axis scale factors (override ``scale_min/max/n_steps``).
-
-    Returns
-    -------
-    dict
-        ``r1_scales`` (K1,), ``r2_scales`` (K2,), ``radius1`` (K1,),
-        ``radius2`` (K2,); ``feasible`` and ``beta``, ``alpha1``, ``alpha2``,
-        ``total_md`` each (K1, K2) with axis 0 = ``R1`` and axis 1 = ``R2`` (NaN
-        where infeasible); ``design_index`` = (i, j) of the ``(1.0, 1.0)`` cell.
-    """
-    R2 = R1 if R2 is None else R2
-    s1 = _build_r_scales(scale_min, scale_max, n_steps) if r1_scales is None else np.atleast_1d(np.asarray(r1_scales, float))
-    s2 = _build_r_scales(scale_min, scale_max, n_steps) if r2_scales is None else np.atleast_1d(np.asarray(r2_scales, float))
-    R1v, R2v = R1 * s1, R2 * s2
-    K1, K2 = len(s1), len(s2)
-    G1, G2 = np.meshgrid(R1v, R2v, indexing='ij')       # (K1, K2)
-    R1f, R2f = G1.ravel(), G2.ravel()
-    n = K1 * K2
-    P1 = np.broadcast_to(np.asarray(p1, float), (n, 3))
-    T1 = np.broadcast_to(np.asarray(t1, float), (n, 3))
-    P4 = np.broadcast_to(np.asarray(p4, float), (n, 3))
-    T4 = np.broadcast_to(np.asarray(t4, float), (n, 3))
-    res = solve_clc_batch(P1, T1, P4, T4, R1f, R2f, return_all=True)
-    b, a1, a2, md, valid = (res['beta'], res['alpha1'], res['alpha2'],
-                            res['total_md'], res['valid'])
-    pi = np.pi + 1e-9
-    mdm = np.where(valid & (a1 <= pi) & (a2 <= pi), md, np.inf)
-    j = np.argmin(mdm, axis=1)                           # shortest renderable per cell
-    take = lambda X: np.take_along_axis(X, j[:, None], 1)[:, 0].reshape(K1, K2)
-    feasible = np.isfinite(take(mdm))
-    nan_if = lambda X: np.where(feasible, take(X), np.nan)
-    return dict(r1_scales=s1, r2_scales=s2, radius1=R1v, radius2=R2v,
-                design_index=(int(np.argmin(np.abs(s1 - 1.0))),
-                              int(np.argmin(np.abs(s2 - 1.0)))),
-                feasible=feasible, beta=nan_if(b),
-                alpha1=nan_if(a1), alpha2=nan_if(a2), total_md=nan_if(md))


### PR DESCRIPTION
## What

Pulls the commercial-grade batched CLC solvers from open welleng into the closed **welleng-api**, consistent with the kick batch pull (#253).

**Removed (public API):**
- `solve_clc_batch` — vectorised many-pair companion-matrix solve
- `solve_clc_r_sweep` / `solve_clc_r_grid` / `_build_r_scales` — radius feasibility sweep

**Kept (open reference engine):**
- `_clc_solutions` — vectorised core (drives scalar `solve_clc`)
- `solve_clc`, `solve_clc_2d`, `max_radius`, `solve_clc_landing`, `solve_clc_resultant`

## Why

Open-core / oracle model: open welleng = the validated reference engine (scalar closed-form, proven exact vs SPE-204111-PA Example 2); commercial-grade throughput (batched solve + radius sweep) ships in welleng-api. Closed speed, open proof.

## Compatibility

- Scalar `solve_clc` is **unchanged** — it already drove `_clc_solutions` directly, never `solve_clc_batch`.
- **BREAKING (0.19.0):** `solve_clc_batch` / `solve_clc_r_sweep` / `solve_clc_r_grid` are no longer public.

## Checks

- Full suite green — 703 passed, 7 skipped, 3 xfailed.
- Leak review PASS.
- Grep-clean of removed symbols across `welleng/` + `tests/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)