### PR TITLE
feat(composition): SurveyComposition — multi-tool survey sections, tied covariance

### DIFF
--- a/benchmarks/BENCHMARK_LOG.md
+++ b/benchmarks/BENCHMARK_LOG.md
@@ -381,3 +381,23 @@ exactly.) Only the OUTER `get_sf_mins` optimisation stays scipy: it minimises th
 *separation factor* over reference MD (dist/EOU with a covariance projection), a
 genuine 1-D optimisation with no clean closed form, and fires only at local SF
 minima. The O(n^2) broadphase remains a separately-tracked lever.
+
+## 2026-07-19 · `feat/survey-composition-0.19` · Python 3.12, dev machine
+
+`SurveyComposition` — tie a wellbore's ordered survey sections (per-section
+tool/error model) into one Survey with per-component-correct covariance carry
+(systematic stays correlated within a tool run, restarts at a tool change;
+global geomag carries per share-mode; random correlates per error model).
+
+| operation | result |
+|---|---|
+| compose 3-tool / 202-station wellbore | **16.4 ms** |
+| single-survey error model, same geometry | 3.8 ms |
+
+~4x a single survey — the compose builds each error component as its correlated
+run (multiple Survey+error evaluations; model-definition parses are cached from
+the 0.19 cache). Absolute cost is interactive-fine for the single-wellbore path;
+errors stay lazy at the Survey level. Structural validation: same-tool sections
+compose EXACTLY equal to the single continuous survey (the tie/leg formulation
+of the ISCWSA error-model definition, §4.7), tool-change carry + systematic
+independence + sidetrack ties pinned in tests/test_survey_composition.py (16).

