### PR TITLE
chore(0.19): non-breaking tidies — modern RNG + dedicated [viz] extras

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -66,6 +66,13 @@ easy = [
     "vedo",
     "vtk",
 ]
+# The 3D renderer (welleng.visual) -- vedo + the VTK backend. Guarded/optional:
+# `import welleng` runs without it (visual.py catches the ImportError), so
+# API/headless/CI installs stay VTK-free. Install `welleng[viz]` for plotting.
+viz = [
+    "vedo",
+    "vtk",
+]
 analytical = [
     "python-flint",
 ]
@@ -90,6 +97,8 @@ all = [
     "tabulate",
     "trimesh",
     "utm",
+    "vedo",                 # viz renderer (was missing from [all])
+    "vtk",
     "python-fcl",
     "rtree",
     "python-flint",

--- a/welleng/connector.py
+++ b/welleng/connector.py
@@ -24,6 +24,11 @@ from .utils import (
     radius_from_dls, get_arc
 )
 
+# Module-level Generator for the degeneracy jitter in `_mod_pos` (nudges a
+# straight-ahead target off the hold/curve ambiguity). Uses NumPy's modern
+# `default_rng` rather than the legacy global `np.random.random` singleton.
+_RNG = np.random.default_rng()
+
 
 class Connector:
     """Solves minimum-MD wellbore trajectories between two survey stations.
@@ -961,7 +966,7 @@ class Connector:
         return interpolate_well([self], step)
 
     def _mod_pos(self, pos: np.ndarray) -> None:
-        pos_rand = np.random.random(3)  # * self.delta_radius
+        pos_rand = _RNG.random(3)  # * self.delta_radius
         pos += pos_rand
 
     def _get_distances(


### PR DESCRIPTION
Two non-breaking hygiene items folded into 0.19.0.

## RNG
`connector._mod_pos` used the legacy global `np.random.random` singleton → now a module-level `np.random.default_rng()` Generator. Behaviour-identical (it's the degeneracy jitter nudging a straight-ahead target off the hold/curve ambiguity); single caller, no seeded baseline depends on it.

## `[viz]` extras
- New `viz = ["vedo", "vtk"]` optional-deps group → `pip install welleng[viz]` for just the 3D renderer. vedo/vtk are already optional (`visual.py` guards the import, `import welleng` is VTK-free), so this is ergonomics, not a dependency change.
- Added vedo/vtk to `[all]`, which was silently missing the renderer.

## Checks
- pyproject parses; `viz` present; `[all]` now has vedo/vtk.
- `import welleng.connector` OK, `_RNG` is a `Generator`.
- Connector suite green (13 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)