### PR TITLE
docs(clearance): precise Brooks SPE-116155 citation for covariance interpolation

### DIFF
--- a/welleng/clearance.py
+++ b/welleng/clearance.py
@@ -282,8 +282,11 @@ class Clearance:
         Position is interpolated by **minimum curvature** (SLERP of the unit
         tangents, via ``_interpolate_pos_nev``) — the same wellpath the
         separation rule uses, so the between-station closest approach follows the
-        true arc, not the chord. Covariance and radius are interpolated linearly
-        (the standard approximation; cf. Brooks SPE-116155)."""
+        true arc, not the chord. Covariance and radius are interpolated linearly —
+        adequate between adjacent stations of one well, where the eigenbasis
+        rotation is small (Brooks SPE-116155 gives the exact recipe:
+        eigendecompose, interpolate the rotation and the principal-axis sigmas,
+        reassemble; after Woodburn & Tangyin)."""
         md, pos, cov, rad, survey = curve
         i = int(np.clip(np.searchsorted(md, q, side="right") - 1, 0, len(md) - 2))
         p = _interpolate_pos_nev(survey, float(q - md[i]), i)   # min-curvature


### PR DESCRIPTION
The continuous-curve evaluator's docstring cited Brooks as support for linear covariance interpolation; Brooks actually prescribes the eigen recipe (eigendecompose, interpolate rotation + principal-axis sigmas, reassemble, after Woodburn & Tangyin). Linear-on-sigma remains the adequate adjacent-station approximation the evaluator uses — the citation now says exactly that. No behaviour change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)