--- a/tests/test_conditioning.py
+++ b/tests/test_conditioning.py
@@ -1,0 +1,133 @@
+"""welleng.conditioning — shared-error conditioning of two wells' combined
+covariance (co-located wells share global / systematic error realisations, which
+cancel in the position DIFFERENCE; the naive Sigma_A + Sigma_B over-states it).
+
+Pinned here: the exact cancellation algebra per share-mode, the input contracts,
+the PSD defence, the public import surface, and an end-to-end run on two real
+error-modelled Surveys.
+"""
+import numpy as np
+import pytest
+
+from welleng.conditioning import (
+    CombinedCovariance,
+    ShareMode,          # noqa: F401  (the import IS the contract)
+    combine_covariances,
+)
+from welleng.survey import Survey, SurveyHeader
+
+
+def _spd(rng, n, scale=1.0):
+    """Random (n, 3, 3) SPD stack."""
+    A = rng.normal(size=(n, 3, 3))
+    return scale * np.einsum("nij,nkj->nik", A, A) + 1e-6 * np.eye(3)
+
+
+def test_all_independent_is_naive_sum():
+    rng = np.random.default_rng(0)
+    a, b = _spd(rng, 5), _spd(rng, 5)
+    r = combine_covariances(a, b, share_mode="all_independent")
+    assert np.allclose(r.cov_combined, a + b)
+    assert np.allclose(r.cov_naive, a + b)
+    assert np.allclose(r.reduction_factor, 1.0)
+
+
+def test_globals_shared_cancels_identical_global():
+    # A = R_a + G, B = R_b + G with the SAME global realisation G:
+    # cov(X_A - X_B) must reduce to R_a + R_b exactly.
+    rng = np.random.default_rng(1)
+    Ra, Rb, G = _spd(rng, 6), _spd(rng, 6), _spd(rng, 6)
+    r = combine_covariances(Ra + G, Rb + G,
+                            cov_global_a=G, cov_global_b=G,
+                            share_mode="globals_shared")
+    assert np.allclose(r.cov_combined, Ra + Rb, atol=1e-10)
+    assert np.all(r.reduction_factor >= 1.0 - 1e-12)
+
+
+def test_globals_and_systematic_shared_cancels_both():
+    rng = np.random.default_rng(2)
+    Ra, Rb, G, S = _spd(rng, 4), _spd(rng, 4), _spd(rng, 4), _spd(rng, 4)
+    r = combine_covariances(
+        Ra + G + S, Rb + G + S,
+        cov_global_a=G, cov_global_b=G,
+        cov_systematic_a=S, cov_systematic_b=S,
+        share_mode="globals_and_systematic_shared")
+    assert np.allclose(r.cov_combined, Ra + Rb, atol=1e-10)
+
+
+def test_slightly_differing_globals_use_the_mean():
+    # gA != gB (small along-hole variation): the shared estimate is the
+    # arithmetic mean, so cov_combined = A + B - (gA + gB).
+    rng = np.random.default_rng(3)
+    Ra, Rb = _spd(rng, 3), _spd(rng, 3)
+    gA = _spd(rng, 3, scale=0.5)
+    gB = gA * 1.05                       # 5% different realisation-magnitude
+    r = combine_covariances(Ra + gA, Rb + gB,
+                            cov_global_a=gA, cov_global_b=gB,
+                            share_mode="globals_shared")
+    assert np.allclose(r.cov_combined, Ra + Rb, atol=1e-10)
+
+
+def test_input_contracts():
+    rng = np.random.default_rng(4)
+    a, b = _spd(rng, 3), _spd(rng, 4)
+    with pytest.raises(ValueError, match="same shape"):
+        combine_covariances(a, b)
+    a, b = _spd(rng, 3), _spd(rng, 3)
+    with pytest.raises(ValueError, match="globals_shared requires"):
+        combine_covariances(a, b, share_mode="globals_shared")
+    with pytest.raises(ValueError, match="globals_and_systematic"):
+        combine_covariances(a, b, cov_global_a=a, cov_global_b=b,
+                            share_mode="globals_and_systematic_shared")
+    with pytest.raises(ValueError, match="unknown share_mode"):
+        combine_covariances(a, b, share_mode="nonsense")
+
+
+def test_inconsistent_shares_clip_to_psd_with_warning():
+    # "Global" bigger than the total it is claimed to be part of -> the
+    # difference covariance would go negative; the module must warn + clip PSD.
+    rng = np.random.default_rng(5)
+    total = _spd(rng, 3, scale=0.1)
+    g = _spd(rng, 3, scale=5.0)          # >> total: inconsistent share claim
+    with pytest.warns(RuntimeWarning, match="negative eigenvalues"):
+        r = combine_covariances(total, total,
+                                cov_global_a=g, cov_global_b=g,
+                                share_mode="globals_shared")
+    assert np.all(np.linalg.eigvalsh(r.cov_combined) >= -1e-12)   # PSD
+
+
+def test_result_type_and_fields():
+    rng = np.random.default_rng(6)
+    a, b = _spd(rng, 2), _spd(rng, 2)
+    r = combine_covariances(a, b, share_mode="all_independent")
+    assert isinstance(r, CombinedCovariance)
+    for f in ("cov_combined", "cov_naive", "sigma_naive",
+              "sigma_combined", "reduction_factor"):
+        assert getattr(r, f) is not None
+
+
+def test_end_to_end_two_error_modelled_surveys():
+    # Two co-platform wells with the ISCWSA model: Survey exposes cov_nev /
+    # cov_nev_global / cov_nev_systematic -- the documented feed-in. Sharing
+    # globals must tighten (or at worst not widen) the combined uncertainty.
+    def make(shift):
+        md = np.linspace(0, 2400, 40)
+        inc = np.clip(np.linspace(0, 80, 40), 0, 60)
+        azi = (np.linspace(0, 90, 40) + shift) % 360
+        return Survey(md=md, inc=inc, azi=azi, header=SurveyHeader(),
+                      error_model="ISCWSA MWD Rev5.11")
+    a, b = make(0.0), make(12.0)
+    assert a.cov_nev_global is not None          # the 0.19 Survey contract
+    r = combine_covariances(
+        a.cov_nev, b.cov_nev,
+        cov_global_a=a.cov_nev_global, cov_global_b=b.cov_nev_global,
+        share_mode="globals_shared")
+    # station 0 has zero covariance; ignore nan reduction there
+    red = r.reduction_factor[np.isfinite(r.reduction_factor)]
+    assert np.all(red >= 1.0 - 1e-9)             # sharing never widens
+    assert red.max() > 1.01                      # and genuinely tightens somewhere
+    assert np.all(np.linalg.eigvalsh(r.cov_combined) >= -1e-9)
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/tests/test_survey_composition.py
+++ b/tests/test_survey_composition.py
@@ -1,0 +1,351 @@
+"""Tests for welleng.composition.SurveyComposition.
+
+Ties a wellbore's ordered survey sections (legs) into one continuous survey
+with per-component-correct covariance carry across tool changes.
+"""
+import json
+
+import numpy as np
+import pytest
+
+from welleng.survey import Survey, SurveyHeader
+from welleng.composition import SurveyComposition, SurveySection
+from welleng.conditioning import combine_covariances
+
+EM = "ISCWSA MWD Rev5.11"
+WELL_DATA = "tests/test_data/clearance_iscwsa_well_data.json"
+
+
+def _header():
+    sh = SurveyHeader()
+    sh.azi_reference = "grid"
+    sh.b_total = 50000.0
+    sh.dip = 70.0
+    sh.latitude = 60.0
+    return sh
+
+
+def _geometry():
+    md = np.arange(0.0, 2001.0, 100.0)
+    inc = np.linspace(0.0, 90.0, len(md))
+    azi = np.full(len(md), 45.0)
+    return md, inc, azi
+
+
+# --------------------------------------------------------------------------- #
+# grouping
+# --------------------------------------------------------------------------- #
+def test_same_tool_sections_form_one_group():
+    md, inc, azi = _geometry()
+    sh = _header()
+    i = 6
+    comp = SurveyComposition([
+        SurveySection(md=md[:i + 1], inc=inc[:i + 1], azi=azi[:i + 1],
+                      header=sh, error_model=EM, tool_id="T1"),
+        SurveySection(md=md[i:], inc=inc[i:], azi=azi[i:],
+                      header=sh, error_model=EM, tool_id="T1"),
+    ])
+    assert len(comp._groups) == 1
+
+
+def test_tool_change_forms_two_groups():
+    md, inc, azi = _geometry()
+    sh = _header()
+    i = 6
+    comp = SurveyComposition([
+        SurveySection(md=md[:i + 1], inc=inc[:i + 1], azi=azi[:i + 1],
+                      header=sh, error_model=EM, tool_id="T1"),
+        SurveySection(md=md[i:], inc=inc[i:], azi=azi[i:],
+                      header=sh, error_model=EM, tool_id="T2"),
+    ])
+    assert len(comp._groups) == 2
+
+
+# --------------------------------------------------------------------------- #
+# GATE 1: same-tool continuation is IDENTICAL to one Survey
+# --------------------------------------------------------------------------- #
+def test_same_tool_equals_single_survey():
+    md, inc, azi = _geometry()
+    sh = _header()
+    full = Survey(md=md, inc=inc, azi=azi, header=sh, error_model=EM)
+    i = 6
+    comp = SurveyComposition([
+        SurveySection(md=md[:i + 1], inc=inc[:i + 1], azi=azi[:i + 1],
+                      header=sh, error_model=EM, tool_id="T1"),
+        SurveySection(md=md[i:], inc=inc[i:], azi=azi[i:],
+                      header=sh, error_model=EM, tool_id="T1"),
+    ]).survey()
+
+    assert np.allclose(comp.md, full.md)
+    # the key correctness test: systematic accumulates correlated, not restarted
+    assert np.allclose(comp.cov_nev, full.cov_nev, atol=1e-9)
+    assert np.allclose(comp.cov_nev_global, full.cov_nev_global, atol=1e-9)
+    assert np.allclose(comp.cov_nev_systematic, full.cov_nev_systematic,
+                       atol=1e-9)
+    assert np.allclose(comp.cov_nev_random, full.cov_nev_random, atol=1e-9)
+
+
+def test_three_same_tool_sections_equal_single_survey():
+    md, inc, azi = _geometry()
+    sh = _header()
+    full = Survey(md=md, inc=inc, azi=azi, header=sh, error_model=EM)
+    a, b = 5, 12
+    comp = SurveyComposition([
+        SurveySection(md=md[:a + 1], inc=inc[:a + 1], azi=azi[:a + 1],
+                      header=sh, error_model=EM, tool_id="T1"),
+        SurveySection(md=md[a:b + 1], inc=inc[a:b + 1], azi=azi[a:b + 1],
+                      header=sh, error_model=EM, tool_id="T1"),
+        SurveySection(md=md[b:], inc=inc[b:], azi=azi[b:],
+                      header=sh, error_model=EM, tool_id="T1"),
+    ]).survey()
+    assert np.allclose(comp.cov_nev, full.cov_nev, atol=1e-9)
+
+
+# --------------------------------------------------------------------------- #
+# GATE 2: a tool change carries the position covariance (does not reset)
+# --------------------------------------------------------------------------- #
+def test_tool_change_carries_covariance():
+    md, inc, azi = _geometry()
+    sh = _header()
+    i = 6
+    comp = SurveyComposition([
+        SurveySection(md=md[:i + 1], inc=inc[:i + 1], azi=azi[:i + 1],
+                      header=sh, error_model=EM, tool_id="T1"),
+        SurveySection(md=md[i:], inc=inc[i:], azi=azi[i:],
+                      header=sh, error_model=EM, tool_id="T2"),
+    ]).survey()
+
+    # covariance at the tie is non-zero (carried) and grows downstream
+    assert np.trace(comp.cov_nev[i]) > 0.0
+    assert np.trace(comp.cov_nev[-1]) > np.trace(comp.cov_nev[i])
+    # component buckets always sum to the total
+    assert np.allclose(
+        comp.cov_nev,
+        comp.cov_nev_global + comp.cov_nev_systematic + comp.cov_nev_random,
+    )
+
+
+def test_new_tool_systematic_is_independent():
+    """A tool change restarts the (independent) systematic, so the end
+    systematic is smaller than if one tool accumulated it correlated."""
+    md, inc, azi = _geometry()
+    sh = _header()
+    i = 6
+    same = SurveyComposition([
+        SurveySection(md=md[:i + 1], inc=inc[:i + 1], azi=azi[:i + 1],
+                      header=sh, error_model=EM, tool_id="T1"),
+        SurveySection(md=md[i:], inc=inc[i:], azi=azi[i:],
+                      header=sh, error_model=EM, tool_id="T1"),
+    ]).survey()
+    changed = SurveyComposition([
+        SurveySection(md=md[:i + 1], inc=inc[:i + 1], azi=azi[:i + 1],
+                      header=sh, error_model=EM, tool_id="T1"),
+        SurveySection(md=md[i:], inc=inc[i:], azi=azi[i:],
+                      header=sh, error_model=EM, tool_id="T2"),
+    ]).survey()
+    # random is identical (always independent); systematic is smaller when the
+    # tool changes (independent realisation, not one correlated accumulation).
+    assert np.allclose(same.cov_nev_random, changed.cov_nev_random, atol=1e-9)
+    assert np.trace(changed.cov_nev_systematic[-1]) < np.trace(
+        same.cov_nev_systematic[-1]
+    )
+
+
+# --------------------------------------------------------------------------- #
+# GATE 3: share_mode overrides
+# --------------------------------------------------------------------------- #
+def _reference_and_composed(tie_share_mode):
+    md, inc, azi = _geometry()
+    sh = _header()
+    i = 5
+    reference = Survey(md=md, inc=inc, azi=azi, header=sh, error_model=EM)
+    composed = SurveyComposition([
+        SurveySection(md=md[:i + 1], inc=inc[:i + 1], azi=azi[:i + 1],
+                      header=sh, error_model=EM, tool_id="T1"),
+        SurveySection(md=md[i:], inc=inc[i:], azi=azi[i:],
+                      header=sh, error_model=EM, tool_id="T2",
+                      share_mode=tie_share_mode),
+    ]).survey()
+    return reference, composed
+
+
+def _relative_sigma(a, b, combine_mode):
+    return combine_covariances(
+        a.cov_nev, b.cov_nev,
+        cov_global_a=a.cov_nev_global, cov_global_b=b.cov_nev_global,
+        cov_systematic_a=a.cov_nev_systematic,
+        cov_systematic_b=b.cov_nev_systematic,
+        share_mode=combine_mode,
+    ).sigma_combined
+
+
+def test_share_mode_tie_all_independent_larger_than_globals_shared():
+    """An all_independent tie leaves its post-tie global in the non-cancelling
+    bucket, so the difference against a well sharing the campaign geomag is
+    LARGER than for a globals_shared tie (globals don't cancel)."""
+    ref, gs = _reference_and_composed("globals_shared")
+    _, ai = _reference_and_composed("all_independent")
+    rel_gs = _relative_sigma(ref, gs, "globals_shared")[-1]
+    rel_ai = _relative_sigma(ref, ai, "globals_shared")[-1]
+    assert rel_ai > rel_gs
+    # and the cancellable global bucket is (much) smaller for the independent tie
+    assert np.trace(ai.cov_nev_global[-1]) < np.trace(gs.cov_nev_global[-1])
+
+
+def test_combine_share_mode_ordering_on_composed_buckets():
+    """The composed per-component buckets drive combine_covariances: more
+    sharing -> more cancellation -> smaller combined covariance."""
+    ref, comp = _reference_and_composed("globals_shared")
+    rel_indep = _relative_sigma(ref, comp, "all_independent")[-1]
+    rel_glob = _relative_sigma(ref, comp, "globals_shared")[-1]
+    rel_both = _relative_sigma(ref, comp, "globals_and_systematic_shared")[-1]
+    assert rel_indep > rel_glob > rel_both
+
+
+# --------------------------------------------------------------------------- #
+# auto share-mode from context keys
+# --------------------------------------------------------------------------- #
+def test_auto_share_mode_far_apart_dates_independent():
+    md, inc, azi = _geometry()
+    sh = _header()
+    i = 6
+    comp = SurveyComposition([
+        SurveySection(md=md[:i + 1], inc=inc[:i + 1], azi=azi[:i + 1],
+                      header=sh, error_model=EM, tool_id="T1",
+                      survey_date="2001-01-01"),
+        SurveySection(md=md[i:], inc=inc[i:], azi=azi[i:],
+                      header=sh, error_model=EM, tool_id="T2",
+                      survey_date="2020-06-01"),  # ~19 years later
+    ])
+    assert comp._groups[1].share_mode == "all_independent"
+
+
+def test_auto_share_mode_close_dates_globals_shared():
+    md, inc, azi = _geometry()
+    sh = _header()
+    i = 6
+    comp = SurveyComposition([
+        SurveySection(md=md[:i + 1], inc=inc[:i + 1], azi=azi[:i + 1],
+                      header=sh, error_model=EM, tool_id="T1",
+                      survey_date="2020-01-01"),
+        SurveySection(md=md[i:], inc=inc[i:], azi=azi[i:],
+                      header=sh, error_model=EM, tool_id="T2",
+                      survey_date="2020-03-01"),
+    ])
+    assert comp._groups[1].share_mode == "globals_shared"
+
+
+def test_auto_share_mode_different_geomag_model_independent():
+    md, inc, azi = _geometry()
+    sh = _header()
+    i = 6
+    comp = SurveyComposition([
+        SurveySection(md=md[:i + 1], inc=inc[:i + 1], azi=azi[:i + 1],
+                      header=sh, error_model=EM, tool_id="T1",
+                      geomag_model="BGGM2015"),
+        SurveySection(md=md[i:], inc=inc[i:], azi=azi[i:],
+                      header=sh, error_model=EM, tool_id="T2",
+                      geomag_model="IFR3"),
+    ])
+    assert comp._groups[1].share_mode == "all_independent"
+
+
+# --------------------------------------------------------------------------- #
+# GATE 4: ISCWSA well-10 side-track tie-on to the Reference well
+# --------------------------------------------------------------------------- #
+def _load_wells():
+    wells = json.load(open(WELL_DATA))["wells"]
+
+    def mk_header(h):
+        sh = SurveyHeader()
+        for k, v in h.items():
+            if k != "name":
+                setattr(sh, k, v)
+        return sh
+    return wells, mk_header
+
+
+def test_sidetrack_tie_carries_reference_covariance():
+    wells, mk_header = _load_wells()
+    ref, w10 = wells["Reference well"], wells["10 - well"]
+    header = mk_header(ref["header"])
+    tie_idx = ref["MD"].index(900.0)  # side-track ties on at MD 900
+
+    # compose: reference trunk (to MD 900) + side-track (well 10)
+    composed = SurveyComposition([
+        SurveySection(md=ref["MD"][:tie_idx + 1], inc=ref["IncDeg"][:tie_idx + 1],
+                      azi=ref["AziDeg"][:tie_idx + 1], header=header,
+                      error_model=EM, tool_id="trunk"),
+        SurveySection(md=w10["MD"], inc=w10["IncDeg"], azi=w10["AziDeg"],
+                      header=header, error_model=EM, tool_id="sidetrack"),
+    ]).survey()
+
+    # a single unified survey over the SAME stitched geometry (one tool) is the
+    # reference for what the tie station's covariance MUST be.
+    umd = np.concatenate([ref["MD"][:tie_idx + 1], w10["MD"][1:]])
+    uinc = np.concatenate([ref["IncDeg"][:tie_idx + 1], w10["IncDeg"][1:]])
+    uazi = np.concatenate([ref["AziDeg"][:tie_idx + 1], w10["AziDeg"][1:]])
+    unified = Survey(md=umd, inc=uinc, azi=uazi, header=header, error_model=EM)
+
+    # the tie station carries the parent's covariance exactly (not reset)
+    assert np.allclose(composed.cov_nev[tie_idx], unified.cov_nev[tie_idx],
+                       atol=1e-9)
+    assert np.trace(composed.cov_nev[tie_idx]) > 0.0
+    # covariance grows down the side-track
+    assert np.trace(composed.cov_nev[-1]) > np.trace(composed.cov_nev[tie_idx])
+
+
+def test_sidetrack_relative_to_parent_zero_at_tie():
+    """The side-track inherits the parent's position error at the tie, so its
+    uncertainty RELATIVE to the tie point is zero there and grows downstream."""
+    wells, mk_header = _load_wells()
+    ref, w10 = wells["Reference well"], wells["10 - well"]
+    header = mk_header(ref["header"])
+    tie_idx = ref["MD"].index(900.0)
+
+    composed = SurveyComposition([
+        SurveySection(md=ref["MD"][:tie_idx + 1], inc=ref["IncDeg"][:tie_idx + 1],
+                      azi=ref["AziDeg"][:tie_idx + 1], header=header,
+                      error_model=EM, tool_id="trunk"),
+        SurveySection(md=w10["MD"], inc=w10["IncDeg"], azi=w10["AziDeg"],
+                      header=header, error_model=EM, tool_id="sidetrack"),
+    ]).survey()
+
+    carried = composed.cov_nev[tie_idx]
+    # side-track uncertainty relative to the tie carry
+    rel = composed.cov_nev - carried[None, :, :]
+    assert np.allclose(rel[tie_idx], 0.0, atol=1e-9)          # zero at the tie
+    assert np.trace(rel[-1]) > 0.0                            # grows below it
+
+
+# --------------------------------------------------------------------------- #
+# misc API
+# --------------------------------------------------------------------------- #
+def test_tie_mismatch_raises():
+    md, inc, azi = _geometry()
+    sh = _header()
+    with pytest.raises(ValueError):
+        SurveyComposition([
+            SurveySection(md=md[:7], inc=inc[:7], azi=azi[:7],
+                          header=sh, error_model=EM, tool_id="T1"),
+            SurveySection(md=md[9:], inc=inc[9:], azi=azi[9:],  # gap: no tie
+                          header=sh, error_model=EM, tool_id="T2"),
+        ])
+
+
+def test_survey_is_cached():
+    md, inc, azi = _geometry()
+    sh = _header()
+    comp = SurveyComposition([
+        SurveySection(md=md, inc=inc, azi=azi, header=sh, error_model=EM),
+    ])
+    assert comp.survey() is comp.survey()
+
+
+def test_section_from_survey_object():
+    md, inc, azi = _geometry()
+    sh = _header()
+    s = Survey(md=md, inc=inc, azi=azi, header=sh, error_model=EM)
+    comp = SurveyComposition([SurveySection(survey=s)]).survey()
+    single = Survey(md=md, inc=inc, azi=azi, header=sh, error_model=EM)
+    assert np.allclose(comp.cov_nev, single.cov_nev, atol=1e-9)

