### PR TITLE
feat(conditioning): shared-error combined covariance for co-located well pairs

### DIFF
--- a/tests/test_conditioning.py
+++ b/tests/test_conditioning.py
@@ -1,0 +1,133 @@
+"""welleng.conditioning — shared-error conditioning of two wells' combined
+covariance (co-located wells share global / systematic error realisations, which
+cancel in the position DIFFERENCE; the naive Sigma_A + Sigma_B over-states it).
+
+Pinned here: the exact cancellation algebra per share-mode, the input contracts,
+the PSD defence, the public import surface, and an end-to-end run on two real
+error-modelled Surveys.
+"""
+import numpy as np
+import pytest
+
+from welleng.conditioning import (
+    CombinedCovariance,
+    ShareMode,          # noqa: F401  (the import IS the contract)
+    combine_covariances,
+)
+from welleng.survey import Survey, SurveyHeader
+
+
+def _spd(rng, n, scale=1.0):
+    """Random (n, 3, 3) SPD stack."""
+    A = rng.normal(size=(n, 3, 3))
+    return scale * np.einsum("nij,nkj->nik", A, A) + 1e-6 * np.eye(3)
+
+
+def test_all_independent_is_naive_sum():
+    rng = np.random.default_rng(0)
+    a, b = _spd(rng, 5), _spd(rng, 5)
+    r = combine_covariances(a, b, share_mode="all_independent")
+    assert np.allclose(r.cov_combined, a + b)
+    assert np.allclose(r.cov_naive, a + b)
+    assert np.allclose(r.reduction_factor, 1.0)
+
+
+def test_globals_shared_cancels_identical_global():
+    # A = R_a + G, B = R_b + G with the SAME global realisation G:
+    # cov(X_A - X_B) must reduce to R_a + R_b exactly.
+    rng = np.random.default_rng(1)
+    Ra, Rb, G = _spd(rng, 6), _spd(rng, 6), _spd(rng, 6)
+    r = combine_covariances(Ra + G, Rb + G,
+                            cov_global_a=G, cov_global_b=G,
+                            share_mode="globals_shared")
+    assert np.allclose(r.cov_combined, Ra + Rb, atol=1e-10)
+    assert np.all(r.reduction_factor >= 1.0 - 1e-12)
+
+
+def test_globals_and_systematic_shared_cancels_both():
+    rng = np.random.default_rng(2)
+    Ra, Rb, G, S = _spd(rng, 4), _spd(rng, 4), _spd(rng, 4), _spd(rng, 4)
+    r = combine_covariances(
+        Ra + G + S, Rb + G + S,
+        cov_global_a=G, cov_global_b=G,
+        cov_systematic_a=S, cov_systematic_b=S,
+        share_mode="globals_and_systematic_shared")
+    assert np.allclose(r.cov_combined, Ra + Rb, atol=1e-10)
+
+
+def test_slightly_differing_globals_use_the_mean():
+    # gA != gB (small along-hole variation): the shared estimate is the
+    # arithmetic mean, so cov_combined = A + B - (gA + gB).
+    rng = np.random.default_rng(3)
+    Ra, Rb = _spd(rng, 3), _spd(rng, 3)
+    gA = _spd(rng, 3, scale=0.5)
+    gB = gA * 1.05                       # 5% different realisation-magnitude
+    r = combine_covariances(Ra + gA, Rb + gB,
+                            cov_global_a=gA, cov_global_b=gB,
+                            share_mode="globals_shared")
+    assert np.allclose(r.cov_combined, Ra + Rb, atol=1e-10)
+
+
+def test_input_contracts():
+    rng = np.random.default_rng(4)
+    a, b = _spd(rng, 3), _spd(rng, 4)
+    with pytest.raises(ValueError, match="same shape"):
+        combine_covariances(a, b)
+    a, b = _spd(rng, 3), _spd(rng, 3)
+    with pytest.raises(ValueError, match="globals_shared requires"):
+        combine_covariances(a, b, share_mode="globals_shared")
+    with pytest.raises(ValueError, match="globals_and_systematic"):
+        combine_covariances(a, b, cov_global_a=a, cov_global_b=b,
+                            share_mode="globals_and_systematic_shared")
+    with pytest.raises(ValueError, match="unknown share_mode"):
+        combine_covariances(a, b, share_mode="nonsense")
+
+
+def test_inconsistent_shares_clip_to_psd_with_warning():
+    # "Global" bigger than the total it is claimed to be part of -> the
+    # difference covariance would go negative; the module must warn + clip PSD.
+    rng = np.random.default_rng(5)
+    total = _spd(rng, 3, scale=0.1)
+    g = _spd(rng, 3, scale=5.0)          # >> total: inconsistent share claim
+    with pytest.warns(RuntimeWarning, match="negative eigenvalues"):
+        r = combine_covariances(total, total,
+                                cov_global_a=g, cov_global_b=g,
+                                share_mode="globals_shared")
+    assert np.all(np.linalg.eigvalsh(r.cov_combined) >= -1e-12)   # PSD
+
+
+def test_result_type_and_fields():
+    rng = np.random.default_rng(6)
+    a, b = _spd(rng, 2), _spd(rng, 2)
+    r = combine_covariances(a, b, share_mode="all_independent")
+    assert isinstance(r, CombinedCovariance)
+    for f in ("cov_combined", "cov_naive", "sigma_naive",
+              "sigma_combined", "reduction_factor"):
+        assert getattr(r, f) is not None
+
+
+def test_end_to_end_two_error_modelled_surveys():
+    # Two co-platform wells with the ISCWSA model: Survey exposes cov_nev /
+    # cov_nev_global / cov_nev_systematic -- the documented feed-in. Sharing
+    # globals must tighten (or at worst not widen) the combined uncertainty.
+    def make(shift):
+        md = np.linspace(0, 2400, 40)
+        inc = np.clip(np.linspace(0, 80, 40), 0, 60)
+        azi = (np.linspace(0, 90, 40) + shift) % 360
+        return Survey(md=md, inc=inc, azi=azi, header=SurveyHeader(),
+                      error_model="ISCWSA MWD Rev5.11")
+    a, b = make(0.0), make(12.0)
+    assert a.cov_nev_global is not None          # the 0.19 Survey contract
+    r = combine_covariances(
+        a.cov_nev, b.cov_nev,
+        cov_global_a=a.cov_nev_global, cov_global_b=b.cov_nev_global,
+        share_mode="globals_shared")
+    # station 0 has zero covariance; ignore nan reduction there
+    red = r.reduction_factor[np.isfinite(r.reduction_factor)]
+    assert np.all(red >= 1.0 - 1e-9)             # sharing never widens
+    assert red.max() > 1.01                      # and genuinely tightens somewhere
+    assert np.all(np.linalg.eigvalsh(r.cov_combined) >= -1e-9)
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/welleng/__init__.py
+++ b/welleng/__init__.py
@@ -25,6 +25,7 @@ from welleng.exchange.edm_stream import (
     SurveyStation,
     WellboreSurvey,
 )
