### PR TITLE
feat(utils): arc_inc_azi_extrema — exact inc/azi extrema over min-curve arcs [0.19.0]

### DIFF
--- a/benchmarks/BENCHMARK_LOG.md
+++ b/benchmarks/BENCHMARK_LOG.md
@@ -280,3 +280,17 @@ was re-parsed N times). `cov_nev` is **bit-identical** cold vs warm
 (fixes repeated I/O, not a commercial capability); feeds the lazy error-class
 redesign (parse model defs once, reuse per section). Regression:
 `tests/test_error_model_cache.py` (4).
+
+## 2026-07-19 · `feat/arc-inc-azi-extrema` · Python 3.12, dev machine
+
+`welleng.utils.arc_inc_azi_extrema` — exact inclination/azimuth extrema over
+min-curvature arcs. Replaces a 96-sample/arc envelope test with a closed form.
+
+| operation | result |
+|---|---|
+| vectorized over 100k arcs | 72.8 ms (**1.4M arcs/s**) |
+
+Exactness (vs 4000-sample/arc reference over 3000 random arcs incl. reflex):
+inclination extrema max err 2.8e-5 rad; azimuth swing max err 1.8e-15 (azimuth is
+strictly monotonic along a circular arc -> extrema at endpoints, signed swing via
+an analytic branch-crossing count). `tests/test_arc_extrema.py` (6).

