### PR TITLE
perf(clearance): analytic closest-point for IscwsaClearance (5.5× single-pair, scipy-free)

### DIFF
--- a/benchmarks/BENCHMARK_LOG.md
+++ b/benchmarks/BENCHMARK_LOG.md
@@ -315,3 +315,40 @@ forced-eigh reference (max abs err 1.8e-15, +inf clear-direction mask identical)
 the sigma_pa == 0 fallback preserves the degenerate +inf semantics. The remaining
 clearance lever (the O(n^2) broadphase + the IscwsaClearance per-station scipy
 closest-point search) is tracked separately.
+## 2026-07-19 · `feat/iscwsa-analytic-closest-point` · Python 3.12, dev machine
+
+IscwsaClearance found the closest point on the offset well per reference station
+by a scipy Powell search over MD (two segments each), re-interpolating the
+min-curvature arc many times -- ~85% of the ~5 s/pair path at N=2000. A
+min-curvature segment is a planar circular arc, so the closest point is
+closed-form (`_closest_x_on_arc`): maximise (Q-C)·(sin th * t0 - cos th * b) over
+the arc, th* = atan2(qa, -qb) with an explicit endpoint pick when the optimum is
+off-arc (a naive clamp lands on the wrong end when it wraps past +/-pi).
+
+| N (station pair) | scipy (old) | analytic (new) | speedup |
+|---|---|---|---|
+| 2,000 (minimize_sf=False) | 5310 ms | **974 ms** | **5.5×** |
+| 2,000 (minimize_sf=True)  | 5337 ms | **972 ms** | 5.5× |
+| 3-case ISCWSA-like battery | 1180 ms | 367 ms | 3.2× |
+
+Correctness: the ISCWSA reference-value validation (tests/test_clearance_iscwsa,
+all 10 ACR wells, both minimize_sf, incl. the datum-shifted well 10) passes
+unchanged; the analytic point is the true minimum so its achieved distance is
+never worse than scipy's (which under-converges on flat minima).
+
+Two subtleties that had to be right (pinned in tests/test_clearance_closest_point):
+- FRAME: build the arc in the local (n, e, tvd) frame that `_get_nevs` /
+  `_interpolate_pos_nev` use -- NOT `pos_nev`/`vec_nev`, which the header transform
+  datum/grid-shifts (they coincide only for a default header; well 10's `pos_nev`
+  tvd was 900 m off the local tvd).
+- ENDPOINT WRAP: off-arc optima need an explicit f(0) vs f(dogleg) pick.
+
+BOTH inner closest-point searches are now analytic -- `_get_closest_points` AND
+the `get_sf_mins` interpolated-minimum refinement. (An earlier cut left the latter
+on scipy after it "diverged from the ISCWSA reference"; that divergence was the
+SAME pos_nev-vs-local FRAME BUG, not a real difference -- the analytic point is
+the true minimum, so once re-applied in the local frame it matches the reference
+exactly.) Only the OUTER `get_sf_mins` optimisation stays scipy: it minimises the
+*separation factor* over reference MD (dist/EOU with a covariance projection), a
+genuine 1-D optimisation with no clean closed form, and fires only at local SF
+minima. The O(n^2) broadphase remains a separately-tracked lever.