+import welleng.conditioning
 import welleng.fluid
 import welleng.node
 import welleng.architecture

--- a/welleng/conditioning.py
+++ b/welleng/conditioning.py
@@ -1,0 +1,194 @@
+"""Shared-error conditioning of two wells' combined covariance.
+
+The standard ISCWSA pair calculation assumes the two wells' position-error vectors are entirely
+independent — combined covariance ``Σ_A + Σ_B``. This is correct
+between geographically and temporally separated wells, where the
+underlying error sources (magnetic declination, geomagnetic reference
+field, sensor biases, …) really do realise independently. It is *not*
+correct for two wells drilled from the same platform within a short
+time window, where:
+
+- **Global error sources** (magnetic declination model errors,
+  BGGM/IFR field model errors, true-vs-grid azimuth correction) are
+  realised *identically* in both wells. They share one realisation.
+- **Systematic error sources** (sensor biases, tool misalignment, …)
+  are independent if the two wells used different tools, but
+  *identical* if they shared one MWD service per platform run. The
+  honest assumption depends on the operator and the campaign.
+- **Random error sources** (per-station survey noise) are always
+  independent.
+
+When global and (optionally) systematic terms are shared, they
+*cancel* in the position difference:
+
+    cov(X_A − X_B)
+        = cov_random_A + cov_random_B
+        + cov_systematic_A + cov_systematic_B   (if independent)
+        + (cov_global_A − cov_global_B)         (zero if shared)
+
+i.e. the difference covariance can be substantially smaller than the
+naive sum, which translates into a substantially lower probability
+of collision than the naive ISCWSA calculation reports.
+
+This module provides helpers to construct the *correct* combined
+covariance under different assumptions about which error components
+are shared between the two wells.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Literal
+
+import numpy as np
+from numpy.typing import NDArray
+
+ShareMode = Literal["all_independent", "globals_shared", "globals_and_systematic_shared"]
+
+
+@dataclass(frozen=True)
+class CombinedCovariance:
+    """Result of combining two wells' covariances under a sharing assumption.
+
+    Attributes
+    ----------
+    cov_combined : (n, 3, 3) ndarray
+        The covariance of ``X_A − X_B`` per station after
+        accounting for the share-mode.
+    cov_naive : (n, 3, 3) ndarray
+        The naive ``Σ_A + Σ_B`` for comparison.
+    sigma_naive : (n,) ndarray
+        ``sqrt(max eigenvalue)`` of cov_naive — naive 1σ in
+        worst direction, per station.
+    sigma_combined : (n,) ndarray
+        Same for cov_combined.
+    reduction_factor : (n,) ndarray
+        ``sigma_naive / sigma_combined`` per station — how much
+        the share-mode tightens the combined uncertainty.
+    """
+
+    cov_combined: NDArray[np.float64]
+    cov_naive: NDArray[np.float64]
+    sigma_naive: NDArray[np.float64]
+    sigma_combined: NDArray[np.float64]
+    reduction_factor: NDArray[np.float64]
+
+
+def combine_covariances(
+    cov_total_a: NDArray[np.float64],
+    cov_total_b: NDArray[np.float64],
+    *,
+    cov_global_a: NDArray[np.float64] | None = None,
+    cov_global_b: NDArray[np.float64] | None = None,
+    cov_systematic_a: NDArray[np.float64] | None = None,
+    cov_systematic_b: NDArray[np.float64] | None = None,
+    share_mode: ShareMode = "globals_shared",
+) -> CombinedCovariance:
+    """Combine two wells' per-station covariances under a share-mode.
+
+    Parameters
+    ----------
+    cov_total_a, cov_total_b : (n, 3, 3) ndarray
+        Total covariance per station for each well, as produced by
+        the ISCWSA error model.
+    cov_global_a, cov_global_b : (n, 3, 3) ndarray, optional
+        Global-error component per well (magnetic declination, BGGM /
+        IFR field model errors). Required when ``share_mode`` includes
+        global cancellation. The ISCWSA model in welleng exposes this
+        as ``Survey.cov_nev_global``.
+    cov_systematic_a, cov_systematic_b : (n, 3, 3) ndarray, optional
+        Systematic-error component per well (sensor biases, tool
+        misalignment). Required when share_mode is
+        ``'globals_and_systematic_shared'``. ISCWSA exposes this as
+        ``Survey.cov_nev_systematic``.
+    share_mode : {'all_independent', 'globals_shared', 'globals_and_systematic_shared'}
+        Which components are realised identically in the two wells:
+
+        - ``'all_independent'``: classical naive
+          ``Σ_A + Σ_B`` (no cancellation). Equivalent to passing
+          neither global nor systematic arrays.
+        - ``'globals_shared'`` (default): global error sources
+          realise identically; their contribution cancels in the
+          difference covariance. This is the operationally honest
+          default for two wells from the same platform.
+        - ``'globals_and_systematic_shared'``: both global and
+          systematic terms cancel. Stronger assumption — only
+          appropriate if the same MWD service / tool was used on
+          both wells.
+
+    Returns
+    -------
+    CombinedCovariance
+    """
+    cov_a = np.asarray(cov_total_a, dtype=float).reshape(-1, 3, 3)
+    cov_b = np.asarray(cov_total_b, dtype=float).reshape(-1, 3, 3)
+    if cov_a.shape != cov_b.shape:
+        raise ValueError(
+            f"cov_total_a {cov_a.shape} and cov_total_b {cov_b.shape} "
+            "must have the same shape (per-station alignment)"
+        )
+
+    cov_naive = cov_a + cov_b
+
+    if share_mode == "all_independent":
+        cov_combined = cov_naive.copy()
+    elif share_mode == "globals_shared":
+        if cov_global_a is None or cov_global_b is None:
+            raise ValueError("globals_shared requires cov_global_a and _b")
+        gA = np.asarray(cov_global_a, dtype=float).reshape(-1, 3, 3)
+        gB = np.asarray(cov_global_b, dtype=float).reshape(-1, 3, 3)
+        # If the global realisation is identical, the contribution to
+        # cov(X_A - X_B) is (gA + gB) - 2*shared_global. With identical
+        # gA == gB == g_shared, that's (g + g) - 2*g = 0. We don't
+        # require gA == gB exactly because sample-time differences
+        # along the well allow small variation; we subtract the
+        # arithmetic mean of the two as a robust shared estimate.
+        shared = 0.5 * (gA + gB)
+        cov_combined = cov_naive - 2.0 * shared
+    elif share_mode == "globals_and_systematic_shared":
+        if any(c is None for c in (cov_global_a, cov_global_b,
+                                   cov_systematic_a, cov_systematic_b)):
+            raise ValueError(
+                "globals_and_systematic_shared requires cov_global_* "
+                "and cov_systematic_* for both wells"
+            )
+        gA = np.asarray(cov_global_a, dtype=float).reshape(-1, 3, 3)
+        gB = np.asarray(cov_global_b, dtype=float).reshape(-1, 3, 3)
+        sA = np.asarray(cov_systematic_a, dtype=float).reshape(-1, 3, 3)
+        sB = np.asarray(cov_systematic_b, dtype=float).reshape(-1, 3, 3)
+        shared = 0.5 * (gA + gB) + 0.5 * (sA + sB)
+        cov_combined = cov_naive - 2.0 * shared
+    else:
+        raise ValueError(f"unknown share_mode {share_mode!r}")
+
+    # Symmetrise + clip to PSD as defence against floating-point drift.
+    cov_combined = 0.5 * (cov_combined + cov_combined.swapaxes(-1, -2))
+    eig = np.linalg.eigvalsh(cov_combined)
+    if (eig < -1e-9).any():
+        # Strong sign that the share-mode is not consistent with the
+        # supplied components (e.g. globals_shared but Σ_global > Σ_total).
+        # Project onto PSD by clipping eigenvalues; warn quietly.
+        import warnings
+        warnings.warn(
+            "combined covariance had negative eigenvalues — clipping to "
+            "PSD; check share-mode assumption against your error model",
+            RuntimeWarning,
+        )
+        eigvals, eigvecs = np.linalg.eigh(cov_combined)
+        eigvals = np.clip(eigvals, 0.0, None)
+        cov_combined = np.einsum(
+            "...ij,...j,...kj->...ik", eigvecs, eigvals, eigvecs
+        )
+
+    sigma_naive = np.sqrt(np.linalg.eigvalsh(cov_naive).max(axis=-1))
+    sigma_combined = np.sqrt(np.linalg.eigvalsh(cov_combined).max(axis=-1))
+    with np.errstate(divide="ignore", invalid="ignore"):
+        reduction = np.where(sigma_combined > 0, sigma_naive / sigma_combined, np.nan)
+
+    return CombinedCovariance(
+        cov_combined=cov_combined,
+        cov_naive=cov_naive,
+        sigma_naive=sigma_naive,
+        sigma_combined=sigma_combined,
+        reduction_factor=reduction,
+    )

--- a/welleng/conditioning.py
+++ b/welleng/conditioning.py
@@ -1,8 +1,8 @@
 """Shared-error conditioning of two wells' combined covariance.
 