--- a/welleng/__init__.py
+++ b/welleng/__init__.py
@@ -25,6 +25,7 @@ from welleng.exchange.edm_stream import (
     SurveyStation,
     WellboreSurvey,
 )
+import welleng.conditioning
 import welleng.fluid
 import welleng.node
 import welleng.architecture

--- a/welleng/__init__.py
+++ b/welleng/__init__.py
@@ -25,7 +25,9 @@ from welleng.exchange.edm_stream import (
     SurveyStation,
     WellboreSurvey,
 )
+import welleng.composition
 import welleng.conditioning
+from welleng.composition import SurveyComposition, SurveySection
 import welleng.fluid
 import welleng.node
 import welleng.architecture

--- a/welleng/composition.py
+++ b/welleng/composition.py
@@ -1,0 +1,562 @@
+"""Compose a single wellbore's survey sections into one tied survey.
+
+A wellbore is rarely surveyed by a single continuous run of one tool. It is
+drilled and surveyed in ordered *sections* (legs), each potentially using a
+different survey tool / ISCWSA error model, and each tied on to the end of the
+previous section. Naively concatenating the per-section covariances is wrong
+in two opposite ways:
+
+- **Restarting the systematic error at every section** understates the
+  uncertainty of a section that is really one continuous survey (the
+  systematic sensor biases keep accumulating *correlated* down the hole — they
+  are one physical realisation, not a fresh draw per section).
+- **Treating a genuine tool change as one continuous survey** overstates the
+  correlation: a new tool's sensor biases are an *independent* realisation, so
+  its systematic error must restart (while the accumulated *position*
+  uncertainty of course carries forward).
+
+``SurveyComposition`` ties the sections together with per-component-correct
+covariance carry:
+
+1. Consecutive sections sharing a tool (same ``error_model`` *and* ``tool_id``)
+   are grouped into **one** :class:`~welleng.survey.Survey` so their systematic
+   error accumulates correlated — exactly as if surveyed in one run.
+2. At a tool change the next group is tied on at the previous group's end
+   position, carrying the accumulated covariance. The new tool's *systematic*
+   is independent (restarts); only the accumulated *position* covariance and
+   the shared *global* geomagnetic terms carry across the tie.
+3. Whether the *global* (declination / B-field, ``DECG`` / ``DBHG``) and
+   *systematic* terms are shared across a given tie is controlled by a
+   :data:`~welleng.conditioning.ShareMode`, defaulting to the ISCWSA Side-track
+   Clearance RP (2022) recommendation: within one wellbore / campaign the
+   global geomag terms stay *correlated* across the tie (same geomag date and
+   model), while sensor systematic *resets* at a tool change. A section drilled
+   in a different campaign (e.g. a side-track years later, different geomag
+   secular variation) can be marked ``all_independent``.
+
+The result is one unified :class:`~welleng.survey.Survey` whose total covariance
+*and* per-component (``cov_nev_global`` / ``cov_nev_systematic`` /
+``cov_nev_random``) breakdown are correctly composed. Preserving that breakdown
+is what lets the relative-error / anti-collision framework
+(:func:`welleng.conditioning.combine_covariances`) later difference two composed
+wellbores with correct cancellation of shared global terms.
+"""
+
+from __future__ import annotations
+
+import warnings
+from dataclasses import dataclass, field
+from datetime import datetime
+from typing import List, Optional, Sequence
+
+import numpy as np
+from numpy.typing import ArrayLike, NDArray
+
+from .conditioning import ShareMode
+from .survey import Survey, SurveyHeader
+
+__all__ = ["SurveySection", "SurveyComposition"]
+
+#: Default ISCWSA error model when a section does not name one.
+DEFAULT_ERROR_MODEL = "ISCWSA MWD Rev5.11"
+
+#: Survey-date gap (years) beyond which an unspecified tie auto-defaults to
+#: ``all_independent`` (geomag secular variation makes the global realisation
+#: effectively independent between campaigns this far apart).
+_DATE_INDEPENDENCE_YEARS = 2.0
+
+_TIE_MD_TOL = 1e-6
+
+
+@dataclass
+class SurveySection:
+    """One surveyed section (leg) of a wellbore, tied on to the previous one.
+
+    Provide either raw ``md`` / ``inc`` / ``azi`` arrays (with ``deg`` and an
+    optional ``header``) or an existing :class:`~welleng.survey.Survey` via
+    ``survey``. The first station of each section must coincide (in measured
+    depth) with the last station of the previous section — that shared station
+    is the tie-on.
+
+    Parameters
+    ----------
+    md, inc, azi : array_like, optional
+        Section geometry. Ignored if ``survey`` is given.
+    survey : welleng.survey.Survey, optional
+        An existing survey to take geometry (and, if not overridden, the
+        ``error_model`` / ``header``) from.
+    deg : bool, default True
+        Whether ``inc`` / ``azi`` are in degrees.
+    error_model : str, optional
+        ISCWSA error model name for this section's tool. Defaults to
+        :data:`DEFAULT_ERROR_MODEL`.
+    tool_id : str, optional
+        Identifier of the physical survey tool / run. Consecutive sections with
+        the *same* ``error_model`` and ``tool_id`` are treated as one
+        continuous survey (systematic error stays correlated). A change of
+        ``tool_id`` (or ``error_model``) marks a tool change / tie. ``None`` is
+        treated as "the same unspecified tool continuing" — so if you never say
+        the tool changed, it does not.
+    survey_date : str, optional
+        ``YYYY-MM-DD`` date the section was surveyed. Used only to auto-pick a
+        default ``share_mode`` at the tie *before* this section.
+    geomag_model : str, optional
+        Name of the geomagnetic reference model (e.g. ``"BGGM2020"``). Used only
+        to auto-pick a default ``share_mode``.
+    share_mode : {'all_independent', 'globals_shared', 'globals_and_systematic_shared'}, optional
+        Explicit override for how the tie *before* this section shares error
+        components with the previous group. If ``None``, auto-picked from the
+        context keys (see :class:`SurveyComposition`).
+    header : welleng.survey.SurveyHeader, optional
+        Survey header (geomag field, dip, location) for this section's error
+        model. Falls back to the composition-level default.
+    """
+
+    md: Optional[ArrayLike] = None
+    inc: Optional[ArrayLike] = None
+    azi: Optional[ArrayLike] = None
+    survey: Optional[Survey] = None
+    deg: bool = True
+    error_model: Optional[str] = None
+    tool_id: Optional[str] = None
+    survey_date: Optional[str] = None
+    geomag_model: Optional[str] = None
+    share_mode: Optional[ShareMode] = None
+    header: Optional[SurveyHeader] = None
+
+    def __post_init__(self) -> None:
+        if self.survey is not None:
+            if not isinstance(self.survey, Survey):
+                raise TypeError("`survey` must be a welleng.survey.Survey")
+            if self.error_model is None:
+                self.error_model = self.survey.error_model
+            if self.header is None:
+                self.header = self.survey.header
+        elif self.md is None or self.inc is None or self.azi is None:
+            raise ValueError(
+                "SurveySection needs either `survey` or all of md/inc/azi"
+            )
+
+
+@dataclass
+class _Group:
+    """A run of consecutive same-tool sections, built as one Survey."""
+
+    md: NDArray[np.float64]           # grid-radian geometry (tie station incl.)
+    inc_rad: NDArray[np.float64]
+    azi_grid_rad: NDArray[np.float64]
+    error_model: str
+    header: SurveyHeader
+    share_mode: ShareMode             # tie BEFORE this group (ignored for [0])
+    survey: Survey = field(default=None, repr=False)
+
+
+class SurveyComposition:
+    """Tie a wellbore's ordered survey sections into one continuous survey.
+
+    Parameters
+    ----------
+    sections : sequence of SurveySection
+        Ordered from shallow to deep. Each section ties on to the previous.
+    header : welleng.survey.SurveyHeader, optional
+        Default header applied to any section that does not carry its own.
+    share_mode : ShareMode, optional
+        Default share mode for every tie whose section does not set one and
+        for which the context keys do not force a choice. Defaults to
+        ``"globals_shared"`` (the ISCWSA side-track RP recommendation).
+
+    Notes
+    -----
+    **Auto share-mode.** When a section's ``share_mode`` is ``None`` the tie
+    before it is resolved from context: if the two sides name *different*
+    ``geomag_model`` values, or their ``survey_date`` values differ by more
+    than two years, the tie is ``all_independent`` (the global geomagnetic
+    realisation has drifted / changed model and no longer cancels); otherwise
+    the composition ``share_mode`` (default ``globals_shared``) is used.
+
+    **Mixed error models across a shared tie.** The *shared* (globally- or
+    systematically-correlated) component of a multi-group run is computed by
+    building that run as a single survey using the run's first section's error
+    model. This is exact when all groups in the run use the same error model
+    (the common case). If they differ, the shared component uses the first
+    model as the reference and a warning is issued.
+    """
+
+    def __init__(
+        self,
+        sections: Sequence[SurveySection],
+        header: Optional[SurveyHeader] = None,
+        share_mode: ShareMode = "globals_shared",
+    ) -> None:
+        sections = list(sections)
+        if not sections:
+            raise ValueError("SurveyComposition needs at least one section")
+        self.sections = sections
+        self.default_header = header
+        self.default_share_mode = share_mode
+
+        self._groups = self._build_groups()
+        self._survey: Optional[Survey] = None
+
+    # ------------------------------------------------------------------ #
+    # public API
+    # ------------------------------------------------------------------ #
+    def survey(self) -> Survey:
+        """Return the unified, tied :class:`~welleng.survey.Survey`.
+
+        The result carries the composed total covariance (``cov_nev`` /
+        ``cov_hla``) and its per-component breakdown (``cov_nev_global`` /
+        ``cov_nev_systematic`` / ``cov_nev_random``). It is cached.
+        """
+        if self._survey is None:
+            self._survey = self._compose()
+        return self._survey
+
+    # ------------------------------------------------------------------ #
+    # grouping
+    # ------------------------------------------------------------------ #
+    def _resolve_header(self, section: SurveySection) -> SurveyHeader:
+        header = section.header or self.default_header
+        if header is None:
+            header = SurveyHeader()
+        return header
+
+    def _section_grid(self, section: SurveySection):
+        """Normalise a section to (md, inc_rad, azi_grid_rad) + resolved meta."""
+        header = self._resolve_header(section)
+        error_model = section.error_model or DEFAULT_ERROR_MODEL
+        if section.survey is not None:
+            s = section.survey
+            md = np.asarray(s.md, dtype=float)
+            inc_rad = np.asarray(s.inc_rad, dtype=float)
+            azi_grid_rad = np.asarray(s.azi_grid_rad, dtype=float)
+        else:
+            # Build a geometry-only survey to normalise angles to grid radians
+            # regardless of the section's azi_reference / deg convention.
+            geom = Survey(
+                md=section.md, inc=section.inc, azi=section.azi,
+                deg=section.deg, header=header, error_model=None,
+            )
+            md = np.asarray(geom.md, dtype=float)
+            inc_rad = np.asarray(geom.inc_rad, dtype=float)
+            azi_grid_rad = np.asarray(geom.azi_grid_rad, dtype=float)
+        return md, inc_rad, azi_grid_rad, header, error_model
+
+    def _build_groups(self) -> List[_Group]:
+        groups: List[_Group] = []
+        prev_key = None
+        prev_tool_id = None
+        for section in self.sections:
+            md, inc_rad, azi_grid_rad, header, error_model = (
+                self._section_grid(section)
+            )
+            key = (error_model, section.tool_id)
+            same_tool = bool(groups) and key == prev_key
+
+            if same_tool:
+                g = groups[-1]
+                self._assert_tie(g.md[-1], md[0])
+                # drop the duplicate tie station of the appended section
+                g.md = np.hstack((g.md, md[1:]))
+                g.inc_rad = np.hstack((g.inc_rad, inc_rad[1:]))
+                g.azi_grid_rad = np.hstack((g.azi_grid_rad, azi_grid_rad[1:]))
+            else:
+                if groups:
+                    self._assert_tie(groups[-1].md[-1], md[0])
+                share_mode = self._resolve_share_mode(section, groups)
+                groups.append(_Group(
+                    md=md, inc_rad=inc_rad, azi_grid_rad=azi_grid_rad,
+                    error_model=error_model, header=header,
+                    share_mode=share_mode,
+                ))
+            prev_key = key
+            prev_tool_id = section.tool_id
+        return groups
+
+    @staticmethod
+    def _assert_tie(md_prev_end: float, md_next_start: float) -> None:
+        if abs(md_prev_end - md_next_start) > _TIE_MD_TOL:
+            raise ValueError(
+                f"section tie mismatch: previous section ends at MD "
+                f"{md_prev_end:g} but next starts at MD {md_next_start:g}; "
+                "each section must tie on at the previous section's last MD"
+            )
+
+    def _resolve_share_mode(
+        self, section: SurveySection, groups
+    ) -> ShareMode:
+        if section.share_mode is not None:
+            return section.share_mode
+        if not groups:
+            return self.default_share_mode  # no tie before the first group
+        prev_section = self._last_section_of_group(len(groups) - 1)
+        # Different geomag model -> independent globals.
+        if (
+            section.geomag_model is not None
+            and prev_section.geomag_model is not None
+            and section.geomag_model != prev_section.geomag_model
+        ):
+            return "all_independent"
+        # Far-apart survey dates -> independent globals.
+        d_new = _parse_date(section.survey_date)
+        d_old = _parse_date(prev_section.survey_date)
+        if d_new is not None and d_old is not None:
+            years = abs((d_new - d_old).days) / 365.25
+            if years > _DATE_INDEPENDENCE_YEARS:
+                return "all_independent"
+        return self.default_share_mode
+
+    def _last_section_of_group(self, group_index: int) -> SurveySection:
+        """The final input section that fed a given group (for context keys)."""
+        # Re-walk the section list mirroring _build_groups' grouping to find the
+        # last section belonging to `group_index`.
+        gi = -1
+        prev_key = None
+        last = self.sections[0]
+        for section in self.sections:
+            error_model = section.error_model or DEFAULT_ERROR_MODEL
+            key = (error_model, section.tool_id)
+            if not (gi >= 0 and key == prev_key):
+                gi += 1
+            if gi == group_index:
+                last = section
+            elif gi > group_index:
+                break
+            prev_key = key
+        return last
+
+    # ------------------------------------------------------------------ #
+    # composition
+    # ------------------------------------------------------------------ #
+    def _group_survey(self, g: _Group, start_nev) -> Survey:
+        # geometry-only (covariance components come from _run_component); this
+        # is used purely to chain group start positions.
+        if g.survey is None or not np.allclose(g.survey.start_nev, start_nev):
+            g.survey = Survey(
+                md=g.md, inc=g.inc_rad, azi=g.azi_grid_rad, deg=False,
+                header=g.header, error_model=None,
+                start_nev=np.asarray(start_nev, dtype=float),
+            )
+        return g.survey
+
+    def _compose(self) -> Survey:
+        groups = self._groups
+
+        # 1. Chain group start positions (only TVD affects covariance, but we
+        #    need continuous positions anyway).
+        start_nev = np.array([0.0, 0.0, 0.0])
+        group_surveys: List[Survey] = []
+        start_nevs: List[NDArray[np.float64]] = []
+        for g in groups:
+            start_nevs.append(np.asarray(start_nev, dtype=float))
+            s = self._group_survey(g, start_nev)
+            group_surveys.append(s)
+            start_nev = s.pos_nev[-1]
+
+        # 2. Compose each error component across the groups with its own
+        #    correlation rule.
+        share_global = [
+            g.share_mode in ("globals_shared", "globals_and_systematic_shared")
+            for g in groups
+        ]
+        share_systematic = [
+            g.share_mode == "globals_and_systematic_shared" for g in groups
+        ]
+        # Random noise accumulates continuously and depends only on the tool
+        # *type* (error model), never on the tool instance — so it stays
+        # correlated (one continuous run) across any tie that keeps the same
+        # error model, breaking only at a genuine model change. Composing it
+        # per-group instead would inject a small propagation-context artifact
+        # at every tool change.
+        share_random = [
+            groups[k].error_model == groups[k - 1].error_model
+            for k in range(len(groups))
+        ]
+        # k=0 has no tie before it.
+        share_global[0] = False
+        share_systematic[0] = False
+        share_random[0] = False
+
+        glob = self._compose_component(
+            "cov_nev_global", share_global, start_nevs
+        )
+        syst = self._compose_component(
+            "cov_nev_systematic", share_systematic, start_nevs
+        )
+        rand = self._compose_component(
+            "cov_nev_random", share_random, start_nevs
+        )
+
+        # 3. Stitch per-group arrays (drop duplicate tie station of each
+        #    subsequent group) into unified per-station arrays.
+        cov_global = self._stitch(glob)
+        cov_systematic = self._stitch(syst)
+        cov_random = self._stitch(rand)
+
+        # 3a. Re-bucket the non-cancellable global. The ``cov_nev_global``
+        #     bucket is what cancels against another wellbore that shares the
+        #     campaign's geomagnetic realisation. An ``all_independent`` tie
+        #     marks a change of that realisation (different geomag date/model),
+        #     so everything the well accumulates *after* the first such tie is
+        #     no longer cancellable against the campaign baseline — its global
+        #     contribution is folded into the (non-cancelling) systematic
+        #     bucket. The accumulated baseline global is frozen as a constant
+        #     offset downstream. This is total-preserving: it only moves
+        #     covariance between buckets, never changes ``cov_nev``.
+        cov_global, cov_systematic = self._rebucket_global(
+            cov_global, cov_systematic, share_global
+        )
+        cov_nev = cov_global + cov_systematic + cov_random
+
+        # 4. Unified geometry -> one Survey with the composed covariance.
+        md = self._stitch_1d([g.md for g in groups])
+        inc = self._stitch_1d([g.inc_rad for g in groups])
+        azi = self._stitch_1d([g.azi_grid_rad for g in groups])
+
+        header = groups[0].header
+        # Compose in the grid domain; force the unified header to match so the
+        # supplied grid angles are interpreted consistently.
+        if header.azi_reference != "grid":
+            header = _grid_header(header)
+
+        survey = Survey(
+            md=md, inc=inc, azi=azi, deg=False, header=header,
+            start_nev=group_surveys[0].start_nev,
+            start_xyz=group_surveys[0].start_xyz,
+            cov_nev=cov_nev, error_model=None,
+        )
+        survey.cov_nev_global = cov_global
+        survey.cov_nev_systematic = cov_systematic
+        survey.cov_nev_random = cov_random
+        return survey
+
+    def _rebucket_global(self, cov_global, cov_systematic, share_global):
+        """Fold post-``all_independent`` global into the systematic bucket.
+
+        Returns ``(cov_global_cancellable, cov_systematic_adjusted)`` with an
+        unchanged sum. See the caller for the rationale.
+        """
+        # first group tied on with a non-shared (all_independent) global
+        break_group = next(
+            (k for k in range(1, len(self._groups)) if not share_global[k]),
+            None,
+        )
+        if break_group is None:
+            return cov_global, cov_systematic  # everything cancellable
+
+        # unified index of the last station still connected to the baseline
+        # geomag realisation (the tie station into ``break_group``).
+        n_pref = len(self._groups[0].md)
+        for k in range(1, break_group):
+            n_pref += len(self._groups[k].md) - 1
+        b = n_pref - 1
+
+        baseline = cov_global[b]
+        cov_global_cancellable = cov_global.copy()
+        cov_systematic_adjusted = cov_systematic.copy()
+        # downstream of the break: freeze the baseline global, move the rest
+        # (post-break global accumulation) into the systematic bucket.
+        post = slice(b + 1, None)
+        cov_systematic_adjusted[post] += cov_global[post] - baseline
+        cov_global_cancellable[post] = baseline
+        return cov_global_cancellable, cov_systematic_adjusted
+
+    def _compose_component(self, attr, share, start_nevs):
+        """Return a list of per-group composed arrays (each incl tie station 0).
+
+        ``share[k]`` (k>=1) is True when this component continues *correlated*
+        across the tie before group k. Correlated runs are computed by building
+        the run as one survey; a carry (freeze + independent add) is applied
+        across run boundaries.
+        """
+        n = len(self._groups)
+        out: List[NDArray[np.float64]] = [None] * n
+        carry = np.zeros((3, 3))
+        k = 0
+        while k < n:
+            # maximal run [k..j] joined by shared ties
+            j = k
+            while j + 1 < n and share[j + 1]:
+                j += 1
+            run_comp = self._run_component(attr, k, j, start_nevs[k])
+            run_composed = carry + run_comp
+
+            # slice run back into per-group arrays (each incl its tie station)
+            idx = 0
+            for gi in range(k, j + 1):
+                n_g = len(self._groups[gi].md)
+                if gi == k:
+                    out[gi] = run_composed[idx:idx + n_g]
+                    idx += n_g
+                else:
+                    tie = run_composed[idx - 1][None]
+                    out[gi] = np.vstack((tie, run_composed[idx:idx + n_g - 1]))
+                    idx += n_g - 1
+            carry = run_composed[-1]
+            k = j + 1
+        return out
+
+    def _run_component(self, attr, k, j, start_nev):
+        """Component of groups k..j computed as ONE correlated survey.
+
+        A "ghost" continuation station (the first post-tie station of group
+        ``j+1``, if any) is appended so the run's final station — the tie into
+        the next group — is computed *with* its true following interval, exactly
+        as it would be in a single unified survey. The ghost is then discarded.
+        Several ISCWSA weight-function terms use the interval to the *next*
+        station, so without this the tie station would be mis-computed.
+        """
+        groups = self._groups[k:j + 1]
+        models = {g.error_model for g in groups}
+        if len(models) > 1:
+            warnings.warn(
+                "shared-error tie spans multiple error models "
+                f"{sorted(models)}; the shared component uses "
+                f"{groups[0].error_model!r} as the reference model",
+                RuntimeWarning,
+            )
+        md = self._stitch_1d([g.md for g in groups])
+        inc = self._stitch_1d([g.inc_rad for g in groups])
+        azi = self._stitch_1d([g.azi_grid_rad for g in groups])
+        n_real = len(md)
+        if j + 1 < len(self._groups) and len(self._groups[j + 1].md) > 1:
+            nxt = self._groups[j + 1]
+            md = np.append(md, nxt.md[1])
+            inc = np.append(inc, nxt.inc_rad[1])
+            azi = np.append(azi, nxt.azi_grid_rad[1])
+        run = Survey(
+            md=md, inc=inc, azi=azi, deg=False, header=groups[0].header,
+            error_model=groups[0].error_model, start_nev=start_nev,
+        )
+        return getattr(run, attr)[:n_real]
+
+    # ------------------------------------------------------------------ #
+    # stitching helpers (drop the duplicate tie station of each next group)
+    # ------------------------------------------------------------------ #
+    @staticmethod
+    def _stitch(arrays: List[NDArray[np.float64]]) -> NDArray[np.float64]:
+        parts = [arrays[0]] + [a[1:] for a in arrays[1:]]
+        return np.concatenate(parts, axis=0)
+
+    @staticmethod
+    def _stitch_1d(arrays: List[NDArray[np.float64]]) -> NDArray[np.float64]:
+        parts = [arrays[0]] + [a[1:] for a in arrays[1:]]
+        return np.concatenate(parts)
+
+
+def _parse_date(value: Optional[str]) -> Optional[datetime]:
+    if not value:
+        return None
+    for fmt in ("%Y-%m-%d", "%Y/%m/%d", "%d/%m/%Y"):
+        try:
+            return datetime.strptime(value, fmt)
+        except ValueError:
+            continue
+    return None
+
+
+def _grid_header(header: SurveyHeader) -> SurveyHeader:
+    import copy
+    h = copy.copy(header)
+    h.azi_reference = "grid"
+    return h

