### PR TITLE
fix(clc): landing branch selection by chord-identity closure (razor-edge flip)

### DIFF
--- a/tests/test_sawaryn_analytical.py
+++ b/tests/test_sawaryn_analytical.py
@@ -351,3 +351,27 @@ def test_landing_reproduces_example4():
     assert np.allclose(s['p4'], [533.30, -194.11, 3280.8], atol=0.15)
 
 
+def test_landing_branch_closure_is_unit(seed=3):
+    # Regression for the razor-edge branch flip (fixed via chord-identity
+    # arbitration): every returned landing solution must have a
+    # UNIT middle tangent v = (p4-p1 - R1 T1 t1 - R2 T2 t4)/(R1 T1 + R2 T2) -- a
+    # wrong branch (the failure mode) gives |v| far from 1.
+    rng = np.random.default_rng(seed)
+    checked = 0
+    for _ in range(200):
+        p1 = rng.normal(scale=300, size=3)
+        t1 = tangent(rng.uniform(5, 175), rng.uniform(0, 360))
+        p0 = rng.normal(scale=300, size=3)
+        t4 = tangent(rng.uniform(5, 175), rng.uniform(0, 360))
+        R1, R2 = rng.uniform(200, 600), rng.uniform(200, 600)
+        for s in solve_clc_landing(p1, t1, p0, t4, R1, R2, return_all=True):
+            T1, T2 = np.tan(s['alpha1'] / 2), np.tan(s['alpha2'] / 2)
+            denom = R1 * T1 + R2 * T2
+            if abs(denom) < 1e-9:
+                continue
+            v = (s['p4'] - p1 - R1 * T1 * t1 - R2 * T2 * t4) / denom
+            assert abs(np.linalg.norm(v) - 1.0) < 1e-4, (R1, R2, s['k'])
+            checked += 1
+    assert checked > 50   # the battery actually exercised landings
+
+

--- a/welleng/sawaryn_analytical.py
+++ b/welleng/sawaryn_analytical.py
@@ -729,13 +729,23 @@ def solve_clc_landing(p1, t1, p0, t4, R1, R2=None, return_all=False):
         psi2 = psi0_2 + 2 * eps4 * k + k * k
         g1, g4 = eps1 + mu * k, eps4 + k
         a1s, a2s = subtended_angles(0.0, psi2, g1, g4, eps14, mu, R1, R2)
+        # Branch selection by CHORD-IDENTITY CLOSURE, not the forward-residual.
+        # The middle tangent v = (delta - R1 T1 t1 - R2 T2 t4)/(R1 T1 + R2 T2)
+        # (beta = 0 on the landing biarc) must be a UNIT vector for a valid
+        # solution. This is decisive at the razor-edge (|v|-1 ~ 1e-5 for the true
+        # branch vs ~1 for the alternate), where the forward-residual flips with
+        # the last bits of k: forward()'s Eq.13 surd sits at +/-1e-16 at the root
+        # and its strict surd<0 -> None rejects the true branch on rounding.
         best = (np.inf, None, None)
+        delta = (p0 + k * t4) - p1
         for x1 in a1s:
             for x2 in a2s:
-                f = forward(x1, x2, 0.0, mu, R1, R2)
-                if f is None:
+                T1, T2 = np.tan(x1 / 2), np.tan(x2 / 2)
+                denom = R1 * T1 + R2 * T2
+                if abs(denom) < 1e-12:
                     continue
-                r = abs(f[0] - g1) + abs(f[1] - g4) + abs(abs(f[2]) - abs(eps14))
+                v = (delta - R1 * T1 * t1 - R2 * T2 * t4) / denom
+                r = abs(float(np.linalg.norm(v)) - 1.0)
                 if r < best[0]:
                     best = (r, x1, x2)
         if best[1] is None:


### PR DESCRIPTION
## Finding (welleng-api, via the closed landing sweep = oracle seam)
`solve_clc_landing` picked `(alpha1, alpha2)` by the `forward()` invariant residual, but `forward()` returns `None` on its Eq.13 surd `< 0` **strictly**. At razor-edge `(R1,R2)` combos the true branch's surd sits at ±1e-16 *at* the root → the strict rejection drops the true branch and the pick flips with the last bits of `k` (brentq vs bisection, or a different grid) → a landing solution off by ~1 in the invariants. (`_clc_solutions` clamps tiny-negative surds for exactly this reason; the landing tail didn't.)

Repro (welleng-api): `R1=375.952, R2=563.928, k=24.157` — true branch `(358.655°, 344.265°)` closes to 2e-5; the flip picks the alternate, off by ~1.

## Fix
Select the branch by **chord-identity closure**. The middle tangent
`v = (p4 − p1 − R1·T1·t1 − R2·T2·t4)/(R1·T1 + R2·T2)` (β=0 on the landing biarc) must be a **unit** vector; `||v|−1|` is ~1e-5 for the true branch vs ~1 for the alternate — decisive and immune to `k`'s last bits. Sidesteps `forward()`'s surd rejection entirely (`forward` untouched → other callers unaffected).

## Validation
- **Example 4 (Wang 2019) still exact.**
- New `test_landing_branch_closure_is_unit`: every returned landing solution over a 200-problem random battery has a unit `v` (a wrong branch — the failure mode — gives `|v|` far from 1).
- Sawaryn suite **18 passed**. Leak PASS.

Finding 2 (k-grid root-count fp-stability) is separately tracked — it folds into the chord-normalized residual planned for the long-hold conditioning fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)