-The standard ISCWSA pair calculation assumes the two wells' position-error vectors are entirely
-independent — combined covariance ``Σ_A + Σ_B``. This is correct
-between geographically and temporally separated wells, where the
+The standard ISCWSA pair calculation assumes the two wells' position-error
+vectors are entirely independent — combined covariance ``Σ_A + Σ_B``. This
+is correct between geographically and temporally separated wells, where the
 underlying error sources (magnetic declination, geomagnetic reference
 field, sensor biases, …) really do realise independently. It is *not*
 correct for two wells drilled from the same platform within a short
@@ -43,7 +43,9 @@ from typing import Literal
 import numpy as np
 from numpy.typing import NDArray
 
-ShareMode = Literal["all_independent", "globals_shared", "globals_and_systematic_shared"]
+ShareMode = Literal[
+    "all_independent", "globals_shared", "globals_and_systematic_shared"
+]
 
 
 @dataclass(frozen=True)
@@ -101,7 +103,8 @@ def combine_covariances(
         misalignment). Required when share_mode is
         ``'globals_and_systematic_shared'``. ISCWSA exposes this as
         ``Survey.cov_nev_systematic``.
-    share_mode : {'all_independent', 'globals_shared', 'globals_and_systematic_shared'}
+    share_mode : {'all_independent', 'globals_shared', \
+'globals_and_systematic_shared'}
         Which components are realised identically in the two wells:
 
         - ``'all_independent'``: classical naive
