### PR TITLE
perf(clearance): Mahalanobis SF via batched solve, not eigh (3× single-pair)

### DIFF
--- a/benchmarks/BENCHMARK_LOG.md
+++ b/benchmarks/BENCHMARK_LOG.md
@@ -294,3 +294,24 @@ Exactness (vs 4000-sample/arc reference over 3000 random arcs incl. reflex):
 inclination extrema max err 2.8e-5 rad; azimuth swing max err 1.8e-15 (azimuth is
 strictly monotonic along a circular arc -> extrema at endpoints, signed swing via
 an analytic branch-crossing count). `tests/test_arc_extrema.py` (6).
+
+## 2026-07-19 · `perf/mahalanobis-solve` · Python 3.12, dev machine
+
+MahalanobisClearance combined-metric quadratic form dp^T S^{-1} dp: was a full
+eigendecomposition per station (`np.linalg.eigh`, ~85% of the 4.1 s/pair path at
+N=2000). When sigma_pa > 0 (operational default 0.5), S = (PSD covariances) +
+sigma_pa^2 I is strictly positive-definite, so the form is a direct batched
+`np.linalg.solve` — identical to floating tolerance, ~3x cheaper. The eigh path
+is kept only for sigma_pa == 0 (a zero-variance direction must read +inf =
+"clear"); a shared `_quad_form_inv` branches on sigma_pa.
+
+| N (station pair) | eigh (old) | solve (new) | speedup |
+|---|---|---|---|
+| 800 | 754.1 ms | **247.1 ms** | **3.05×** |
+
+Parity (tests/test_clearance_mahalanobis_solve, 5): the solve form equals the
+eigh form for random SPD S (max rel err 5e-15); end-to-end SF is unchanged vs a
+forced-eigh reference (max abs err 1.8e-15, +inf clear-direction mask identical);
+the sigma_pa == 0 fallback preserves the degenerate +inf semantics. The remaining
+clearance lever (the O(n^2) broadphase + the IscwsaClearance per-station scipy
+closest-point search) is tracked separately.