--- a/tests/test_arc_extrema.py
+++ b/tests/test_arc_extrema.py
@@ -1,0 +1,107 @@
+"""arc_inc_azi_extrema — exact inclination/azimuth extrema over min-curvature arcs.
+
+Verified against dense sampling. The two results pinned: inclination extrema at
+the closed-form critical points, and
+azimuth strictly monotonic along a circular arc (extrema = endpoints, signed
+swing exact including reflex arcs and multi-wrap).
+"""
+import numpy as np
+import pytest
+
+from welleng.utils import arc_inc_azi_extrema
+
+
+def _unit(v):
+    return v / np.linalg.norm(v, axis=-1, keepdims=True)
+
+
+def _make_arcs(n, seed, amax=2 * np.pi * 0.999):
+    rng = np.random.default_rng(seed)
+    va = _unit(rng.normal(size=(n, 3)))
+    nhat = _unit(np.cross(va, rng.normal(size=(n, 3))))
+    u = _unit(np.cross(nhat, va))
+    alpha = rng.uniform(0.02, amax, n)
+    vb = va * np.cos(alpha)[:, None] + u * np.sin(alpha)[:, None]
+    return va, vb, u, alpha
+
+
+def test_matches_dense_sampling():
+    va, vb, u, alpha = _make_arcs(3000, seed=1)
+    r = arc_inc_azi_extrema(va, vb, alpha)
+    e_inc = e_swing = 0.0
+    for i in range(len(alpha)):
+        if abs(np.sin(alpha[i])) < 1e-6:      # antiparallel: u unrecoverable
+            continue
+        th = np.linspace(0, alpha[i], 4000)
+        t = va[i][None, :] * np.cos(th)[:, None] + u[i][None, :] * np.sin(th)[:, None]
+        inc = np.arccos(np.clip(t[:, 2], -1, 1))
+        e_inc = max(e_inc, abs(inc.min() - r['inc_min'][i]),
+                    abs(inc.max() - r['inc_max'][i]))
+        if np.hypot(t[:, 0], t[:, 1]).min() < 1e-3:   # passes vertical: azi singular
+            continue
+        azi = np.unwrap(np.arctan2(t[:, 1], t[:, 0]))
+        e_swing = max(e_swing, abs((azi[-1] - azi[0]) - r['azi_swing'][i]))
+    assert e_inc < 1e-3          # inclination extrema exact
+    assert e_swing < 1e-6        # azimuth swing exact (incl. reflex + multi-wrap)
+
+
+def test_azimuth_monotonic_direction_is_sign_K():
+    va, vb, u, alpha = _make_arcs(2000, seed=2)
+    r = arc_inc_azi_extrema(va, vb, alpha)
+    K = va[:, 0] * u[:, 1] - va[:, 1] * u[:, 0]
+    ok = np.abs(K) > 1e-6
+    # swing sign follows K; a near-vertical arc can flip, so allow the ones that
+    # pass vertical to differ
+    good = ok & ~r['passes_vertical']
+    assert np.all(np.sign(r['azi_swing'][good]) == np.sign(K[good]))
+
+
+def test_endpoints_and_reflex():
+    # a reflex arc (dogleg > pi) must still reproduce vec_b azimuth at the end
+    va = np.array([[1.0, 0.0, 0.5]])
+    va = _unit(va)
+    u = _unit(np.array([[0.0, 1.0, 0.0]]))          # in-plane perp
+    alpha = np.array([1.2 * np.pi])                  # reflex
+    vb = va * np.cos(alpha)[:, None] + u * np.sin(alpha)[:, None]
+    r = arc_inc_azi_extrema(va, vb, alpha)
+    assert np.isclose(r['azi_start'][0], np.arctan2(va[0, 1], va[0, 0]))
+    assert np.isclose(r['azi_end'][0], np.arctan2(vb[0, 1], vb[0, 0]))
+
+
+def test_straight_segment_constant():
+    va = _unit(np.array([[0.4, 0.3, 0.87]]))
+    r = arc_inc_azi_extrema(va, va.copy(), np.array([0.0]))
+    inc = np.arccos(np.clip(va[0, 2], -1, 1))
+    assert np.isclose(r['inc_min'][0], inc) and np.isclose(r['inc_max'][0], inc)
+    assert r['azi_swing'][0] == 0.0
+    assert not r['passes_vertical'][0]
+
+
+def test_vertical_passage_flagged():
+    # start vertical, curl slightly off: min inclination hits 0 -> flagged
+    va = np.array([[0.0, 0.0, 1.0]])
+    u = _unit(np.array([[0.3, 0.1, 0.0]]))
+    alpha = np.array([0.4])
+    vb = va * np.cos(alpha)[:, None] + u * np.sin(alpha)[:, None]
+    r = arc_inc_azi_extrema(va, vb, alpha)
+    assert bool(r['passes_vertical'][0])
+    assert r['inc_min'][0] < 1e-4
+
+
+def test_horizontal_plane_swing_equals_alpha():
+    # tangent confined to the horizontal plane (V=0): |t_EN|=1 everywhere, so the
+    # azimuth swings at unit rate -> total swing = +/- alpha exactly, and inc is
+    # constant at 90 deg. A near-2pi arc therefore covers (almost) all azimuths.
+    va = np.array([[1.0, 0.0, 0.0]])
+    u = np.array([[0.0, 1.0, 0.0]])
+    for a in (0.5, 0.9 * np.pi, 1.5 * np.pi, 1.99 * np.pi):
+        alpha = np.array([a])
+        vb = va * np.cos(alpha)[:, None] + u * np.sin(alpha)[:, None]
+        r = arc_inc_azi_extrema(va, vb, alpha)
+        assert np.isclose(abs(r['azi_swing'][0]), a, atol=1e-9)
+        assert np.isclose(r['inc_min'][0], np.pi / 2) and \
+            np.isclose(r['inc_max'][0], np.pi / 2)
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/welleng/utils.py
+++ b/welleng/utils.py
@@ -246,6 +246,122 @@ def _get_angles(vec):
     return np.stack((inc, azi), axis=1)
 
 