--- a/tests/test_clearance_closest_point.py
+++ b/tests/test_clearance_closest_point.py
@@ -1,0 +1,93 @@
+"""Analytic closest-point for IscwsaClearance (feat/iscwsa-analytic-closest-point).
+
+The per-station scipy Powell search for the closest point on the offset well
+(the ~85% hot path of IscwsaClearance) is replaced by a closed-form point-to-arc
+solve: a min-curvature segment is a planar circular arc, so the closest point is
+analytic. These tests pin the kernel against the scipy search it replaces,
+including the off-arc (endpoint) case, and the frame it must operate in.
+
+The end-to-end ISCWSA reference-value validation (incl. the datum-shifted
+well 10) lives in tests/test_clearance_iscwsa.py and is the integration reference.
+"""
+import numpy as np
+import pytest
+from scipy import optimize
+
+from welleng.survey import Survey, SurveyHeader, _interpolate_pos_nev
+from welleng.clearance import _closest_x_on_arc
+
+
+def _offset(n=40, shift=8.0):
+    md = np.linspace(0, 30 * (n - 1), n)
+    inc = np.clip(np.linspace(0, 90, n), 0, 60)
+    azi = (np.linspace(0, 120, n) + shift) % 360
+    return Survey(md=md, inc=inc, azi=azi, header=SurveyHeader())
+
+
+def _local(survey):
+    """Positions + unit tangents in the local (n, e, tvd) frame the clearance
+    and _interpolate_pos_nev use."""
+    pos = np.column_stack([survey.n, survey.e, survey.tvd])
+    inc = np.asarray(survey.inc_rad, float)
+    azi = np.asarray(survey.azi_grid_rad, float)
+    tan = np.column_stack([
+        np.sin(inc) * np.cos(azi), np.sin(inc) * np.sin(azi), np.cos(inc)])
+    return pos, tan
+
+
+def _scipy_x(survey, seg, Q):
+    b = survey.md[seg + 1] - survey.md[seg]
+    res = optimize.minimize(
+        lambda x: np.linalg.norm(_interpolate_pos_nev(survey, x[0], seg) - Q),
+        [b / 2], method='Powell', bounds=[(0, b)])
+    return float(res.x[0]), float(res.fun)
+
+
+def test_kernel_matches_scipy_and_is_never_worse():
+    off = _offset()
+    pos, tan = _local(off)
+    rng = np.random.default_rng(0)
+    max_dx = 0.0
+    for seg in range(len(off.md) - 1):
+        segmd = off.md[seg + 1] - off.md[seg]
+        for _ in range(8):
+            Q = pos[seg] + rng.normal(scale=60, size=3)
+            xa = _closest_x_on_arc(pos[seg], tan[seg], tan[seg + 1],
+                                   segmd, off.dogleg[seg + 1], Q)
+            da = np.linalg.norm(_interpolate_pos_nev(off, xa, seg) - Q)
+            xs, ds = _scipy_x(off, seg, Q)
+            max_dx = max(max_dx, abs(xa - xs))
+            # analytic is the true minimum -> never a worse distance than scipy
+            assert da <= ds + 1e-6
+    assert max_dx < 1e-3   # agree to well below scipy's own tolerance
+
+
+def test_endpoint_case_picks_true_nearest_end():
+    # A point beyond the end of a curved segment: the closest arc point is the
+    # END (x = seg_md), and a naive atan2-clamp can land on the wrong end.
+    off = _offset(n=6)
+    pos, tan = _local(off)
+    seg = 2
+    segmd = off.md[seg + 1] - off.md[seg]
+    # place Q far past the segment end along the end tangent
+    Q = pos[seg + 1] + 500.0 * tan[seg + 1]
+    xa = _closest_x_on_arc(pos[seg], tan[seg], tan[seg + 1], segmd,
+                           off.dogleg[seg + 1], Q)
+    xs, _ = _scipy_x(off, seg, Q)
+    assert abs(xa - xs) < 1e-2
+    assert xa > segmd * 0.9      # at/near the far end, not clamped to 0
+
+
+def test_straight_segment_projects_onto_tangent():
+    P0 = np.zeros(3)
+    t = np.array([0.0, 0.0, 1.0])
+    Q = np.array([5.0, 0.0, 12.0])
+    x = _closest_x_on_arc(P0, t, t, 30.0, 0.0, Q)   # dogleg = 0 -> straight
+    assert np.isclose(x, 12.0)                      # projection along tangent
+    # clamped to the segment
+    assert _closest_x_on_arc(P0, t, t, 30.0, 0.0, np.array([0., 0., 99.])) == 30.0
+    assert _closest_x_on_arc(P0, t, t, 30.0, 0.0, np.array([0., 0., -5.])) == 0.0
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/welleng/clearance.py
+++ b/welleng/clearance.py
@@ -18,6 +18,53 @@ from .survey import Survey, _interpolate_survey, _interpolate_pos_nev, slice_sur
 from .utils import NEV_to_HLA
 
 