--- a/tests/test_clearance_mahalanobis_solve.py
+++ b/tests/test_clearance_mahalanobis_solve.py
@@ -1,0 +1,98 @@
+"""MahalanobisClearance quadratic-form fast path (perf/mahalanobis-solve).
+
+The combined-metric quadratic form dp^T S^{-1} dp was computed via a full
+eigendecomposition per station. When sigma_pa > 0 (operational default 0.5), S
+is strictly positive-definite, so a direct linear solve gives the identical form
+~3x faster; the eigh path is retained only for the sigma_pa == 0 degenerate case
+(a zero-variance direction must read as +inf = "clear"). These tests pin: the
+solve path equals the eigh path for SPD S, the fallback keeps the +inf
+semantics, and the end-to-end SF is unchanged vs a forced-eigh reference.
+"""
+import numpy as np
+import pytest
+
+from welleng.survey import Survey, SurveyHeader
+from welleng.clearance import MahalanobisClearance
+
+
+def _survey(n, shift):
+    md = np.linspace(0, 30 * (n - 1), n)
+    inc = np.clip(np.linspace(0, 90, n), 0, 60)
+    azi = (np.linspace(0, 120, n) + shift) % 360
+    return Survey(md=md, inc=inc, azi=azi, header=SurveyHeader(),
+                  error_model="ISCWSA MWD Rev5.11")
+
+
+def _clearance(sigma_pa=0.5, n=60):
+    return MahalanobisClearance(_survey(n, 0.0), _survey(n, 8.0),
+                                sigma_pa=sigma_pa)
+
+
+def _eigh_quad_form(S, dp):
+    """The previous (eigendecomposition) implementation, verbatim, as reference."""
+    vals, vecs = np.linalg.eigh(S)
+    proj = np.einsum('...ji,...j->...i', vecs, dp)
+    with np.errstate(divide='ignore', invalid='ignore'):
+        terms = np.where(vals > 0, proj ** 2 / vals, np.inf)
+    terms = np.where(np.isclose(proj, 0.0), 0.0, terms)
+    return np.sum(terms, axis=-1)
+
+
+def test_default_sigma_pa_uses_fast_path():
+    assert _clearance().sigma_pa == 0.5  # > 0 -> solve path
+
+
+def test_solve_path_equals_eigh_for_spd():
+    c = _clearance()  # sigma_pa > 0 -> fast solve path
+    rng = np.random.default_rng(0)
+    A = rng.normal(size=(400, 3, 3))
+    S = np.einsum('oij,okj->oik', A, A) + 0.5 * np.eye(3)   # SPD
+    dp = rng.normal(size=(400, 3))
+    fast = c._quad_form_inv(S, dp)
+    ref = _eigh_quad_form(S, dp)
+    assert np.allclose(fast, ref, rtol=1e-9, atol=1e-12)
+
+
+def test_scalar_and_batched_agree():
+    c = _clearance()
+    rng = np.random.default_rng(1)
+    A = rng.normal(size=(3, 3))
+    S = A @ A.T + 0.5 * np.eye(3)
+    dp = rng.normal(size=3)
+    scalar = float(c._quad_form_inv(S, dp))
+    batched = c._quad_form_inv(S[None], dp[None])[0]
+    assert np.isclose(scalar, batched, rtol=1e-12)
+
+
+def test_fallback_preserves_inf_clear_direction():
+    # sigma_pa == 0 -> eigh fallback. A rank-deficient S (zero variance along z):
+    # a dp component in that zero-variance direction is infinitely many sigma away
+    # => +inf ("clear"); a dp lying in the range space is finite.
+    c = _clearance(sigma_pa=0.0)
+    S = np.diag([1.0, 1.0, 0.0])
+    assert np.isinf(c._quad_form_inv(S, np.array([0.0, 0.0, 1.0])))   # null dir
+    assert np.isclose(c._quad_form_inv(S, np.array([2.0, 0.0, 0.0])), 4.0)  # in-plane
+
+
+def test_end_to_end_sf_unchanged_vs_eigh():
+    n = 120
+    new = MahalanobisClearance(_survey(n, 0.0), _survey(n, 8.0))
+    sf_new = np.asarray(new.sf, float)
+
+    orig = MahalanobisClearance._quad_form_inv
+    try:
+        MahalanobisClearance._quad_form_inv = staticmethod(
+            lambda S, dp: _eigh_quad_form(S, dp)
+        )
+        old = MahalanobisClearance(_survey(n, 0.0), _survey(n, 8.0))
+        sf_old = np.asarray(old.sf, float)
+    finally:
+        MahalanobisClearance._quad_form_inv = orig
+
+    assert np.array_equal(np.isfinite(sf_new), np.isfinite(sf_old))  # inf mask
+    m = np.isfinite(sf_new)
+    assert np.allclose(sf_new[m], sf_old[m], rtol=1e-9, atol=1e-12)
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/welleng/clearance.py
+++ b/welleng/clearance.py
@@ -247,6 +247,35 @@ class Clearance:
         c = (1.0 - f) * cov[i] + f * cov[i + 1]
         return p, c, float((1.0 - f) * rad[i] + f * rad[i + 1])
 