+def arc_inc_azi_extrema(vec_a, vec_b, dogleg, vertical_eps=1e-4):
+    """Exact inclination + azimuth extrema over minimum-curvature arcs.
+
+    A minimum-curvature segment is a planar circular arc whose unit tangent
+    sweeps ``t(theta) = vec_a * cos(theta) + u * sin(theta)`` for
+    ``theta in [0, dogleg]``, where ``u`` is the in-plane unit vector
+    perpendicular to ``vec_a`` (so ``t(0) = vec_a``, ``t(dogleg) = vec_b``).
+    All inputs/outputs are in the NEV (north, east, tvd-down) frame.
+
+    Two closed-form results (verified against dense sampling):
+
+    - **Inclination** ``inc = acos(t_V)`` with ``t_V = A cos + B sin``
+      (``A = vec_a_V``, ``B = u_V``); its extrema are at the arc ends plus the
+      interior critical points ``theta = phi (+/- pi, + 2pi)`` that fall in
+      ``[0, dogleg]``, ``phi = atan2(B, A)``. Exact, <=6 evaluations/arc.
+    - **Azimuth** ``azi = atan2(t_E, t_N)`` is **strictly monotonic** along any
+      circular arc: ``d(azi)/dtheta`` numerator ``= vec_a_N u_E - vec_a_E u_N``
+      is constant (the ``cos^2 + sin^2`` cross-terms cancel identically). So its
+      extrema are the two ENDPOINTS, swept in direction ``sign(K)``; the total
+      signed swing can exceed 2*pi (arc covers all azimuths).
+
+    Parameters
+    ----------
+    vec_a, vec_b : (n, 3) array — unit start/end tangents (NEV).
+    dogleg : (n,) array — subtended (dogleg) angle of each arc, radians.
+    vertical_eps : float — arcs whose minimum inclination is below this (radians)
+        pass through vertical, where azimuth is singular; ``passes_vertical`` is
+        flagged and the azimuth span should be treated as full-wrap by callers.
+
+    Notes
+    -----
+    At ``dogleg`` exactly ``pi`` (antiparallel tangents, ``vec_b = -vec_a``) the
+    arc plane -- hence ``u`` -- is not recoverable from ``vec_a``/``vec_b`` alone;
+    such arcs are treated as degenerate (constant inc/azi, zero swing). This is a
+    measure-zero case for real min-curvature/CLC arcs; near-``pi`` is exact.
+
+    Returns
+    -------
+    dict with (n,)-arrays: ``inc_min``, ``inc_max`` (radians); ``azi_start``,
+    ``azi_end`` (radians, in (-pi, pi]); ``azi_swing`` (signed total azimuth
+    change, radians; ``abs >= 2*pi`` => all azimuths covered);
+    ``passes_vertical`` (bool).
+    """
+    vec_a = np.atleast_2d(np.asarray(vec_a, dtype=float))
+    vec_b = np.atleast_2d(np.asarray(vec_b, dtype=float))
+    dogleg = np.atleast_1d(np.asarray(dogleg, dtype=float))
+
+    # In-plane unit perpendicular u such that t(theta)=vec_a*cos+u*sin reaches
+    # vec_b at theta=dogleg: u = (vec_b - cos(dogleg) vec_a) / sin(dogleg). The
+    # SIGN of sin(dogleg) is what orients the sweep for REFLEX arcs (dogleg > pi,
+    # as the CLC solver produces) -- a norm-only recovery would flip it.
+    dot = np.einsum('ij,ij->i', vec_a, vec_b)          # = cos(dogleg)
+    sin_dl = np.sin(dogleg)
+    w = vec_b - dot[:, None] * vec_a
+    nw = np.linalg.norm(w, axis=1)
+    # degenerate when sin(dogleg)~0: dogleg ~ 0 (straight) or ~ pi (antiparallel
+    # tangents, u unrecoverable from vec_a/vec_b alone).
+    straight = (np.abs(dogleg) < 1e-9) | (nw < 1e-12)
+    safe_nw = np.where(nw < 1e-12, 1.0, nw)
+    u = np.sign(np.where(sin_dl == 0.0, 1.0, sin_dl))[:, None] * (w / safe_nw[:, None])
+
+    # --- inclination extrema (critical points of t_V) ---
+    A, B = vec_a[:, 2], u[:, 2]
+    phi = np.arctan2(B, A)
+    cand = np.stack([
+        np.zeros_like(dogleg), dogleg,
+        phi, phi + np.pi, phi - np.pi, phi + 2.0 * np.pi
+    ], axis=1)
+    in_range = (cand >= 0.0) & (cand <= dogleg[:, None])
+    tV = A[:, None] * np.cos(cand) + B[:, None] * np.sin(cand)
+    tV = np.where(in_range, tV, np.nan)
+    tV_min = np.nanmin(tV, axis=1)
+    tV_max = np.nanmax(tV, axis=1)
+    inc_min = np.arccos(np.clip(tV_max, -1.0, 1.0))
+    inc_max = np.arccos(np.clip(tV_min, -1.0, 1.0))
+    inc_a = np.arccos(np.clip(vec_a[:, 2], -1.0, 1.0))
+    inc_min = np.where(straight, inc_a, inc_min)
+    inc_max = np.where(straight, inc_a, inc_max)
+
+    # --- azimuth: monotonic; endpoints + signed swing ---
+    azi_start = np.arctan2(vec_a[:, 1], vec_a[:, 0])
+    azi_end = np.arctan2(vec_b[:, 1], vec_b[:, 0])
+    K = vec_a[:, 0] * u[:, 1] - vec_a[:, 1] * u[:, 0]  # t_N u_E - t_E u_N, constant
+
+    # Signed swing = continuous (unwrapped) atan2(t_E, t_N) over [0, dogleg].
+    # atan2 wraps by 2*pi each time the projection crosses the -N axis
+    # (t_E = 0 while t_N < 0). Count those crossings analytically: zeros of
+    # t_E(theta) = vec_a_E cos + u_E sin are theta0 + k*pi, theta0 = atan2(-vec_a_E, u_E).
+    cE, sE = vec_a[:, 1], u[:, 1]
+    cN, sN = vec_a[:, 0], u[:, 0]
+    theta0 = np.arctan2(-cE, sE)
+    n = len(dogleg)
+    wraps = np.zeros(n)
+    kmax = int(np.ceil(np.nanmax(dogleg) / np.pi)) + 2 if n else 0
+    for k in range(-1, kmax + 1):
+        th = theta0 + k * np.pi
+        hit = (th > 1e-12) & (th < dogleg - 1e-12)
+        tN_here = cN * np.cos(th) + sN * np.sin(th)
+        cross = hit & (tN_here < 0.0)
+        wraps += np.where(cross, np.sign(K), 0.0)
+    azi_swing = (azi_end - azi_start) + 2.0 * np.pi * wraps
+    # snap toward the monotonic direction when the raw endpoint diff disagrees
+    disagree = (np.abs(azi_swing) > 1e-9) & (np.sign(azi_swing) != np.sign(K)) \
+        & (np.abs(K) > 1e-12)
+    azi_swing = np.where(disagree, azi_swing + np.sign(K) * 2.0 * np.pi, azi_swing)
+    azi_swing = np.where(straight, 0.0, azi_swing)
+
+    passes_vertical = inc_min < vertical_eps
+
+    return {
+        'inc_min': inc_min, 'inc_max': inc_max,
+        'azi_start': azi_start, 'azi_end': azi_end,
+        'azi_swing': azi_swing, 'passes_vertical': passes_vertical,
+    }
+
+
 def get_angles(
     vec: Annotated[NDArray, Literal["N", 3]], nev: bool = False
 ):


