### PR TITLE
fix/feat(geomag): correct magnetic-reference handling end to end (BREAKING)

### DIFF
--- a/CITATIONS.md
+++ b/CITATIONS.md
@@ -81,8 +81,12 @@ If your work relies on a specific method, please **also** cite the relevant pape
   reference-EOS backend for kick-tolerance gas-property validation.
 - **SymPy** — Meurer, A., et al. (2017). *SymPy: symbolic computing in Python.*
   PeerJ Computer Science 3:e103. [doi:10.7717/peerj-cs.103](https://doi.org/10.7717/peerj-cs.103)
-- **VTK / vedo**, **NetworkX**, **utm**, **magnetic_field_calculator**,
+- **VTK / vedo**, **NetworkX**, **utm**,
   **tabulate** — acknowledged by name.
+- **BGS Geomagnetism web service** — geomagnetic reference values (WMM /
+  IGRF) are looked up from the British Geological Survey's
+  [geomagnetic model web service](https://geomag.bgs.ac.uk/web_service/GMModels/help/general)
+  (`welleng.geomag`).
 
 ## Methods & standards welleng implements
 

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@
 - **Kick tolerance** — deterministic, conservative single-bubble kick-tolerance engine (drill and swab cases): the mandated NOGEPA-50 static formula, a whole-path gas-migration check over the pore–fracture envelope, and an exact analytical breakpoint solver, reproducing the published worked examples of SPE-208788-PA, SPE-202426-PA (Kiani Nassab) and Santos (SPE/IADC-140113); real-gas *Z* via a clean-room Hall–Yarborough backend with an optional CoolProp EOS backend for CO₂/CCUS mixtures; deviated-well aware
 - **Visualization** — interactive 3D via [vedo]/VTK or browser-based via plotly (requires `easy` install)
 - **Data exchange** — import/export Landmark .wbp files; read EDM datasets
-- **World Magnetic Model** — auto-calculates magnetic field data when not supplied
+- **Geomagnetic reference lookup** — fetches WMM/IGRF field values from the BGS web service when not supplied (given a real well location)
 
 ### Selecting an error model
 
@@ -36,6 +36,12 @@ import welleng as we
 
 we.error.get_error_models()            # -> list every available model name
 
+# magnetic models need a real geomagnetic reference: set b_total/dip/
+# declination on the header, or give latitude/longitude (+ survey_date)
+# for an automatic lookup — package defaults are refused
+header = we.survey.SurveyHeader(
+    name="my well", b_total=50_800., dip=72., declination=-1.5,
+)
 survey = we.survey.Survey(
     md, inc, azi, header=header,
     error_model="ISCWSA MWD Rev5.11",  # the standard; change this string to switch
@@ -168,11 +174,10 @@ See the [interactive docs](https://api.welleng.org/api/docs) to try it out.
 * [numpy] — scientific computing
 * [scipy] — mathematics, science, and engineering
 * [vedo] — 3D visualization based on VTK
-* [magnetic-field-calculator] — BGS magnetic field calculator API
 
 ## Installation
 
-The default install includes core dependencies (numpy, scipy, pandas, etc.) and covers survey generation, error models, and trajectory design. The `easy` extras add 3D visualization (vedo/VTK), magnetic field lookup, network analysis, and mesh import. The `all` extras add mesh-based collision detection, which requires compiled dependencies.
+The default install includes core dependencies (numpy, scipy, pandas, etc.) and covers survey generation, error models, and trajectory design. Geomagnetic reference lookup (BGS web service) is built in. The `easy` extras add 3D visualization (vedo/VTK), network analysis, and mesh import. The `all` extras add mesh-based collision detection, which requires compiled dependencies.
 
 You'll receive an `ImportError` with a suggested install tag if a required optional dependency is missing.
 
@@ -181,7 +186,7 @@ You'll receive an `ImportError` with a suggested install tag if a required optio
 pip install welleng
 ```
 
-### Easy install (recommended — adds 3D visualization, magnetic field calculator, trimesh, networkx)
+### Easy install (recommended — adds 3D visualization, trimesh, networkx)
 ```
 pip install welleng[easy]
 ```
@@ -446,6 +451,5 @@ Please note the terms of the license. Although this software endeavors to be acc
    [volve]: <https://www.equinor.com/en/how-and-why/digitalisation-in-our-dna/volve-field-data-village-download.html>
    [ISCWSA]: <https://www.iscwsa.net/>
    [build_a_well_from_sections.py]: <https://github.com/jonnymaserati/welleng/tree/main/examples/build_a_well_from_sections.py>
-   [magnetic-field-calculator]: <https://pypi.org/project/magnetic-field-calculator/>
    [jonnymaserati]: <https://jonnymaserati.github.io/>
    [documentation]: <https://jonnymaserati.github.io/welleng/>

--- a/docs/welleng.rst
+++ b/docs/welleng.rst
@@ -69,6 +69,14 @@ welleng.fluid module
    :undoc-members:
    :show-inheritance:
 
+welleng.geomag module
+---------------------
+
+.. automodule:: welleng.geomag
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
 welleng.hierarchy module
 ------------------------
 

--- a/examples/interpolate_sparse_survey.py
+++ b/examples/interpolate_sparse_survey.py
@@ -22,10 +22,16 @@ Requirements: pip install welleng[easy]
 import welleng as we
 
 # create a sparse survey with only 4 stations
+# magnetic error models need a real geomagnetic reference: provide
+# b_total/dip/declination explicitly, or give the well's latitude/longitude
+# (+ survey_date) so they can be looked up
 s_ref = we.survey.Survey(
     md=[0., 1000., 2000., 5000.],
     inc=[0., 0., 30., 90.],
     azi=[0., 10., 20., 30.],
+    header=we.survey.SurveyHeader(
+        b_total=50_800., dip=72., declination=-1.5
+    ),
     error_model='ISCWSA MWD Rev4'
 )
 

--- a/examples/simple_example.py
+++ b/examples/simple_example.py
@@ -44,10 +44,15 @@ connector_offset = we.survey.from_connections(
 )
 
 # make survey objects and calculate the uncertainty covariances
+# magnetic error models need a real geomagnetic reference: provide
+# b_total/dip/declination explicitly, or give the well's latitude/longitude
+# (+ survey_date) so they can be looked up
 print("Making surveys...")
+MAG_REF = dict(b_total=50_800., dip=72., declination=-1.5)
 sh_reference = we.survey.SurveyHeader(
     name="reference",
-    azi_reference="grid"
+    azi_reference="grid",
+    **MAG_REF
 )
 survey_reference = we.survey.Survey(
     md=connector_reference.md,
@@ -58,7 +63,8 @@ survey_reference = we.survey.Survey(
 )
 sh_offset = we.survey.SurveyHeader(
     name="offset",
-    azi_reference="grid"
+    azi_reference="grid",
+    **MAG_REF
 )
 survey_offset = we.survey.Survey(
     md=connector_offset.md,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,7 +58,6 @@ dependencies = [
 
 [project.optional-dependencies]
 easy = [
-    "magnetic_field_calculator",
     "networkx",
     "tabulate",
     "trimesh",
@@ -92,7 +91,6 @@ kick = [
     "sympy",
 ]
 all = [
-    "magnetic_field_calculator",
     "networkx",
     "tabulate",
     "trimesh",
@@ -182,7 +180,6 @@ disallow_incomplete_defs = true
 [dependency-groups]
 dev = [
     "pytest>=9.0",
-    "magnetic_field_calculator",
     "networkx",
     "trimesh",
 ]

--- a/setup.py
+++ b/setup.py
@@ -38,7 +38,6 @@ requirements_default = set([
 
 # these can be installed without compiling required
 requirements_easy = set([
-    'magnetic_field_calculator',    # used to get default mag data for survey
     'networkx',
     'tabulate',
     'trimesh',

--- a/tests/test_bug_fixes.py
+++ b/tests/test_bug_fixes.py
@@ -67,6 +67,9 @@ def _make_survey_with_errors():
             md=[0, 500, 1000, 2000, 3000],
             inc=[0, 0, 30, 90, 90],
             azi=[0, 0, 45, 135, 180],
+            header=we.survey.SurveyHeader(
+                b_total=50_000., dip=72., declination=-2.
+            ),
             error_model='ISCWSA MWD Rev4',
         ),
         step=300,
@@ -169,7 +172,10 @@ def test_func_dict_msixy_entries_are_distinct():
     # ToolError._initiate_func_dict is called during __init__; we instantiate
     # it with a minimal error/model pair via ErrorModel so we can inspect
     # func_dict directly without running the full model.
-    survey = we.survey.Survey(md=[0, 100], inc=[0, 10], azi=[0, 0])
+    survey = we.survey.Survey(
+        md=[0, 100], inc=[0, 10], azi=[0, 0],
+        header=we.survey.SurveyHeader(b_total=50_000., dip=72., declination=-2.),
+    )
     error = we.error.ErrorModel(survey, error_model='ISCWSA MWD Rev4')
     te = error.errors  # ToolError instance
 
@@ -189,7 +195,10 @@ def test_func_dict_dbhr_present():
     """Issue #163: DBHR must be present in func_dict."""
     from welleng.errors.tool_errors import DBHR
 
-    survey = we.survey.Survey(md=[0, 100], inc=[0, 10], azi=[0, 0])
+    survey = we.survey.Survey(
+        md=[0, 100], inc=[0, 10], azi=[0, 0],
+        header=we.survey.SurveyHeader(b_total=50_000., dip=72., declination=-2.),
+    )
     error = we.error.ErrorModel(survey, error_model='ISCWSA MWD Rev4')
     te = error.errors  # ToolError instance
 

--- a/tests/test_clearance_mahalanobis_solve.py
+++ b/tests/test_clearance_mahalanobis_solve.py
@@ -14,12 +14,14 @@ import pytest
 from welleng.survey import Survey, SurveyHeader
 from welleng.clearance import MahalanobisClearance
 
+MAG_REF = dict(b_total=50_000., dip=72., declination=-2.)
+
 
 def _survey(n, shift):
     md = np.linspace(0, 30 * (n - 1), n)
     inc = np.clip(np.linspace(0, 90, n), 0, 60)
     azi = (np.linspace(0, 120, n) + shift) % 360
-    return Survey(md=md, inc=inc, azi=azi, header=SurveyHeader(),
+    return Survey(md=md, inc=inc, azi=azi, header=SurveyHeader(**MAG_REF),
                   error_model="ISCWSA MWD Rev5.11")
 
 

--- a/tests/test_conditioning.py
+++ b/tests/test_conditioning.py
@@ -16,6 +16,8 @@ from welleng.conditioning import (
 )
 from welleng.survey import Survey, SurveyHeader
 
+MAG_REF = dict(b_total=50_000., dip=72., declination=-2.)
+
 
 def _spd(rng, n, scale=1.0):
     """Random (n, 3, 3) SPD stack."""
@@ -114,7 +116,7 @@ def test_end_to_end_two_error_modelled_surveys():
         md = np.linspace(0, 2400, 40)
         inc = np.clip(np.linspace(0, 80, 40), 0, 60)
         azi = (np.linspace(0, 90, 40) + shift) % 360
-        return Survey(md=md, inc=inc, azi=azi, header=SurveyHeader(),
+        return Survey(md=md, inc=inc, azi=azi, header=SurveyHeader(**MAG_REF),
                       error_model="ISCWSA MWD Rev5.11")
     a, b = make(0.0), make(12.0)
     assert a.cov_nev_global is not None          # the 0.19 Survey contract

--- a/tests/test_datum_realisation.py
+++ b/tests/test_datum_realisation.py
@@ -21,6 +21,8 @@ from welleng.hierarchy import (
 )
 from welleng.survey import Survey, SurveyHeader
 
+MAG_REF = dict(b_total=50_000., dip=72., declination=-2.)
+
 
 def _chain():
     d = Datum(name="PlatformA-RKB")
@@ -85,7 +87,7 @@ def _net(pin_a="v1", pin_b="v1"):
         md = np.linspace(0, 2400, 40)
         inc = np.clip(np.linspace(0, 80, 40), 0, 60)
         azi = (np.linspace(0, 90, 40) + shift) % 360
-        return Survey(md=md, inc=inc, azi=azi, header=SurveyHeader(),
+        return Survey(md=md, inc=inc, azi=azi, header=SurveyHeader(**MAG_REF),
                       error_model="ISCWSA MWD Rev5.11")
 
     net = WellNetwork()

--- a/tests/test_error_model_cache.py
+++ b/tests/test_error_model_cache.py
@@ -10,6 +10,8 @@ import pytest
 from welleng.survey import Survey, SurveyHeader
 from welleng.errors import tool_errors as te
 
+MAG_REF = dict(b_total=50_000., dip=72., declination=-2.)
+
 
 def _survey():
     n = 200
@@ -17,7 +19,7 @@ def _survey():
     inc = np.clip(np.linspace(0, 90, n), 0, 60)
     azi = np.linspace(0, 120, n) % 360
     return Survey(
-        md=md, inc=inc, azi=azi, header=SurveyHeader(),
+        md=md, inc=inc, azi=azi, header=SurveyHeader(**MAG_REF),
         error_model="ISCWSA MWD Rev5.11",
     )
 

--- a/tests/test_hierarchy.py
+++ b/tests/test_hierarchy.py
@@ -14,6 +14,8 @@ from welleng.hierarchy import (
 from welleng import osdu
 from welleng.survey import Survey, SurveyHeader
 
+MAG_REF = dict(b_total=50_000., dip=72., declination=-2.)
+
 
 # --------------------------------------------------------------------------- #
 # helpers
@@ -27,7 +29,7 @@ def _parent_and_sidetracks():
     md_p = list(range(0, 2001, 100))
     parent = Survey(
         md=md_p, inc=[min(0.03 * m, 40) for m in md_p], azi=[45.0] * len(md_p),
-        header=SurveyHeader(name="P"), error_model="ISCWSA MWD Rev5.11",
+        header=SurveyHeader(name="P", **MAG_REF), error_model="ISCWSA MWD Rev5.11",
     )
     i = md_p.index(1000.0)
     pos, cst = parent.pos_nev[i], parent.cov_nev[i]
@@ -37,7 +39,7 @@ def _parent_and_sidetracks():
         return Survey(
             md=md, inc=[40.0] * len(md),
             azi=[45.0 + sign * 1.2 * (m - 1000) / 100 for m in md],
-            header=SurveyHeader(name="S"), error_model="ISCWSA MWD Rev5.11",
+            header=SurveyHeader(name="S", **MAG_REF), error_model="ISCWSA MWD Rev5.11",
             start_nev=pos, start_cov_nev=cst,
         )
 

--- a/tests/test_iscwsa_mwd_error.py
+++ b/tests/test_iscwsa_mwd_error.py
@@ -120,6 +120,7 @@ def test_drdp_single_pass_matches_column_methods():
         inc=[0, 15, 45, 60, 80],
         azi=[0, 30, 90, 150, 270],
         unit='meters',
+        header=SurveyHeader(b_total=50_000., dip=72., declination=-2.),
     )
     for model in ('ISCWSA MWD Rev4', 'ISCWSA MWD Rev5.11'):
         em = ErrorModel(s, error_model=model)

--- a/tests/test_iscwsa_sing_highfreq.py
+++ b/tests/test_iscwsa_sing_highfreq.py
@@ -34,7 +34,7 @@ N = 6
 
 def _vertical_highfreq_err(dmd=DMD, n=N, model=MODEL):
     md = np.arange(n) * dmd
-    sh = SurveyHeader()
+    sh = SurveyHeader(b_total=50_000., dip=72., declination=-2.)
     sh.error_model = model
     survey = Survey(
         md=md, inc=np.zeros(n), azi=np.zeros(n),
@@ -125,7 +125,7 @@ def test_highfreq_sing_covariance_matches_propagation():
 def _err(md, inc, azi, model):
     """Build an Error for an arbitrary geometry with magnetic params set, so
     field-dependent terms (ABXY/MBXY/...) evaluate on non-vertical wells."""
-    sh = SurveyHeader()
+    sh = SurveyHeader(b_total=50_000., dip=72., declination=-2.)
     sh.error_model = model
     sh.latitude = 60.0
     sh.b_total = 50000.0

--- a/tests/test_minimal.py
+++ b/tests/test_minimal.py
@@ -13,6 +13,9 @@ def test_survey():
             md=[0, 500, 1000, 2000, 3000],
             inc=[0, 0, 30, 90, 90],
             azi=[90, 90, 90, 135, 180],
+            header=we.survey.SurveyHeader(
+                b_total=50_000., dip=72., declination=-2.
+            ),
             error_model='ISCWSA MWD Rev5.11'
         ),
         step=30.

--- a/tests/test_survey_composition.py
+++ b/tests/test_survey_composition.py
@@ -17,7 +17,7 @@ WELL_DATA = "tests/test_data/clearance_iscwsa_well_data.json"
 
 
 def _header():
-    sh = SurveyHeader()
+    sh = SurveyHeader(b_total=50_000., dip=72., declination=-2.)
     sh.azi_reference = "grid"
     sh.b_total = 50000.0
     sh.dip = 70.0
@@ -257,7 +257,7 @@ def _load_wells():
     wells = json.load(open(WELL_DATA))["wells"]
 
     def mk_header(h):
-        sh = SurveyHeader()
+        sh = SurveyHeader(b_total=50_000., dip=72., declination=-2.)
         for k, v in h.items():
             if k != "name":
                 setattr(sh, k, v)

--- a/tests/test_survey_header_mag.py
+++ b/tests/test_survey_header_mag.py
@@ -1,0 +1,194 @@
+"""SurveyHeader magnetic-field lookup: historic dates, provenance, the gate.
+
+The BGS default model (WMM) only covers a ~10-year window around the present;
+a historic ``survey_date`` errors on it. The lookup must fall back to IGRF
+*for the requested date* — never silently substitute today's field (a ~3.5 deg
+declination bias at Volve for a 2008 well) nor overwrite the header's
+``survey_date``.
+
+``SurveyHeader.mag_source`` records where each geomagnetic value came from
+(``'user'`` / ``'lookup'`` / ``'default'``) and magnetic error models refuse
+``'default'`` — provided OR looked up, never a placeholder.
+
+The BGS client is mocked so the tests run without network access.
+"""
+
+import warnings
+
+import pytest
+
+import welleng.survey as ws
+from welleng.geomag import GeomagLookupError, _build_url
+
+
+class _FakeLookup:
+    """Mimics welleng.geomag.lookup_field.
+
+    The WMM model raises for dates before 2025, as the live BGS service
+    does; IGRF accepts historic dates. Distinct field values per model so
+    tests can tell which epoch/model was used.
+    """
+
+    def __init__(self):
+        self.calls = []
+        self.altitudes = []
+        self.fail_all = False
+
+    def __call__(self, latitude, longitude, altitude=0.0, date=None,
+                 model="wmm", **kwargs):
+        self.calls.append(model)
+        self.altitudes.append(altitude)
+        if self.fail_all:
+            raise GeomagLookupError("service unreachable")
+        if model == "wmm" and date is not None and int(date[:4]) < 2025:
+            raise GeomagLookupError(
+                "400: Date for WMM 2025 must be between 2025.0 and 2035.0"
+            )
+        b = 50365.0 if model == "igrf" else 50943.0
+        dec = -2.08 if model == "igrf" else 1.43
+        return {
+            "field-value": {
+                "total-intensity": {"value": b},
+                "inclination": {"value": 70.0},
+                "declination": {"value": dec},
+            }
+        }
+
+
+@pytest.fixture
+def fake_lookup(monkeypatch):
+    fake = _FakeLookup()
+    monkeypatch.setattr(ws, "lookup_field", fake)
+    return fake
+
+
+def _header(**kwargs):
+    return ws.SurveyHeader(
+        name="volve-like",
+        latitude=58.4416,
+        longitude=1.8875,
+        **kwargs,
+    )
+
+
+def test_historic_date_uses_igrf_for_requested_date(fake_lookup):
+    sh = _header(survey_date="2008-12-31")
+    assert fake_lookup.calls == ["wmm", "igrf"]
+    assert sh.b_total == 50365.0          # the IGRF (requested-epoch) value
+    assert sh.survey_date == "2008-12-31"  # never overwritten
+
+
+def test_current_date_uses_default_model(fake_lookup):
+    sh = _header(survey_date="2026-01-01")
+    assert fake_lookup.calls == ["wmm"]
+    assert sh.b_total == 50943.0
+
+
+def test_total_failure_warns_and_keeps_defaults_and_date(fake_lookup):
+    fake_lookup.fail_all = True
+    with pytest.warns(UserWarning, match="2008-12-31"):
+        sh = _header(survey_date="2008-12-31")
+    assert sh.b_total == 50000.0           # mag_defaults, not a wrong epoch
+    assert sh.survey_date == "2008-12-31"
+
+
+def test_user_supplied_values_skip_lookup_entirely(fake_lookup):
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
+        sh = _header(
+            survey_date="2008-12-31", b_total=50100.0, dip=71.0, declination=-1.5
+        )
+    assert sh.b_total == 50100.0
+    assert fake_lookup.calls == []         # nothing missing -> no round-trip
+
+
+def test_defaulted_location_skips_lookup(fake_lookup):
+    # A lookup at the fallback location would be as fictitious as the
+    # defaults — don't pay the round-trip for it.
+    sh = ws.SurveyHeader(survey_date="2026-01-01")
+    assert fake_lookup.calls == []
+    assert sh.b_total == 50000.0
+
+
+def test_altitude_passed_through_in_metres(fake_lookup):
+    # welleng speaks metres end-to-end; the km conversion happens inside the
+    # BGS client at the wire (see test_bgs_url_converts_altitude_to_km).
+    _header(survey_date="2026-01-01", altitude=-90.0)
+    assert fake_lookup.altitudes == [-90.0]
+
+
+def test_bgs_url_converts_altitude_to_km():
+    url = _build_url(58.4416, 1.8875, altitude=-90.0, date="2008-12-31",
+                     model="igrf")
+    assert url.startswith("https://geomag.bgs.ac.uk/web_service/GMModels/igrf/")
+    assert "altitude=-0.09" in url
+    assert "date=2008-12-31" in url
+    assert "format=json" in url
+
+
+# --- mag provenance + the ErrorModel gate (magnetic models refuse defaults) --
+
+
+def _survey(header, error_model):
+    import welleng as we
+
+    return we.survey.Survey(
+        md=[0.0, 500.0, 1000.0],
+        inc=[0.0, 30.0, 60.0],
+        azi=[45.0, 45.0, 45.0],
+        header=header,
+        error_model=error_model,
+    ).err
+
+
+def test_default_header_magnetic_model_raises():
+    sh = ws.SurveyHeader()          # no location, no mag data, no lookup
+    assert sh.mag_source == {
+        "b_total": "default", "dip": "default", "declination": "default"
+    }
+    with pytest.raises(ValueError, match="magnetic model"):
+        _survey(sh, "ISCWSA MWD Rev5.11")
+
+
+def test_default_header_gyro_model_passes():
+    sh = ws.SurveyHeader()          # gyro models don't consume B/dip/dec
+    _survey(sh, "GYRO-MWD")
+
+
+def test_explicit_mag_values_pass_gate():
+    sh = ws.SurveyHeader(b_total=50365.0, dip=72.1, declination=-2.08)
+    assert all(s == "user" for s in sh.mag_source.values())
+    _survey(sh, "ISCWSA MWD Rev5.11")
+
+
+def test_post_init_setattr_marks_user_and_passes_gate():
+    # The common pattern: bare header, fields assigned afterwards from a file
+    sh = ws.SurveyHeader()
+    for k, v in {"b_total": 50365.0, "dip": 72.1, "declination": -2.08}.items():
+        setattr(sh, k, v)
+    assert all(s == "user" for s in sh.mag_source.values())
+    _survey(sh, "ISCWSA MWD Rev5.11")
+
+
+def test_lookup_at_user_location_passes_gate(fake_lookup):
+    sh = _header(survey_date="2008-12-31")
+    assert all(s == "lookup" for s in sh.mag_source.values())
+    _survey(sh, "ISCWSA MWD Rev5.11")
+
+
+def test_defaulted_location_fails_gate(fake_lookup):
+    # No real location -> defaults -> refused by the magnetic gate
+    sh = ws.SurveyHeader(survey_date="2026-01-01")
+    assert all(s == "default" for s in sh.mag_source.values())
+    with pytest.raises(ValueError, match="magnetic model"):
+        _survey(sh, "ISCWSA MWD Rev5.11")
+
+
+def test_shallow_copy_does_not_leak_provenance():
+    import copy
+
+    sh = ws.SurveyHeader(b_total=50365.0, dip=72.1, declination=-2.08)
+    sh2 = copy.copy(sh)
+    sh2.b_total = None
+    assert sh.mag_source["b_total"] == "user"       # source unaffected
+    assert sh2.mag_source["b_total"] == "default"

--- a/tests/test_survey_parameters.py
+++ b/tests/test_survey_parameters.py
@@ -15,23 +15,20 @@ CALCULATOR = we.survey.SurveyParameters(REFERENCE.get('srs'))
 
 
 def test_known_location(monkeypatch):
-    # Always runs -- no optional 'magnetic_field_calculator' install and no live BGS
-    # network call needed. Stub the API client to return the known BGS response for
-    # this location/date, so we deterministically validate welleng's own code: the
-    # projection factors (real pyproj) and the magnetic-field processing (dip sign
-    # from the "down" units, nested-field extraction). The external service's values
-    # are not welleng's to test.
-    class _StubMagCalc:
-        def calculate(self, **kwargs):
-            return {"field-value": {
-                "total-intensity": {"value": REFERENCE["magnetic_field_intensity"]},
-                "declination": {"value": REFERENCE["declination"]},
-                # welleng negates a "down" inclination -> dip; feed +intensity so the
-                # sign handling is what's under test.
-                "inclination": {"value": -REFERENCE["dip"], "units": "deg (down)"},
-            }}
-    monkeypatch.setattr(we.survey, "MAG_CALC", True)
-    monkeypatch.setattr(we.survey, "MagneticFieldCalculator", _StubMagCalc, raising=False)
+    # Always runs -- no live BGS network call needed. Stub the BGS client to
+    # return the known response for this location/date, so we deterministically
+    # validate welleng's own code: the projection factors (real pyproj) and the
+    # magnetic-field processing (dip sign from the "down" units, nested-field
+    # extraction). The external service's values are not welleng's to test.
+    def _stub_lookup(**kwargs):
+        return {"field-value": {
+            "total-intensity": {"value": REFERENCE["magnetic_field_intensity"]},
+            "declination": {"value": REFERENCE["declination"]},
+            # welleng negates a "down" inclination -> dip; feed +intensity so
+            # the sign handling is what's under test.
+            "inclination": {"value": -REFERENCE["dip"], "units": "deg (down)"},
+        }}
+    monkeypatch.setattr(we.survey, "lookup_field", _stub_lookup)
 
     survey_parameters = CALCULATOR.get_factors_from_x_y(
         x=REFERENCE.get('x'), y=REFERENCE.get('y'),

--- a/welleng/error.py
+++ b/welleng/error.py
@@ -9,6 +9,7 @@ correct) covariance output. ``"ISCWSA MWD Rev4"`` is unchanged.
 """
 
 import os
+import re
 import warnings
 
 import numpy as np
@@ -199,10 +200,46 @@ class ErrorModel():
                 model = k
                 break
 
+        self._validate_mag_reference(model)
+
         self.errors = ToolError(
             error=self,
             model=model
         )
+
+    def _validate_mag_reference(self, model: str) -> None:
+        """Magnetic models need a real geomagnetic reference — refuse package
+        defaults.
+
+        Magnetic-compass models' weighting functions consume the header's
+        ``b_total``/``dip``/``declination``; gyro models (OWSG ``A<nn>G*``,
+        the GYRO short names, the SPE-90408 example model) do not. Those
+        values must be either user-provided or looked up for a user-provided
+        location — the header's fallback values (or a lookup at the fallback
+        location) are placeholders, not a geomagnetic reference, and would
+        silently bias every magnetic term. Unclassified models are treated
+        as magnetic (the strict direction). See ``SurveyHeader.mag_source``.
+        """
+        is_gyro = (
+            re.match(r"^A\d+G", model) is not None
+            or 'GYRO' in self.error_model.upper()
+            or '90408' in model
+        )
+        if is_gyro:
+            return
+        sources = getattr(self.survey.header, 'mag_source', None)
+        if sources is None:     # header predates provenance tracking
+            return
+        bad = sorted(f for f, s in sources.items() if s == 'default')
+        if bad:
+            raise ValueError(
+                f"error_model {self.error_model!r} is a magnetic model but "
+                f"the survey header's {', '.join(bad)} came from package "
+                "defaults. Provide b_total, dip and declination on the "
+                "SurveyHeader, or provide the well's latitude/longitude "
+                "(+ survey_date) so they can be looked up (requires the "
+                "optional 'magnetic_field_calculator' package)."
+            )
 
     def _e_NEV(self, e_DIA):
         D, I, A = e_DIA.T

--- a/welleng/error.py
+++ b/welleng/error.py
@@ -237,8 +237,8 @@ class ErrorModel():
                 f"the survey header's {', '.join(bad)} came from package "
                 "defaults. Provide b_total, dip and declination on the "
                 "SurveyHeader, or provide the well's latitude/longitude "
-                "(+ survey_date) so they can be looked up (requires the "
-                "optional 'magnetic_field_calculator' package)."
+                "(+ survey_date) so they can be looked up from the BGS "
+                "geomagnetic web service."
             )
 
     def _e_NEV(self, e_DIA):

--- a/welleng/geomag.py
+++ b/welleng/geomag.py
@@ -1,0 +1,118 @@
+"""Client for the BGS geomagnetic model web service.
+
+Replaces the unmaintained ``magnetic_field_calculator`` package (which spoke
+plain http, had no timeout and is no longer developed) with a small stdlib
+client for the same service. The geomagnetic models themselves live server
+side at the British Geological Survey, so this client stays current as BGS
+revises them.
+
+Service documentation:
+https://geomag.bgs.ac.uk/web_service/GMModels/help/parameters
+
+The service URL structure is ``GMModels/<model>/<revision>?<parameters>``
+with altitude in km above the WGS84 spheroid and dates as ``yyyy-mm-dd``.
+This module speaks welleng conventions at its boundary — altitude in METRES
+(negative below datum) — and converts at the wire.
+"""
+
+import json
+import urllib.error
+import urllib.parse
+import urllib.request
+
+BGS_GEOMAG_URL = "https://geomag.bgs.ac.uk/web_service/GMModels"
+
+#: models useful to welleng: 'wmm' (current-epoch default) and 'igrf'
+#: (historic coverage — the fallback for pre-window survey dates).
+KNOWN_MODELS = ("wmm", "igrf")
+
+
+class GeomagLookupError(ValueError):
+    """The BGS lookup failed (bad request, service down, no network)."""
+
+
+def _build_url(
+    latitude,
+    longitude,
+    altitude=0.0,
+    date=None,
+    model="wmm",
+    revision="current",
+):
+    """Build the GMModels request URL. ``altitude`` is in METRES."""
+    params = {
+        "latitude": latitude,
+        "longitude": longitude,
+        # BGS expects km above the WGS84 spheroid; welleng altitudes are m
+        "altitude": altitude / 1000.0,
+        "format": "json",
+    }
+    if date is not None:
+        params["date"] = date
+    return (
+        f"{BGS_GEOMAG_URL}/{model}/{revision}?"
+        f"{urllib.parse.urlencode(params)}"
+    )
+
+
+def lookup_field(
+    latitude,
+    longitude,
+    altitude=0.0,
+    date=None,
+    model="wmm",
+    revision="current",
+    timeout=10.0,
+):
+    """Look up the geomagnetic field from the BGS web service.
+
+    Parameters
+    ----------
+    latitude, longitude : float
+        Geodetic coordinates in decimal degrees.
+    altitude : float
+        Height in METRES above the WGS84 spheroid (negative below — e.g. a
+        subsea wellhead). Converted to the service's km at the wire.
+    date : str, optional
+        ``yyyy-mm-dd``. Omitted -> the service's default epoch.
+    model : str
+        ``'wmm'`` (default) or ``'igrf'`` (historic coverage).
+    revision : str
+        Model revision; ``'current'`` tracks the latest server-side.
+    timeout : float
+        Socket timeout in seconds.
+
+    Returns
+    -------
+    dict
+        The service's ``geomagnetic-field-model-result`` payload, e.g.
+        ``result['field-value']['total-intensity']['value']`` (nT),
+        ``['inclination']`` (dip, deg down-positive) and
+        ``['declination']`` (deg east-positive).
+
+    Raises
+    ------
+    GeomagLookupError
+        On any HTTP error (with the server's message, e.g. a date outside
+        the model's validity window), connection failure or bad payload.
+    """
+    url = _build_url(latitude, longitude, altitude, date, model, revision)
+    try:
+        with urllib.request.urlopen(url, timeout=timeout) as response:
+            payload = json.load(response)
+    except urllib.error.HTTPError as exc:
+        detail = exc.read().decode("utf-8", errors="replace").strip()
+        raise GeomagLookupError(
+            f"BGS geomag lookup failed ({exc.code}): {detail[:300]}"
+        ) from exc
+    except Exception as exc:
+        raise GeomagLookupError(
+            f"BGS geomag lookup failed: {exc}"
+        ) from exc
+    try:
+        return payload["geomagnetic-field-model-result"]
+    except (KeyError, TypeError) as exc:
+        raise GeomagLookupError(
+            f"BGS geomag lookup returned an unexpected payload: "
+            f"{str(payload)[:300]}"
+        ) from exc

--- a/welleng/hierarchy.py
+++ b/welleng/hierarchy.py
@@ -997,8 +997,9 @@ class WellNetwork:
                 "azi": list(np.asarray(getattr(s, f"azi_{azi_ref}_rad")).tolist()),
                 "azi_reference": azi_ref,
                 "header": {k: v for k, v in vars(hdr).items()
-                           if isinstance(v, (str, int, float, bool,
-                                             type(None)))} if hdr else None,
+                           if not k.startswith("_")
+                           and isinstance(v, (str, int, float, bool,
+                                              type(None)))} if hdr else None,
                 "start_nev": list(np.asarray(s.start_nev).tolist()),
                 "error_model": getattr(getattr(s, "header", None), "error_model", None),
             }

--- a/welleng/survey.py
+++ b/welleng/survey.py
@@ -17,11 +17,6 @@ import numpy as np
 import math
 import warnings
 import pandas as pd
-try:
-    from magnetic_field_calculator import MagneticFieldCalculator
-    MAG_CALC = True
-except ImportError:
-    MAG_CALC = False
 from datetime import datetime
 from pyproj import CRS, Proj, Transformer
 from pyproj.enums import TransformDirection
@@ -41,6 +36,7 @@ from .utils import (
     radius_from_dls,
 )
 from .error import ErrorModel, ERROR_MODELS
+from .geomag import GeomagLookupError, lookup_field
 from .node import Node
 from .connector import Connector, interpolate_well
 from .visual import figure
@@ -61,8 +57,8 @@ class SurveyParameters(Proj):
 
     Notes
     -----
-    Requires ``pyproj`` and ``magnetic_field_calculator`` to be installed and
-    access to the internet.
+    Requires ``pyproj``; the magnetic-field values need internet access (the
+    BGS geomagnetic web service, via ``welleng.geomag``).
 
     For reference, here's some EPSG codes:
     {
@@ -112,8 +108,10 @@ class SurveyParameters(Proj):
         y: float
             The y or North/South coordinate.
         altitude: float (default: None)
-            The altitude or z value coordinate. If none is provided this will
-            default to zero (sea level).
+            The altitude or z value coordinate in metres above mean sea
+            level (negative for below MSL). If none is provided this will
+            default to zero (sea level). Converted to km at the BGS
+            magnetic-lookup boundary.
         date: str (default: None)
             The date of the survey, used when calculating the magnetic
             parameters. Will default to the current date.
@@ -180,26 +178,16 @@ class SurveyParameters(Proj):
             datetime.today().strftime('%Y-%m-%d') if date is None
             else date
         )
-        if MAG_CALC:
-            magnetic_calculator = MagneticFieldCalculator()
-            try:
-                result_magnetic = magnetic_calculator.calculate(
-                    latitude=latitude, longitude=longitude,
-                    altitude=0 if altitude is None else altitude,
-                    date=date
-                )
-            except Exception as exc:
-                warnings.warn(
-                    f"Magnetic-field lookup failed ({exc}); declination, dip and "
-                    "field intensity set to None (no connection to the BGS service?)."
-                )
-                result_magnetic = None
-        else:
+        try:
+            result_magnetic = lookup_field(
+                latitude=latitude, longitude=longitude,
+                altitude=0 if altitude is None else altitude,
+                date=date
+            )
+        except GeomagLookupError as exc:
             warnings.warn(
-                "Magnetic-field parameters (declination, dip, field intensity) need "
-                "the optional 'magnetic_field_calculator' package -- install with "
-                "`pip install welleng[all]` (or `pip install magnetic_field_calculator`). "
-                "Returning None for those fields."
+                f"Magnetic-field lookup failed ({exc}); declination, dip and "
+                "field intensity set to None (no connection to the BGS service?)."
             )
             result_magnetic = None
 
@@ -289,7 +277,25 @@ class SurveyHeader:
     Stores the geographic position, magnetic field parameters (total field,
     dip, declination), convergence, azimuth reference system, and unit
     conventions needed to interpret and process directional survey data.
+
+    ``mag_source`` tracks the provenance of each geomagnetic reference value
+    (``'user'`` / ``'lookup'`` / ``'default'``); magnetic error models refuse
+    ``'default'`` (see ``ErrorModel``). Assigning ``b_total``, ``dip`` or
+    ``declination`` — at construction or any time after — marks that field
+    ``'user'``.
     """
+
+    #: geomagnetic reference fields whose provenance is tracked
+    _MAG_FIELDS = ('b_total', 'dip', 'declination')
+
+    def __setattr__(self, name, value):
+        super().__setattr__(name, value)
+        if name in self._MAG_FIELDS:
+            # copy-on-write: shallow header copies share the dict; never
+            # mutate it in place or the copy's provenance leaks to the source
+            src = dict(self.__dict__.get('mag_source', {}))
+            src[name] = 'default' if value is None else 'user'
+            self.__dict__['mag_source'] = src
 
     def __init__(
         self,
@@ -333,8 +339,10 @@ class SurveyHeader:
             default (None) then it will be assigned to Grenwich, the
             undisputed center of the universe.
         altitude: float (default: None)
-            The altitude of the surface location. If left defaults (None)
-            then it will be assigned to 0.
+            The altitude of the surface location in METRES above mean sea
+            level (negative for below MSL, e.g. a subsea wellhead). If left
+            default (None) then it will be assigned to 0. Converted to km at
+            the BGS magnetic-lookup boundary.
         survey_date: YYYY-mm-dd (default: None)
             The date on which the survey data was recorded. If left
             default then the current date is assigned.
@@ -398,6 +406,9 @@ class SurveyHeader:
 
         self._validate_date(survey_date)
         self.name = name
+        # A geomag lookup at the fallback location is as fictitious as the
+        # package default values — the provenance tracking below treats it so.
+        self._location_defaulted = latitude is None or longitude is None
         self.latitude = latitude if latitude is not None else 51.4934
         self.longitude = longitude if longitude is not None else 0.0098
         self.altitude = altitude if altitude is not None else 0.
@@ -427,7 +438,17 @@ class SurveyHeader:
     def _get_mag_data(self, deg: bool) -> None:
         """
         Initiates b_total if provided, else calculates a value.
+
+        Records the provenance of each geomagnetic reference value in
+        ``self.mag_source`` (``'user'``, ``'lookup'`` or ``'default'``).
+        Magnetic error models require every value to be ``'user'`` or
+        ``'lookup'`` — a package default (or a lookup at the defaulted
+        location) is not a valid geomagnetic reference for error modelling
+        and ``ErrorModel`` raises on it. Assigning ``b_total``/``dip``/
+        ``declination`` on the header at any time marks that field ``'user'``
+        (see ``__setattr__``).
         """
+        lookup_ok = False
         result = {
             'field-value': {
                 'total-intensity': {
@@ -442,42 +463,62 @@ class SurveyHeader:
             }
         }
 
-        if MAG_CALC:
-            calculator = MagneticFieldCalculator()
+        # Look up only when something is missing AND the location is real:
+        # user-supplied values make the result unused, and a lookup at the
+        # defaulted location is as fictitious as the package defaults — no
+        # point paying a network round-trip for either.
+        need_lookup = (
+            (self.b_total is None or self.dip is None
+             or self.declination is None)
+            and not self._location_defaulted
+        )
+        if need_lookup:
             try:
-                result = calculator.calculate(
+                result = lookup_field(
                     latitude=self.latitude,
                     longitude=self.longitude,
                     altitude=self.altitude,
                     date=self.survey_date
                 )
-            except Exception:
+                lookup_ok = True
+            except GeomagLookupError:
+                # The default model (WMM) only covers a ~10-year window around
+                # the present; historic survey dates 400 on it. IGRF covers
+                # historic epochs, so retry there with the SAME date rather
+                # than silently substituting today's field.
                 try:
-                    # retry with today's date (sets self.survey_date, then use it)
-                    self._get_date(date=None)
-                    result = calculator.calculate(
+                    result = lookup_field(
                         latitude=self.latitude,
                         longitude=self.longitude,
                         altitude=self.altitude,
-                        date=self.survey_date
+                        date=self.survey_date,
+                        model='igrf'
                     )
-                except Exception as exc:
+                    lookup_ok = True
+                except GeomagLookupError as exc:
                     warnings.warn(
-                        f"Magnetic-field lookup failed ({exc}); using the header's "
-                        "default magnetic parameters (no connection to the BGS "
-                        "service?)."
+                        f"Magnetic-field lookup failed for survey_date "
+                        f"{self.survey_date} ({exc}); using the header's "
+                        "default magnetic parameters (no connection to the "
+                        "BGS service, or a date outside the models' range?)."
                     )
+
+        looked_up = 'lookup' if lookup_ok else 'default'
+        filled = []
 
         if self.b_total is None:
             self.b_total = result['field-value']['total-intensity']['value']
+            filled.append('b_total')
             # if not deg:
             #     self.b_total = math.radians(self.b_total)
         if self.dip is None:
             self.dip = -result['field-value']['inclination']['value']  # type: ignore[operator]
+            filled.append('dip')
             if not deg:
                 self.dip = math.radians(self.dip)
         if self.declination is None:
             self.declination = result['field-value']['declination']['value']
+            filled.append('declination')
             if not deg:
                 self.declination = math.radians(self.declination)  # type: ignore[arg-type]
 
@@ -491,6 +532,12 @@ class SurveyHeader:
             self.vertical_section_azimuth = math.radians(
                 self.vertical_section_azimuth
             )
+
+        # Stamp provenance LAST — the unit conversions above re-assign the
+        # fields, which __setattr__ marks 'user'; lookup-filled fields must
+        # end up marked with the lookup's own provenance.
+        for field in filled:
+            self.mag_source[field] = looked_up
 
     def _get_date(self, date: Optional[str]) -> None:
         if date is None:

--- a/welleng/survey.py
+++ b/welleng/survey.py
@@ -349,22 +349,25 @@ class SurveyHeader:
         G: float (default: 9.80665)
             The gravitational field strength in m/s^2.
         b_total: float (default: None)
-            The gravitation field strength in nT. If left default, then
-            the value is calculated from the longitude, latitude, altitude
-            and survey_data properties using the magnetic_field_calculator.
+            The total magnetic field strength in nT. If left default, the
+            value is looked up from the BGS geomagnetic web service
+            (``welleng.geomag``) using the longitude, latitude, altitude
+            and survey_date properties — a real latitude/longitude must be
+            provided for the result to count as a valid reference (see
+            ``mag_source``).
         earth_rate: float (default: 0.26249751949994715)
             The rate of rotation of the earth in radians per hour.
         noise_reduction_factor: float (default: 1.0)
             A fiddle factor for random gyro noise.
         dip: float (default: None)
             The dip (inclination) of the magnetic field relative to the
-            earth's horizontal. If left default, then the value is
-            calculated using the magnetic_field_calculator. The unit (deg
-            of rad) is determined by the deg property.
+            earth's horizontal. If left default, the value is looked up
+            from the BGS geomagnetic web service (``welleng.geomag``). The
+            unit (deg or rad) is determined by the deg property.
         declination: float (default: None)
             The angle between true north and magnetic north at the well
-            location. If left default, then the value is calculated
-            using the magnetic_field_calculator.
+            location. If left default, the value is looked up from the
+            BGS geomagnetic web service (``welleng.geomag``).
         convergence: float (default: 0)
             The angle of convergence between the projection meridian and
             the line from true north through the location of the well.


### PR DESCRIPTION
Four tightly-coupled changes to how surveys obtain and trust their geomagnetic reference:

1. **Historic survey dates no longer silently get today's field.** The default BGS model (WMM) only covers a ~10-year window; the old fallback retried with today's date AND overwrote the header's survey_date (~3.5 deg declination bias for a 2008 North Sea well). Now: IGRF fallback for the REQUESTED date; if that also fails, warn naming the date, keep survey_date untouched.
2. **Magnetic error models refuse placeholder references (BREAKING).** SurveyHeader.mag_source records per-value provenance ('user'/'lookup'/'default'). Magnetic models raise on 'default' — provided or looked up, never a package default (a lookup at the defaulted location counts as default). Gyro models exempt; unclassified treated as magnetic.
3. **Altitude units fixed at the lookup boundary** — welleng speaks metres (negative = subsea); the BGS km conversion happens in the client (a -90 m wellhead was previously queried as -90 km, ~2000 nT error).
4. **Own BGS web-service client (welleng.geomag)** replacing the unmaintained magnetic_field_calculator dependency: stdlib, https, timeout, wmm/igrf selectable; lookups skipped when values are user-supplied or the location is defaulted (CI fully offline via mocks). Dependency removed from all extras.

Suite: 790 passed. Live-verified against the BGS service (2008 IGRF at Volve coordinates: 50365 nT / -2.077 deg; -90 m altitude applied).

🤖 Generated with [Claude Code](https://claude.com/claude-code)