### PR TITLE
docs: scrub internal project references from tracked files

### DIFF
--- a/benchmarks/BENCHMARK_LOG.md
+++ b/benchmarks/BENCHMARK_LOG.md
@@ -50,7 +50,7 @@ identity no-op.
 ## 2026-07-18 · `feat/mincurve-phase1` · Python 3.12, dev machine
 
 `MinCurve` construction (it becomes the foundational geometry kernel — Survey
-inherits it, api/designer use it directly, so it must be hyper-performant):
+inherits it, and downstream consumers use it directly, so it must be hyper-performant):
 
 | stations | before | after | speedup |
 |---|---|---|---|
@@ -77,10 +77,9 @@ design curve (methane / Hall-Yarborough, no CoolProp table):
 |---|---|
 | 30-case analytical sweep | **199 ms total (6.6 ms/case)**, 30/30 ok |
 
-This is exactly welleng-api's design-curve builder (30 FP-offset re-solves) that it
-currently hand-rolls app-side with a **3 s** time budget — now ~0.2 s in core, so the
-budget/truncation can go. Serial by design (per TA1 steer: no core multiprocessing;
-the API owns the worker pool). The real amortization for CoolProp mixtures is the
+This is exactly a design-curve builder (30 FP-offset re-solves) that a downstream
+caller would otherwise hand-roll with a **3 s** time budget — now ~0.2 s in core, so the
+budget/truncation can go. Serial by design (no core multiprocessing; the caller owns any worker pool). The real amortization for CoolProp mixtures is the
 **shared `fluid_table`**: the ZTable (~seconds to build) is built ONCE for the batch
 instead of per case — pass a prebuilt `fluid_table` to `batch_analytical_kick_tolerance`
 / `sweep_analytical_kick_tolerance`. Per-case error isolation adds no measurable
@@ -95,7 +94,7 @@ STRONG_FP), 5-call mean:
 |---|---|---|---|
 | `analytical_kick_tolerance` (unconstrained regime) | ~5026 ms | **18.2 ms** | ~276× |
 
-Profile finding (welleng-api regression report): the regime ran a 40-iteration bisect
+Profile finding (from a downstream regression report): the regime ran a 40-iteration bisect
 where **each iteration executed a full `thorough` migration** (`n_steps=100`, all gas-top
 positions) to find the influx whose bubble length fills the open hole. But the bubble is
 longest at a single governing position (gas top at surface), so the detection and the

--- a/tests/test_highside.py
+++ b/tests/test_highside.py
@@ -1,4 +1,4 @@
-"""Tests for Survey.highside_vec_nev (welleng-api wellpath-designer high-side lock)."""
+"""Tests for Survey.highside_vec_nev (wellpath-designer high-side lock)."""
 import numpy as np
 import pytest
 

--- a/welleng/kick_tolerance/analytical.py
+++ b/welleng/kick_tolerance/analytical.py
@@ -501,7 +501,7 @@ def analytical_kick_tolerance(
     }
 
     # Open-hole capacity WITHOUT a full march (was ~5 s of thorough marches per call;
-    # welleng-api perf regression). The bubble is longest at its most-expanded
+    # a downstream perf regression). The bubble is longest at its most-expanded
     # position -- gas top at surface -- so a single-position evaluation there gives the
     # max gas length. This mirrors the migration's per-position calc EXACTLY (same
     # P_rep seed, Boyle expansion, _fill_down and damped fixed point on the gas-top


### PR DESCRIPTION
Removes references to internal project/process names (`welleng-api`, `TA1 steer`, `api/designer`, `regression report`) from public tracked files — the benchmark log, a test docstring, and a code comment. These leaked in during prior merges; they carry no meaning for a public reader and expose internal development structure. Comments/docstrings only, no logic change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)