### PR TITLE
docs(frame): clarify NEV frame convention in Survey + KT docstrings

### DIFF
--- a/welleng/kick_tolerance/core.py
+++ b/welleng/kick_tolerance/core.py
@@ -161,8 +161,13 @@ class KickInputs:
         ``interpolate_md(md) -> node`` exposing ``pos_nev`` and ``inc_deg`` works.
 
         ``Node`` has no direct ``.tvd``; its position is ``pos_nev = [North, East,
-        Vertical]`` (welleng NEV convention), so ``pos_nev[2]`` IS the TVD -- verified
-        to equal ``survey.tvd`` at every station and to reduce to MD for a vertical well.
+        Vertical]`` (welleng NEV convention), so ``pos_nev[2]`` IS the TVD. This is
+        the GLOBAL (datum-referenced, ``start_nev``-inclusive) TVD -- which is the
+        correct depth for the hydrostatic terms (the mud column is referenced to the
+        surface datum, not the survey start). It equals ``survey.tvd`` only at a zero
+        datum (``survey.tvd`` is the LOCAL depth, per the ``Survey`` docstring); on a
+        datum-shifted / sidetrack survey they differ by ``start_nev``, and the global
+        ``pos_nev[2]`` is the one KT wants. Reduces to MD for a vertical well.
         """
         shoe = survey.interpolate_md(shoe_md)
         td = survey.interpolate_md(td_md)

--- a/welleng/survey.py
+++ b/welleng/survey.py
@@ -690,8 +690,13 @@ class Survey(MinCurve):
         steering: Optional[Union[str, ArrayLike]] = None,
         **kwargs: Any
     ) -> None:
-        """Initialize a `welleng.Survey` object. Calculations are performed in the
-        azi_reference "grid" domain.
+        """Initialize a `welleng.Survey` object.
+
+        Geometry is computed INTERNALLY in the grid-azimuth domain (the canonical
+        engine frame); the header's ``azi_reference`` names the INPUT azimuth frame
+        and is converted to grid on construction. The input-reference default is
+        ``"true"`` (see ``SurveyHeader``), not grid -- the "grid" here is the
+        internal calculation domain, not the expected input.
 
         Parameters
         ----------


### PR DESCRIPTION
Docstring-only tidies from the 0.19 `pos_nev` / local-`tvd` frame review. **No behaviour change.**

- **`Survey.__init__`** — the "calculations performed in the azi_reference 'grid' domain" line read as if grid were the expected *input*. Clarified: geometry is computed *internally* in the grid domain (canonical engine frame); the input `azi_reference` default is **"true"** and is converted to grid on construction.
- **`kick_tolerance/core.py`** — `from_survey` claimed `pos_nev[2]` *"equals survey.tvd at every station"* — only true at a zero datum. `pos_nev[2]` is the **global** (datum-referenced) TVD, which is the correct hydrostatic depth (mud column referenced to surface); `survey.tvd` is the **local** depth per the `Survey` docstring, differing by `start_nev` on a sidetrack. The code is correct (uses global `pos_nev[2]`); only the equivalence claim was overstated.

Imports clean; no logic touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)