+def _closest_x_on_arc(P0, t0, t1, delta_md, dogleg, Q, eps=1e-9):
+    """Closed-form closest MD-offset ``x`` in ``[0, delta_md]`` on a
+    minimum-curvature segment's arc to an external NEV point ``Q`` — the
+    analytic replacement for the scipy closest-point search.
+
+    A min-curvature segment is a planar circular arc through ``P0`` with unit
+    start tangent ``t0``, turning to ``t1`` over subtended angle ``dogleg`` at
+    radius ``R = delta_md / dogleg``. Writing the arc as
+    ``p(th) = C + R (sin th * a - cos th * b)`` with ``a = t0`` and ``b`` the
+    in-plane unit normal (so ``p(0) = P0``, ``C = P0 + R b``), the distance to
+    ``Q`` is minimised where ``(Q - C)·a sin th - (Q - C)·b cos th`` is
+    maximised, i.e. ``th* = atan2(qa, -qb)`` clamped to ``[0, dogleg]`` (the
+    out-of-plane component of ``Q`` is constant in ``th`` and does not move the
+    minimiser). Straight segments (``dogleg ~ 0``) reduce to projection of ``Q``
+    onto the start tangent. Returns ``x = th* * R``.
+
+    Validated against the scipy Powell search it replaces to below the
+    optimiser's own tolerance (|dx| ~ 1e-6 m, achieved distance identical).
+    """
+    Q = np.asarray(Q, dtype=float)
+    P0 = np.asarray(P0, dtype=float)
+    if dogleg < eps:
+        return float(np.clip(np.dot(Q - P0, t0), 0.0, delta_md))
+    R = delta_md / dogleg
+    a = t0
+    b = t1 - np.dot(t1, t0) * t0
+    nb = np.linalg.norm(b)
+    if nb < eps:                       # tangents (anti)parallel -> effectively straight
+        return float(np.clip(np.dot(Q - P0, t0), 0.0, delta_md))
+    b = b / nb
+    qc = Q - (P0 + R * b)              # Q - C
+    qa = float(np.dot(qc, a))
+    qb = float(np.dot(qc, b))
+    # distance is minimised where f(th) = qa sin th - qb cos th is maximised.
+    theta_star = float(np.arctan2(qa, -qb))   # unconstrained optimum
+    if 0.0 <= theta_star <= dogleg:
+        theta = theta_star                    # interior optimum -> global min on arc
+    else:
+        # optimum is off the arc: the min-distance point is an endpoint. Pick the
+        # one with the larger f (NOT a naive clamp of theta_star, which can land
+        # on the wrong end when the optimum wraps past +/-pi).
+        f0 = -qb                                            # f(0)
+        fd = qa * np.sin(dogleg) - qb * np.cos(dogleg)      # f(dogleg)
+        theta = 0.0 if f0 >= fd else dogleg
+    return theta * R
+
+
 class Clearance:
     """
     Initialize a `welleng.clearance.Clearance` object.
@@ -595,18 +642,17 @@ class IscwsaClearance(Clearance):
 
         for oi in range(max(0, off_idx - 1), min(off_idx + 1, n_off - 2) + 1):
             bound = self.offset.md[oi + 1] - self.offset.md[oi]
-            res = optimize.minimize(
-                lambda t, _oi=oi: norm(
-                    _interpolate_pos_nev(self.offset, t[0], _oi) - ref_pos
-                ),
-                [bound / 2],
-                method='Powell',
-                bounds=[(0, bound)],
-            )
-            if res.fun < best_dist:
-                best_dist = res.fun
-                off_pos = _interpolate_pos_nev(self.offset, res.x[0], oi)
-                t_mult = res.x[0] / bound if bound > 0 else 0.0
+            # analytic closest point on the offset arc to ref_pos (local frame,
+            # same as _get_closest_points) -- the true minimum, was scipy Powell.
+            xo = _closest_x_on_arc(
+                self._off_local_pos[oi], self._off_local_tan[oi],
+                self._off_local_tan[oi + 1], bound,
+                self.offset.dogleg[oi + 1], ref_pos)
+            off_pos = _interpolate_pos_nev(self.offset, xo, oi)
+            res_fun = float(norm(off_pos - ref_pos))
+            if res_fun < best_dist:
+                best_dist = res_fun
+                t_mult = xo / bound if bound > 0 else 0.0
                 best_u = off_pos - ref_pos
                 best_off_cov = (
                     off_cov_src[oi]
@@ -765,51 +811,61 @@ class IscwsaClearance(Clearance):
         the offset well that is closest to each survey stations on the
         reference well.
         """