+    def _quad_form_inv(self, S, dp):
+        """The combined-metric quadratic form ``dp^T S^{-1} dp`` (batched or
+        scalar via ``...`` broadcasting) — the core of the Mahalanobis SF.
+
+        Two paths, same result:
+
+        - ``sigma_pa > 0``: ``S = (PSD covariances) + sigma_pa**2 I`` is strictly
+          positive-definite, so ``S^{-1} dp`` is a direct linear solve (LU) — much
+          cheaper than the eigendecomposition and giving the identical quadratic
+          form to floating tolerance. This is the operational path.
+        - ``sigma_pa == 0``: ``S`` can be semidefinite, so keep the eigen path with
+          its degenerate semantics — a zero-variance direction with a non-zero
+          projection is +inf ("clear"), a zero projection contributes 0.
+
+        Equal to the previous eigh implementation in the semidefinite path;
+        equal to floating tolerance in the PD path.
+        """
+        if self.sigma_pa > 0.0:
+            sol = np.linalg.solve(S, dp[..., None])[..., 0]
+            return np.einsum('...i,...i->...', dp, sol)
+        # Degenerate-safe fallback (sigma_pa == 0): a zero eigenvalue with a
+        # non-zero projection -> +inf (clear), not 0.
+        vals, vecs = np.linalg.eigh(S)
+        proj = np.einsum('...ji,...j->...i', vecs, dp)
+        with np.errstate(divide='ignore', invalid='ignore'):
+            terms = np.where(vals > 0, proj ** 2 / vals, np.inf)
+        terms = np.where(np.isclose(proj, 0.0), 0.0, terms)
+        return np.sum(terms, axis=-1)
+
     def _sf_point(self, pr, cr, rr, po, co, ro):
         """Radii-adjusted Mahalanobis separation factor between two single
         uncertain points — the general kernel (scalar; used by the narrowphase).
@@ -278,14 +307,7 @@ class Clearance:
             return 0.0
         S = cr + co + (self.sigma_pa ** 2) * np.eye(3)
         dp = d * (max(D - (rr + ro + self.Sm), 0.0) / D)
-        # eigen-decomposition (consistent with _sf_row, robust to degenerate S):
-        # a zero eigenvalue with a non-zero projection -> +inf (clear), not 0.
-        vals, vecs = np.linalg.eigh(S)
-        proj = vecs.T @ dp
-        with np.errstate(divide='ignore', invalid='ignore'):
-            terms = np.where(vals > 0, proj ** 2 / vals, np.inf)
-        terms = np.where(np.isclose(proj, 0.0), 0.0, terms)
-        return float(np.sqrt(np.sum(terms))) / self.k
+        return float(np.sqrt(self._quad_form_inv(S, dp))) / self.k
 
     def _sf_row(self, pr, cr, rr, Op, Oc, Ro):
         """Exact (Mahalanobis) separation factor of one reference point against
@@ -296,12 +318,7 @@ class Clearance:
         scale = np.divide(np.maximum(D - (rr + Ro + self.Sm), 0.0), D,
                           out=np.zeros_like(D), where=D > 0)
         dp = d * scale[:, None]
-        vals, vecs = np.linalg.eigh(S)            # robust to degenerate S
-        proj = np.einsum('oji,oj->oi', vecs, dp)
-        with np.errstate(divide='ignore', invalid='ignore'):
-            terms = np.where(vals > 0, proj ** 2 / vals, np.inf)
-        terms = np.where(np.isclose(proj, 0.0), 0.0, terms)
-        m = np.sqrt(np.sum(terms, axis=1))
+        m = np.sqrt(self._quad_form_inv(S, dp))
         m[D == 0] = 0.0
         return m / self.k
 


### PR DESCRIPTION
## What
`MahalanobisClearance`'s combined-metric quadratic form `dpᵀS⁻¹dp` was a full eigendecomposition per station (`np.linalg.eigh` = ~85% of the ~4 s/pair path at N=2000).

When `sigma_pa > 0` (operational default 0.5), `S = (PSD covariances) + sigma_pa²·I` is **strictly positive-definite**, so the form is a direct **batched `np.linalg.solve`** — identical to floating tolerance, ~3× cheaper. The `eigh` path is retained only for `sigma_pa == 0`, where `S` can be semidefinite and a zero-variance direction must read `+inf` ("clear"). A shared `_quad_form_inv` branches on `sigma_pa` and feeds both `_sf_row` (broadphase) and `_sf_point` (narrowphase).

## Result
| N (station pair) | eigh (old) | solve (new) | speedup |
|---|---|---|---|
| 800 | 754 ms | **247 ms** | **3.05×** |

## Parity (the anti-collision gate)
`tests/test_clearance_mahalanobis_solve.py` (5):
- solve form == eigh form for random SPD `S` — max rel err **5e-15**.
- **end-to-end SF unchanged** vs a forced-`eigh` reference — max abs err **1.8e-15**, `+inf` clear-direction mask **identical**.
- `sigma_pa == 0` fallback preserves the degenerate `+inf` semantics.
- Clearance suite: 18 passed.

## Scope
OPEN per TA0 (2026-07-19): single-run clearance speed = usable reference engine, not a scale product. The bigger clearance levers (the O(n²) broadphase + `IscwsaClearance`'s per-station scipy closest-point search) remain tracked in FUTURE_WORK as their own parity-gated pieces.

🤖 Generated with [Claude Code](https://claude.com/claude-code)