--- a/welleng/conditioning.py
+++ b/welleng/conditioning.py
@@ -1,0 +1,194 @@
+"""Shared-error conditioning of two wells' combined covariance.
+
+The standard ISCWSA pair calculation assumes the two wells' position-error vectors are entirely
+independent — combined covariance ``Σ_A + Σ_B``. This is correct
+between geographically and temporally separated wells, where the
+underlying error sources (magnetic declination, geomagnetic reference
+field, sensor biases, …) really do realise independently. It is *not*
+correct for two wells drilled from the same platform within a short
+time window, where:
+
+- **Global error sources** (magnetic declination model errors,
+  BGGM/IFR field model errors, true-vs-grid azimuth correction) are
+  realised *identically* in both wells. They share one realisation.
+- **Systematic error sources** (sensor biases, tool misalignment, …)
+  are independent if the two wells used different tools, but
+  *identical* if they shared one MWD service per platform run. The
+  honest assumption depends on the operator and the campaign.
+- **Random error sources** (per-station survey noise) are always
+  independent.
+
+When global and (optionally) systematic terms are shared, they
+*cancel* in the position difference:
+
+    cov(X_A − X_B)
+        = cov_random_A + cov_random_B
+        + cov_systematic_A + cov_systematic_B   (if independent)
+        + (cov_global_A − cov_global_B)         (zero if shared)
+
+i.e. the difference covariance can be substantially smaller than the
+naive sum, which translates into a substantially lower probability
+of collision than the naive ISCWSA calculation reports.
+
+This module provides helpers to construct the *correct* combined
+covariance under different assumptions about which error components
+are shared between the two wells.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Literal
+
+import numpy as np
+from numpy.typing import NDArray
+
+ShareMode = Literal["all_independent", "globals_shared", "globals_and_systematic_shared"]
+
+
+@dataclass(frozen=True)
+class CombinedCovariance:
+    """Result of combining two wells' covariances under a sharing assumption.
+
+    Attributes
+    ----------
+    cov_combined : (n, 3, 3) ndarray
+        The covariance of ``X_A − X_B`` per station after
+        accounting for the share-mode.
+    cov_naive : (n, 3, 3) ndarray
+        The naive ``Σ_A + Σ_B`` for comparison.
+    sigma_naive : (n,) ndarray
+        ``sqrt(max eigenvalue)`` of cov_naive — naive 1σ in
+        worst direction, per station.
+    sigma_combined : (n,) ndarray
+        Same for cov_combined.
+    reduction_factor : (n,) ndarray
+        ``sigma_naive / sigma_combined`` per station — how much
+        the share-mode tightens the combined uncertainty.
+    """
+
+    cov_combined: NDArray[np.float64]
+    cov_naive: NDArray[np.float64]
+    sigma_naive: NDArray[np.float64]
+    sigma_combined: NDArray[np.float64]
+    reduction_factor: NDArray[np.float64]
+
+
+def combine_covariances(
+    cov_total_a: NDArray[np.float64],
+    cov_total_b: NDArray[np.float64],
+    *,
+    cov_global_a: NDArray[np.float64] | None = None,
+    cov_global_b: NDArray[np.float64] | None = None,
+    cov_systematic_a: NDArray[np.float64] | None = None,
+    cov_systematic_b: NDArray[np.float64] | None = None,
+    share_mode: ShareMode = "globals_shared",
+) -> CombinedCovariance:
+    """Combine two wells' per-station covariances under a share-mode.
+
+    Parameters
+    ----------
+    cov_total_a, cov_total_b : (n, 3, 3) ndarray
+        Total covariance per station for each well, as produced by
+        the ISCWSA error model.
+    cov_global_a, cov_global_b : (n, 3, 3) ndarray, optional
+        Global-error component per well (magnetic declination, BGGM /
+        IFR field model errors). Required when ``share_mode`` includes
+        global cancellation. The ISCWSA model in welleng exposes this
+        as ``Survey.cov_nev_global``.
+    cov_systematic_a, cov_systematic_b : (n, 3, 3) ndarray, optional
+        Systematic-error component per well (sensor biases, tool
+        misalignment). Required when share_mode is
+        ``'globals_and_systematic_shared'``. ISCWSA exposes this as
+        ``Survey.cov_nev_systematic``.
+    share_mode : {'all_independent', 'globals_shared', 'globals_and_systematic_shared'}
+        Which components are realised identically in the two wells:
+
+        - ``'all_independent'``: classical naive
+          ``Σ_A + Σ_B`` (no cancellation). Equivalent to passing
+          neither global nor systematic arrays.
+        - ``'globals_shared'`` (default): global error sources
+          realise identically; their contribution cancels in the
+          difference covariance. This is the operationally honest
+          default for two wells from the same platform.
+        - ``'globals_and_systematic_shared'``: both global and
+          systematic terms cancel. Stronger assumption — only
+          appropriate if the same MWD service / tool was used on
+          both wells.
+
+    Returns
+    -------
+    CombinedCovariance
+    """
+    cov_a = np.asarray(cov_total_a, dtype=float).reshape(-1, 3, 3)
+    cov_b = np.asarray(cov_total_b, dtype=float).reshape(-1, 3, 3)
+    if cov_a.shape != cov_b.shape:
+        raise ValueError(
+            f"cov_total_a {cov_a.shape} and cov_total_b {cov_b.shape} "
+            "must have the same shape (per-station alignment)"
+        )
+
+    cov_naive = cov_a + cov_b
+
+    if share_mode == "all_independent":
+        cov_combined = cov_naive.copy()
+    elif share_mode == "globals_shared":
+        if cov_global_a is None or cov_global_b is None:
+            raise ValueError("globals_shared requires cov_global_a and _b")
+        gA = np.asarray(cov_global_a, dtype=float).reshape(-1, 3, 3)
+        gB = np.asarray(cov_global_b, dtype=float).reshape(-1, 3, 3)
+        # If the global realisation is identical, the contribution to
+        # cov(X_A - X_B) is (gA + gB) - 2*shared_global. With identical
+        # gA == gB == g_shared, that's (g + g) - 2*g = 0. We don't
+        # require gA == gB exactly because sample-time differences
+        # along the well allow small variation; we subtract the
+        # arithmetic mean of the two as a robust shared estimate.
+        shared = 0.5 * (gA + gB)
+        cov_combined = cov_naive - 2.0 * shared
+    elif share_mode == "globals_and_systematic_shared":
+        if any(c is None for c in (cov_global_a, cov_global_b,
+                                   cov_systematic_a, cov_systematic_b)):
+            raise ValueError(
+                "globals_and_systematic_shared requires cov_global_* "
+                "and cov_systematic_* for both wells"
+            )
+        gA = np.asarray(cov_global_a, dtype=float).reshape(-1, 3, 3)
+        gB = np.asarray(cov_global_b, dtype=float).reshape(-1, 3, 3)
+        sA = np.asarray(cov_systematic_a, dtype=float).reshape(-1, 3, 3)
+        sB = np.asarray(cov_systematic_b, dtype=float).reshape(-1, 3, 3)
+        shared = 0.5 * (gA + gB) + 0.5 * (sA + sB)
+        cov_combined = cov_naive - 2.0 * shared
+    else:
+        raise ValueError(f"unknown share_mode {share_mode!r}")
+
+    # Symmetrise + clip to PSD as defence against floating-point drift.
+    cov_combined = 0.5 * (cov_combined + cov_combined.swapaxes(-1, -2))
+    eig = np.linalg.eigvalsh(cov_combined)
+    if (eig < -1e-9).any():
+        # Strong sign that the share-mode is not consistent with the
+        # supplied components (e.g. globals_shared but Σ_global > Σ_total).
+        # Project onto PSD by clipping eigenvalues; warn quietly.
+        import warnings
+        warnings.warn(
+            "combined covariance had negative eigenvalues — clipping to "
+            "PSD; check share-mode assumption against your error model",
+            RuntimeWarning,
+        )
+        eigvals, eigvecs = np.linalg.eigh(cov_combined)
+        eigvals = np.clip(eigvals, 0.0, None)
+        cov_combined = np.einsum(
+            "...ij,...j,...kj->...ik", eigvecs, eigvals, eigvecs
+        )
+
+    sigma_naive = np.sqrt(np.linalg.eigvalsh(cov_naive).max(axis=-1))
+    sigma_combined = np.sqrt(np.linalg.eigvalsh(cov_combined).max(axis=-1))
+    with np.errstate(divide="ignore", invalid="ignore"):
+        reduction = np.where(sigma_combined > 0, sigma_naive / sigma_combined, np.nan)
+
+    return CombinedCovariance(
+        cov_combined=cov_combined,
+        cov_naive=cov_naive,
+        sigma_naive=sigma_naive,
+        sigma_combined=sigma_combined,
+        reduction_factor=reduction,
+    )


### PR DESCRIPTION
## What
`SurveyComposition` + `SurveySection`: tie a wellbore's ordered survey sections (each potentially a different tool / ISCWSA error model) into **one Survey with per-component-correct covariance carry**.

Naive concatenation is wrong both ways — restarting systematic error at every section **understates** a continuous run; treating a genuine tool change as continuous **overstates** the correlation. The composition:
- groups consecutive **same-tool** sections into one survey (systematic accumulates correlated, exactly as one run);
- at a **tool change**, ties on at the previous end with the accumulated covariance carried — the new tool's systematic **restarts independent**, global geomag terms stay correlated per the tie's `ShareMode` (default `globals_shared`; auto `all_independent` when the geomag model differs or survey dates are >2 years apart);
- correlates **random** noise per error *model* (a tool-instance change doesn't re-draw station-noise statistics);
- returns one `Survey` carrying composed `cov_nev` **plus the per-component breakdown** (`cov_nev_global`/`_systematic`/`_random`) — preserving exactly what `welleng.conditioning.combine_covariances` (#269) needs to difference two wellbores with correct shared-global cancellation. Post-independent-tie global is re-bucketed into systematic (total-preserving) so the cancellable bucket stays honest.

## Validation (structural, per the ISCWSA error-model definition's leg/tie formulation)
`tests/test_survey_composition.py` (16):
- **Same-tool sections compose EXACTLY equal to the single continuous survey** (the equivalence the standard requires).
- Tool-change covariance carry; new-tool systematic independence; share-mode ordering (`all_independent` ≥ `globals_shared` uncertainty); sidetrack ties (zero *relative* uncertainty at the tie); date/geomag auto share-mode; tie-mismatch contract; caching; from-`Survey` sections.

Broad suite 232 passed. Benchmarked: 3-tool / 202-station wellbore composes in **16.4 ms**. Leak PASS.

Stacked on #269 (`welleng.conditioning`) — merge that first. Increment 2 of 3; hierarchy/OSDU follows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)