@@ -183,7 +186,9 @@ def combine_covariances(
     sigma_naive = np.sqrt(np.linalg.eigvalsh(cov_naive).max(axis=-1))
     sigma_combined = np.sqrt(np.linalg.eigvalsh(cov_combined).max(axis=-1))
     with np.errstate(divide="ignore", invalid="ignore"):
-        reduction = np.where(sigma_combined > 0, sigma_naive / sigma_combined, np.nan)
+        reduction = np.where(
+            sigma_combined > 0, sigma_naive / sigma_combined, np.nan
+        )
 
     return CombinedCovariance(
         cov_combined=cov_combined,


### PR DESCRIPTION
## What
New `welleng.conditioning` module. The naive pair combination `Σ_A + Σ_B` assumes the two wells' error realisations are fully independent. For wells drilled from the same platform that's wrong: **global** sources (declination / geomagnetic reference model errors) realise **identically** in both wells — and shared realisations **cancel in the position difference** — so `cov(X_A − X_B)` can be substantially smaller than the naive sum. Systematic sources optionally share too (same tool/service on both wells).

## API
- `combine_covariances(cov_total_a, cov_total_b, *, cov_global_*, cov_systematic_*, share_mode)` → `CombinedCovariance` (combined + naive covariance, worst-direction σs, per-station reduction factor).
- `ShareMode = 'all_independent' | 'globals_shared' (default) | 'globals_and_systematic_shared'`.
- Feeds from the existing `Survey.cov_nev_global` / `cov_nev_systematic`.
- Defensive: shape/argument contracts raise; an inconsistent share claim (a "component" exceeding its total) warns + clips to PSD.

## Tests (8)
Exact cancellation algebra per mode (identical shares reduce the combined covariance to the random parts **exactly**), arithmetic-mean shared estimate for slightly differing realisations, input contracts, PSD defence, and an end-to-end run on two ISCWSA-modelled Surveys (sharing never widens; genuinely tightens). Suite spot 52 passed. Leak PASS.

First increment of the composition/hierarchy consolidation (per the local scope doc); `SurveyComposition` and the hierarchy/OSDU layer follow as separate PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)