### PR DESCRIPTION
## What
`welleng.utils.arc_inc_azi_extrema` — exact inclination/azimuth extrema over minimum-curvature arcs. The open geometry utility from the welleng-api sampled-envelope-filter ruling (exact arc extrema = generic trajectory geometry → open). **Derivation contributed by welleng-api; verified here against dense sampling.**

A min-curvature segment is a planar circular arc `t(θ)=vec_a·cos + u·sin`. Two closed-form results:
- **Inclination extrema** at the critical points of the vertical tangent component `{0, dogleg, φ, φ±π, φ+2π} ∩ [0, dogleg]`, `φ=atan2(u_V, vec_a_V)`.
- **Azimuth is strictly monotonic** along any circular arc — the `d(azi)/dθ` numerator `vec_a_N·u_E − vec_a_E·u_N` is constant (the cos²+sin² cross-terms cancel). So extrema = endpoints; the signed swing (exact incl. reflex + multi-wrap) comes from an analytic count of −N-axis branch crossings.

## Verification (my gate on the derivation)
vs a 4000-sample/arc reference over 3000 random arcs incl. reflex:
- inclination extrema max err **2.8e-5 rad**
- azimuth swing max err **1.8e-15** (machine-exact)

## Perf
Vectorized: **1.4M arcs/s** (100k arcs in 72.8 ms). Replaces welleng-api's 96-sample/arc filter (they'll import this + delete their copy).

## Edge cases
- **Reflex arcs** (dogleg > π, from the CLC solver) handled via `sign(sin(dogleg))`.
- **Vertical passage** (azimuth singular) flagged (`passes_vertical`) for full-wrap handling.
- **dogleg == π** (antiparallel, `u` unrecoverable from tangents alone) = documented degenerate (measure-zero; near-π exact).

`tests/test_arc_extrema.py` (6) + benchmark logged. For 0.19.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)