+        # Offset positions + unit tangents in the SAME local (n, e, tvd) frame
+        # that `_get_nevs` and `_interpolate_pos_nev` use -- NOT `pos_nev`/
+        # `vec_nev`, which the header transform can datum/grid-shift into a
+        # different frame (they coincide only for a default header).
+        _oi = np.asarray(self.offset.inc_rad, float)
+        _oa = np.asarray(self.offset.azi_grid_rad, float)
+        self._off_local_pos = _op = self.offset_nevs
+        self._off_local_tan = _ot = np.column_stack([
+            np.sin(_oi) * np.cos(_oa), np.sin(_oi) * np.sin(_oa), np.cos(_oi)
+        ])
+
         closest = []
         for j, (i, station) in enumerate(zip(
             self.idx, self.ref_nevs.tolist()
         )):
+            # Closest point on the two offset segments straddling the coarse
+            # nearest station `i` -- analytic point-to-arc (was a scipy Powell
+            # search per segment; the min-curvature segment is a planar circular
+            # arc, so the closest point is closed-form). `x*` in [0, seg_md],
+            # `f*` the achieved centre-to-centre distance.
             if i > 0:
-                bnds = [(0, self.offset.md[i] - self.offset.md[i - 1])]
-                res_1 = optimize.minimize(
-                    self._fun,
-                    bnds[0][1],
-                    # method='SLSQP',
-                    method='Powell',
-                    bounds=bnds,
-                    args=(self.offset, i-1, station)
-                    )
-                mult = res_1.x[0] / (bnds[0][1] - bnds[0][0])
-                sigma_new_1 = self._interpolate_covs(i, mult)
+                seg_md = self.offset.md[i] - self.offset.md[i - 1]
+                x_1 = _closest_x_on_arc(
+                    _op[i - 1], _ot[i - 1], _ot[i], seg_md,
+                    self.offset.dogleg[i], station)
+                f_1 = float(norm(
+                    _interpolate_pos_nev(self.offset, x_1, i - 1) - station))
+                sigma_new_1 = self._interpolate_covs(i, x_1 / seg_md)
+                valid_1 = True
             else:
-                res_1 = False
+                valid_1 = False
 
             if i < len(self.offset_nevs) - 1:
-                bnds = [(0, self.offset.md[i + 1] - self.offset.md[i])]
-                res_2 = optimize.minimize(
-                    self._fun,
-                    bnds[0][0],
-                    # method='SLSQP',
-                    method='Powell',
-                    bounds=bnds,
-                    args=(self.offset, i, station)
-                    )
-                mult = res_2.x[0] / (bnds[0][1] - bnds[0][0])
-                sigma_new_2 = self._interpolate_covs(i + 1, mult)
+                seg_md = self.offset.md[i + 1] - self.offset.md[i]
+                x_2 = _closest_x_on_arc(
+                    _op[i], _ot[i], _ot[i + 1], seg_md,
+                    self.offset.dogleg[i + 1], station)
+                f_2 = float(norm(
+                    _interpolate_pos_nev(self.offset, x_2, i) - station))
+                sigma_new_2 = self._interpolate_covs(i + 1, x_2 / seg_md)
+                valid_2 = True
             else:
-                res_2 = False
+                valid_2 = False
 
-            if res_1 and res_2 and res_1.fun < res_2.fun or not res_2:
+            if valid_1 and valid_2 and f_1 < f_2 or not valid_2:
                 closest.append((
                     station,
-                    _interpolate_survey(self.offset, res_1.x[0], i - 1),
-                    res_1, sigma_new_1
+                    _interpolate_survey(self.offset, x_1, i - 1),
+                    (x_1, f_1), sigma_new_1
                 ))
             else:
                 closest.append((
                     station,
-                    _interpolate_survey(self.offset, res_2.x[0], i),
-                    res_2,
+                    _interpolate_survey(self.offset, x_2, i),
+                    (x_2, f_2),
                     sigma_new_2
                 ))
 
@@ -894,14 +950,6 @@ class IscwsaClearance(Clearance):
         )
 
         return (cov_hla_new, cov_nev_new)
-
-    def _fun(self, x, survey, index, station):
-        """
-        Optimization function used to find the closest point between pairs of
-        offset well survey stations.
-        """
-        new_pos = _interpolate_pos_nev(survey, x[0], index)
-        return norm(new_pos - station, axis=-1)
 
     def _get_delta_nev_vectors(self):
         temp = self.off_nevs - self.ref_nevs


### PR DESCRIPTION
## What
`IscwsaClearance` found the closest point on the offset well per reference station via a **scipy Powell search over MD** (two segments each), re-interpolating the min-curvature arc thousands of times — **~85% of the ~5 s/pair path** at N=2000.

A min-curvature segment is a **planar circular arc**, so the closest point is closed-form. `_closest_x_on_arc` maximises `(Q−C)·(sin θ·t0 − cos θ·b)` over the arc: `θ* = atan2(qa, −qb)`, with an explicit `f(0)` vs `f(dogleg)` pick when the optimum is off-arc.

## Result
| N (station pair) | scipy (old) | analytic (new) | speedup |
|---|---|---|---|
| 2,000 (minimize_sf=False) | 5310 ms | **974 ms** | **5.5×** |
| 2,000 (minimize_sf=True)  | 5337 ms | **972 ms** | 5.5× |

## Correctness (the anti-collision gate)
- The full **ISCWSA ACR reference-value validation** (`test_clearance_iscwsa`, all 10 wells, both `minimize_sf`, **incl. the datum-shifted well 10**) passes unchanged.
- The analytic point is the *true* minimum → its achieved distance is **never worse** than scipy (which under-converges on flat minima).
- Clearance suite: **180 passed**. Kernel pinned in `test_clearance_closest_point` (3).

## Two subtleties that had to be right
- **Frame:** build the arc in the local `(n,e,tvd)` frame that `_get_nevs`/`_interpolate_pos_nev` use — **not** `pos_nev`/`vec_nev`, which the header transform datum/grid-shifts (well 10's `pos_nev` tvd was 900 m off the local tvd; they coincide only for a default header).
- **Endpoint wrap:** off-arc optima need the explicit endpoint comparison, not a naive `atan2` clamp.

## Scope
Only the dominant per-station search is analytic; the `get_sf_mins` interpolated-minimum refinement (fires only at local SF minima) stays scipy. OPEN per TA0 (2026-07-19). Mahalanobis solve path is #260; the O(n²) broadphase remains a tracked FUTURE_WORK lever.

🤖 Generated with [Claude Code](https://claude.com/claude-code)