### PR TITLE
feat(errors): EDM/COMPASS IPM import — run the operator's actual tool error models

### DIFF
--- a/benchmarks/BENCHMARK_LOG.md
+++ b/benchmarks/BENCHMARK_LOG.md
@@ -401,3 +401,20 @@ errors stay lazy at the Survey level. Structural validation: same-tool sections
 compose EXACTLY equal to the single continuous survey (the tie/leg formulation
 of the ISCWSA error-model definition, §4.7), tool-change carry + systematic
 independence + sidetrack ties pinned in tests/test_survey_composition.py (16).
+
+## 2026-07-19 · `feat/edm-ipm-parser` · Python 3.12, dev machine
+
+EDM/COMPASS IPM import: DP_TOOL_TERM -> live error models (interpreter path)
++ per-section IPM dicts in SurveyComposition.
+
+| operation | result |
+|---|---|
+| `parse_edm_ipm` (Volve.xml, 211 MB, streaming regex) | 2.0 s cold / 0.2 s warm |
+| standard `ISCWSA MWD Rev5.11`, 100 stations (regression check) | 3.2 ms/survey (baseline 3.8 ms — no regression) |
+| EDM IPM dict model (23 grouped terms, interpreter), 100 stations | 7.1 ms/survey |
+
+The dict-model path costs ~2x the native hand-coded MWD path (every term goes
+through the formula interpreter + intermediates) — new functionality, not a
+regression of an existing path; the standard-model hot path is unchanged. The
+lowercase-vocabulary bindings additions to `_call_interpreter` are dict inserts,
+not measurable at this scale.

--- a/docs/welleng.exchange.rst
+++ b/docs/welleng.exchange.rst
@@ -20,6 +20,14 @@ welleng.exchange.edm module
    :undoc-members:
    :show-inheritance:
 
+welleng.exchange.ipm module
+---------------------------
+
+.. automodule:: welleng.exchange.ipm
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
 welleng.exchange.wbp module
 ---------------------------
 

--- a/tests/test_edm_ipm.py
+++ b/tests/test_edm_ipm.py
@@ -172,6 +172,23 @@ def test_all_volve_tools_run(ipm):
     assert not failures, failures
 
 
+def test_dict_models_respect_the_mag_reference_gate(ipm):
+    """A magnetic IPM dict refuses a default-reference header (the 0.21 gate);
+    a gyro IPM dict is exempt — classification from metadata.tool_type."""
+    bare = we.survey.SurveyHeader()      # no mag data, no location
+    mwd = ipm.error_model("Magnetic, std, non-mag")
+    with pytest.raises(ValueError, match="magnetic model"):
+        we.survey.Survey(
+            md=[0., 500., 1000.], inc=[0., 30., 60.], azi=[45.] * 3,
+            header=bare, error_model=mwd,
+        ).err
+    gyro = ipm.error_model("Wellbore Surveyor, stat")
+    we.survey.Survey(     # bare header: no lookup fires, gyro is exempt
+        md=[0., 500., 1000.], inc=[0., 30., 60.], azi=[45.] * 3,
+        header=we.survey.SurveyHeader(), error_model=gyro,
+    ).err
+
+
 def test_dict_model_equivalent_via_error_model_class(ipm):
     model = ipm.error_model("e3rtk")
     s = _survey(model)

--- a/tests/test_edm_ipm.py
+++ b/tests/test_edm_ipm.py
@@ -1,0 +1,287 @@
+"""EDM IPM import: parse the COMPASS error-model layer and run it.
+
+Uses the public Volve EDM export (``data/Volve.xml``, Equinor CC-BY) — the
+only real EDM in the repo and the validation target: its ``DP_TOOL_TERM``
+table carries COMPASS's actual instrument performance models, so welleng can
+compute uncertainty with the very tool models the operator ran.
+"""
+
+import os
+
+import numpy as np
+import pytest
+
+import welleng as we
+from welleng.errors.edm_ipm import (
+    EDMIPM,
+    IPMTerm,
+    IPMTool,
+    ipm_to_error_model,
+    parse_edm_ipm,
+)
+from welleng.exchange.edm_stream import ToolKind, classify_tool
+
+VOLVE = os.path.join(os.path.dirname(__file__), "..", "data", "Volve.xml")
+
+pytestmark = pytest.mark.skipif(
+    not os.path.isfile(VOLVE), reason="Volve.xml not present"
+)
+
+
+@pytest.fixture(scope="module")
+def ipm() -> EDMIPM:
+    return parse_edm_ipm(VOLVE)
+
+
+MAG_REF = dict(b_total=50365., dip=72., declination=-2.08)
+
+
+def _survey(model):
+    return we.survey.Survey(
+        md=[0., 500., 1000., 2000., 3000.],
+        inc=[0., 10., 30., 60., 88.],
+        azi=[45., 45., 60., 90., 120.],
+        header=we.survey.SurveyHeader(
+            name="t", latitude=58.4416, longitude=1.8875, **MAG_REF
+        ),
+        error_model=model,
+    )
+
+
+# --------------------------------------------------------------------------
+# parsing
+# --------------------------------------------------------------------------
+
+def test_parse_volve_ipm_layer(ipm):
+    assert len(ipm.tools) == 30
+    assert sum(len(t.terms) for t in ipm.tools.values()) == 836
+    assert len(ipm.run_tool_map) > 100      # every raw run links to its tool
+    assert len(ipm.magnetics) == 54
+    # intermediates (tie 'n') are exactly the vector 'n' rows
+    for t in ipm.tools.values():
+        for term in t.intermediates:
+            assert term.vector_type == "n"
+        for term in t.error_terms:
+            assert term.vector_type in ("a", "e", "i", "l")
+            assert term.tie_type in ("r", "s", "w", "g")
+
+
+def test_tool_lookup_by_id_and_name(ipm):
+    by_id = ipm.tool("e3rtk")
+    by_name = ipm.tool("Magnetic, std, non-mag")
+    assert by_id is by_name
+    assert by_id.kind is ToolKind.MWD
+
+
+def test_terms_ordered_by_sequence(ipm):
+    for t in ipm.tools.values():
+        seqs = [term.sequence_no for term in t.terms]
+        assert seqs == sorted(seqs)
+
+
+def test_classify_name_wins_over_description():
+    # Volve's MWD tools carry descriptions like "Magnetic Tools (MWD, EMS)
+    # without gyro-verification" — the word "gyro" there must not flip a
+    # magnetic tool to a gyro.
+    assert classify_tool(
+        "Magn, IFR, mag-corr", "Magnetic Tools without gyro-verification"
+    ) is ToolKind.MWD
+    assert classify_tool("MWD gyro, GyroTrak") is ToolKind.GYRO
+
+
+# --------------------------------------------------------------------------
+# conversion
+# --------------------------------------------------------------------------
+
+def test_hyphenated_intermediate_names_mangled():
+    tool = IPMTool(tool_id="x", name="x", terms=[
+        IPMTerm(name="ngxy-b1", sequence_no=1, vector_type="n", tie_type="n",
+                value=2.0, units="-", formula="1.0"),
+        IPMTerm(name="azt1", sequence_no=2, vector_type="a", tie_type="s",
+                value=1.0, units="d", formula="ngxy-b1*sin(inc)"),
+    ])
+    model = ipm_to_error_model(tool)
+    assert model["edm_intermediates"][0]["name"] == "ngxy_b1"
+    assert model["terms"][0]["azimuth_formula"] == "(ngxy_b1*sin(inc))"
+
+
+def test_lateral_maps_to_azimuth_over_sin_inc():
+    tool = IPMTool(tool_id="x", name="x", terms=[
+        IPMTerm(name="lat1", sequence_no=1, vector_type="l", tie_type="s",
+                value=1.0, units="d", formula="cos(inc)"),
+    ])
+    term = ipm_to_error_model(tool)["terms"][0]
+    assert term["inclination_formula"] == "0"
+    assert "maximum(sin(inc), 1e-9)" in term["azimuth_formula"]
+
+
+def test_units_and_propagation_mapping():
+    tool = IPMTool(tool_id="x", name="x", terms=[
+        IPMTerm(name=n, sequence_no=i, vector_type="i", tie_type=tie,
+                value=1.0, units=u, formula="1")
+        for i, (n, tie, u) in enumerate([
+            ("t1", "r", "d"), ("t2", "s", "m"), ("t3", "w", "nt"),
+            ("t4", "g", "dnt"), ("t5", "s", "im"), ("t6", "s", "-"),
+        ])
+    ])
+    model = ipm_to_error_model(tool)
+    assert [t["propagation_mode"] for t in model["terms"]] == [
+        "Random", "Systematic", "Well", "Global", "Systematic", "Systematic"
+    ]
+    assert [t["units"] for t in model["terms"]] == [
+        "deg", "m", "nT", "deg/nT", "1/m", "-"
+    ]
+
+
+# --------------------------------------------------------------------------
+# engine integration
+# --------------------------------------------------------------------------
+
+def test_volve_mwd_model_runs_clean(ipm, recwarn):
+    model = ipm.error_model("Magnetic, std, non-mag")
+    s = _survey(model)
+    cov = s.err.errors.cov_NEVs
+    # every formula + intermediate evaluated — no "contributes zero" warnings
+    assert not [w for w in recwarn if "could not be evaluated" in str(w.message)]
+    assert np.all(np.isfinite(cov))
+    sigma_td = np.sqrt(cov[-1].diagonal())
+    assert np.all(sigma_td > 0.1)           # real uncertainty accumulated
+    assert np.all(sigma_td < 100.0)         # and a sane magnitude
+    # propagation buckets populated per the tie types present in the IPM
+    assert s.err.errors.cov_NEVs_systematic[-1, 0, 0] > 0
+    assert s.err.errors.cov_NEVs_global[-1, 0, 0] > 0
+
+
+def test_all_volve_tools_run(ipm):
+    """Every tool with an IPM must run the engine without unbound variables."""
+    import warnings as w
+
+    failures = {}
+    for tool in ipm.tools.values():
+        if not tool.error_terms:
+            continue
+        model = ipm_to_error_model(tool)
+        with w.catch_warnings(record=True) as caught:
+            w.simplefilter("always")
+            s = _survey(model)
+            _ = s.err.errors.cov_NEVs
+        bad = [str(c.message) for c in caught
+               if "could not be evaluated" in str(c.message)]
+        if bad:
+            failures[tool.name] = bad[0][:100]
+    assert not failures, failures
+
+
+def test_dict_model_equivalent_via_error_model_class(ipm):
+    model = ipm.error_model("e3rtk")
+    s = _survey(model)
+    em = we.error.ErrorModel(s, error_model=model)
+    assert np.allclose(
+        em.errors.cov_NEVs, s.err.errors.cov_NEVs, atol=1e-12
+    )
+
+
+def test_ipm_file_bridge_runs_engine():
+    """A parsed .IPM FILE model runs the same conversion/engine path as an
+    EDM-embedded one (welleng.exchange.ipm -> tool_from_ipm_model).
+
+    Toolface-EXPLICIT terms (``tfo`` in the formula) are a known gap — the
+    welleng weights are toolface-integrated — so such a term warns and
+    contributes zero; the toolface-free terms evaluate.
+    """
+    import textwrap
+    import warnings as w
+
+    from welleng.errors.edm_ipm import tool_from_ipm_model
+    from welleng.exchange.ipm import loads_ipm
+
+    sample = textwrap.dedent(
+        """\
+        #Tool Name  :TEST_MWD
+        #ShortName  :TEST
+        #Description:synthetic test model
+        #Name\tVector\tTie-On\tUnit\tValue\tFormula
+        abx\ti\ts\t-\t0.004\t(-cos(inc)*sin(tfo))/gtot
+        abz\ti\ts\t-\t0.004\t(-sin(inc))/gtot
+        mbz\ta\ts\tnt\t70\t(-sin(inc)*sin(azm))/(mtot*cos(dip))
+        dref\te\tr\t-\t0.35\t1.0
+        dsf\te\ts\t-\t0.00024\ttmd
+        decg\ta\tg\tdeg\t0.36\t1.0
+        """
+    )
+    tool = tool_from_ipm_model(loads_ipm(sample))
+    assert tool.name == "TEST"
+    model = ipm_to_error_model(tool)
+    with w.catch_warnings(record=True) as caught:
+        w.simplefilter("always")
+        s = _survey(model)
+        cov = s.err.errors.cov_NEVs
+    tfo_warns = [c for c in caught if "abx" in str(c.message)]
+    assert tfo_warns, "toolface-explicit term should warn (known gap)"
+    assert np.all(np.isfinite(cov))
+    assert cov[-1, 2, 2] > 0        # depth terms accumulated fine
+
+
+# --------------------------------------------------------------------------
+# validation: reproduce COMPASS's own covariance (the whole point)
+# --------------------------------------------------------------------------
+
+def test_f12_plan_reproduces_compass_covariance(ipm):
+    """F-12 PLAN definitive: single tool ('Magnetic, std, mag-corr') over the
+    whole path, with COMPASS's own per-station 1-sigma covariances stored in
+    the export — ground truth we did not compute.
+
+    Built with the ACTUAL tool IPM (DP_TOOL_TERM) + the as-run geomagnetic
+    reference (DP_MAGNETIC), welleng matches COMPASS:
+
+    - sigma_N and sigma_E within ±1% (or 2 cm absolute, whichever is
+      larger — the first few stations carry centimetre sigmas where the
+      start-station conventions differ) at every station;
+    - sigma_V within -8%..+1% — welleng slightly UNDER, a known residual
+      with the shape const(0.12 m) + ~3.1e-4*TVD, i.e. a well-level
+      vertical reference term COMPASS carries outside DP_TOOL_TERM (no
+      depth-uncertainty table exists in the export to source it from).
+
+    COMPASS station frame: x=East, y=North, z=Vertical; feet; 1-sigma.
+    """
+    from welleng.exchange.edm_stream import EDMReader, FEET_TO_METERS
+
+    r = EDMReader(VOLVE)
+    hid = "AtCw9"
+    h = r.headers[hid]
+    stations = sorted(r._def_stations[hid], key=lambda s: s["md"])
+    mag = [m for m in ipm.magnetics
+           if m.get("wellbore_id") == h.wellbore_id][0]
+    prog = r.programs[hid][0]
+    tool_id = prog.survey_tool_id or ipm.run_tool_map[prog.survey_header_id]
+    assert ipm.tools[tool_id].name == "Magnetic, std, mag-corr"
+
+    F = FEET_TO_METERS
+    md = np.array([s["md"] for s in stations]) * F
+    inc = np.array([s["inc"] for s in stations])
+    azi = np.array([s["azi"] for s in stations])
+    cc = np.array([s["cov"] for s in stations]) * F ** 2
+
+    s = we.survey.Survey(
+        md=md, inc=inc, azi=azi,
+        header=we.survey.SurveyHeader(
+            name="F-12 PLAN", azi_reference="grid",
+            b_total=float(mag["field_strength"]),
+            dip=float(mag["dip_angle"]),
+            declination=float(mag["declination"]),
+        ),
+        error_model=ipm.error_model(tool_id),
+    )
+    cov = s.err.errors.cov_NEVs
+
+    sig_we = np.sqrt(np.stack(
+        [cov[:, 0, 0], cov[:, 1, 1], cov[:, 2, 2]], axis=1))
+    sig_cp = np.sqrt(np.stack([cc[:, 3], cc[:, 0], cc[:, 5]], axis=1))
+
+    diff = np.abs(sig_we - sig_cp)
+    tol = np.maximum(0.01 * sig_cp, 0.02)
+    assert np.all(diff[:, 0] <= tol[:, 0]), "sigma_N off >1% (>2 cm)"
+    assert np.all(diff[:, 1] <= tol[:, 1]), "sigma_E off >1% (>2 cm)"
+    v_ok = (sig_we[:, 2] >= 0.90 * sig_cp[:, 2] - 0.02) \
+        & (sig_we[:, 2] <= 1.01 * sig_cp[:, 2] + 0.02)
+    assert np.all(v_ok), "sigma_V outside the documented -8%..+1% band"

--- a/tests/test_edm_ipm.py
+++ b/tests/test_edm_ipm.py
@@ -285,3 +285,75 @@ def test_f12_plan_reproduces_compass_covariance(ipm):
     v_ok = (sig_we[:, 2] >= 0.90 * sig_cp[:, 2] - 0.02) \
         & (sig_we[:, 2] <= 1.01 * sig_cp[:, 2] + 0.02)
     assert np.all(v_ok), "sigma_V outside the documented -8%..+1% band"
+
+
+def test_f14_actual_composed_multi_tool_vs_compass(ipm):
+    """F-14 ACTUAL definitive: gyro to 2601 m, then two MWD runs — composed
+    with SurveyComposition using the per-section ACTUAL tool IPMs and
+    compared against COMPASS's own composed covariances.
+
+    Result: sigma_N and sigma_E within a few percent of COMPASS at every
+    covariance-bearing station (a single standard model misses the composed
+    covariance by tens of percent); sigma_V carries the same well-level
+    vertical-reference residual documented on the F-12 case (largest in the
+    vertical gyro section), asserted as a band pending its resolution.
+    """
+    from welleng.composition import SurveyComposition, SurveySection
+    from welleng.exchange.edm_stream import EDMReader, FEET_TO_METERS
+
+    r = EDMReader(VOLVE)
+    st = None
+    for hid, stations in r._def_stations.items():
+        h = r.headers[hid]
+        wb = r.wellbores.get(h.wellbore_id)
+        if wb and wb.name == "F-14" and h.phase == "ACTUAL":
+            st = sorted(stations, key=lambda s: s["md"])
+            header = h
+    assert st is not None
+    mag = [m for m in ipm.magnetics
+           if m.get("wellbore_id") == header.wellbore_id][0]
+
+    F = FEET_TO_METERS
+    md = np.array([s["md"] for s in st]) * F
+    inc = np.array([s["inc"] for s in st])
+    azi = np.array([s["azi"] for s in st])
+    cc = np.array([s["cov"] for s in st]) * F ** 2
+
+    sh = we.survey.SurveyHeader(
+        name="F-14", azi_reference="grid",
+        latitude=58.4416, longitude=1.8875,
+        b_total=float(mag["field_strength"]),
+        dip=float(mag["dip_angle"]),
+        declination=float(mag["declination"]),
+    )
+    gyro = ipm.error_model("Wellbore Surveyor, stat")
+    mwd = ipm.error_model("Magnetic, std, non-mag")
+    i1 = int(np.argmin(np.abs(md - 2601.0)))    # gyro -> MWD (program break)
+    i2 = int(np.argmin(np.abs(md - 2733.1)))    # MWD run 1 -> run 2
+
+    comp = SurveyComposition(sections=[
+        SurveySection(md=md[:i1 + 1], inc=inc[:i1 + 1], azi=azi[:i1 + 1],
+                      header=sh, error_model=gyro, tool_id="gyro"),
+        # a gyro and an MWD share no error realisations
+        SurveySection(md=md[i1:i2 + 1], inc=inc[i1:i2 + 1],
+                      azi=azi[i1:i2 + 1], header=sh, error_model=mwd,
+                      tool_id="mwd1", share_mode="all_independent"),
+        # same magnetic reference across the two MWD runs
+        SurveySection(md=md[i2:], inc=inc[i2:], azi=azi[i2:], header=sh,
+                      error_model=mwd, tool_id="mwd2",
+                      share_mode="globals_shared"),
+    ]).survey()
+    cov = comp.cov_nev
+
+    sig_we = np.sqrt(np.stack(
+        [cov[:, 0, 0], cov[:, 1, 1], cov[:, 2, 2]], axis=1))
+    sig_cp = np.sqrt(np.stack([cc[:, 3], cc[:, 0], cc[:, 5]], axis=1))
+
+    diff = np.abs(sig_we - sig_cp)
+    tol = np.maximum(0.04 * sig_cp, 0.02)   # 4% or 2 cm (shallow stations)
+    assert np.all(diff[:, 0] <= tol[:, 0]), "sigma_N outside 4% of COMPASS"
+    assert np.all(diff[:, 1] <= tol[:, 1]), "sigma_E outside 4% of COMPASS"
+    m = sig_cp[:, 2] > 0.05
+    v_ratio = sig_we[m, 2] / sig_cp[m, 2]
+    assert np.all((v_ratio > 0.50) & (v_ratio < 1.02)), \
+        "sigma_V outside the open vertical-reference residual band"

--- a/tests/test_ipm.py
+++ b/tests/test_ipm.py
@@ -1,0 +1,86 @@
+"""Tests for the IPM (Instrument Performance Model) reader.
+
+Uses a small synthetic model in the IPM format — no third-party/vendor error models.
+"""
+import textwrap
+
+from welleng.exchange.ipm import read_ipm, loads_ipm, IPMModel, IPMTerm
+
+
+# A minimal, made-up IPM model (a few ISCWSA-style terms) — not a vendor model.
+SAMPLE = textwrap.dedent(
+    """\
+    #Tool Name  :TEST_MWD
+    #ShortName  :TEST
+    #Description:synthetic test model
+    #Remarks    :for unit tests only
+    #ToolGroup  :1
+    #Name\tVector\tTie-On\tUnit\tValue\tFormula
+    abx\ti\ts\t-\t0.004\t(-cos(inc)*sin(tfo))/gtot
+    abz\ti\ts\t-\t0.004\t(-sin(inc))/gtot
+    mbz\ta\ts\tnt\t70\t(-sin(inc)*sin(azm))/(mtot*cos(dip))
+    dref\te\tr\t-\t0.35\t1.0
+    dsf\te\ts\t-\t0.00024\ttmd
+    decg\ta\tg\tdeg\t0.36\t1.0
+    """
+)
+
+
+def test_loads_header_and_terms():
+    m = loads_ipm(SAMPLE)
+    assert isinstance(m, IPMModel)
+    assert m.name == "TEST_MWD"
+    assert m.short_name == "TEST"
+    assert m.description == "synthetic test model"
+    assert len(m.terms) == 6
+    assert m.header["ToolGroup"] == "1"
+
+
+def test_term_fields_parsed():
+    m = loads_ipm(SAMPLE)
+    abx = m.terms[0]
+    assert isinstance(abx, IPMTerm)
+    assert (abx.name, abx.vector, abx.tie_on, abx.unit) == ("abx", "i", "s", "-")
+    assert abx.value == 0.004
+    assert abx.formula == "(-cos(inc)*sin(tfo))/gtot"
+    # a magnetic term keeps its unit + full formula
+    mbz = [t for t in m.terms if t.name == "mbz"][0]
+    assert mbz.unit == "nt" and mbz.value == 70.0
+    assert mbz.formula == "(-sin(inc)*sin(azm))/(mtot*cos(dip))"
+
+
+def test_sources_and_tie_on():
+    m = loads_ipm(SAMPLE)
+    assert m.sources() == ["abx", "abz", "decg", "dref", "dsf", "mbz"]
+    assert {t.name for t in m.by_tie_on("s")} == {"abx", "abz", "mbz", "dsf"}
+    assert [t.name for t in m.by_tie_on("r")] == ["dref"]
+    assert [t.name for t in m.by_tie_on("g")] == ["decg"]
+
+
+def test_to_dict_json_safe():
+    import json
+    m = loads_ipm(SAMPLE)
+    d = m.to_dict()
+    json.dumps(d)                       # must not raise
+    assert d["terms"][0]["name"] == "abx"
+    assert len(d["terms"]) == 6
+
+
+def test_whitespace_delimited_fallback():
+    # some exports use runs of spaces instead of tabs
+    txt = (
+        "#Tool Name  :SPACED\n"
+        "#Name  Vector  Tie-On  Unit  Value  Formula\n"
+        "abx    i       s       -     0.004  (-cos(inc)*sin(tfo))/gtot\n"
+    )
+    m = loads_ipm(txt)
+    assert m.name == "SPACED"
+    assert len(m.terms) == 1
+    assert m.terms[0].name == "abx" and m.terms[0].value == 0.004
+
+
+def test_read_ipm_from_file(tmp_path):
+    p = tmp_path / "TEST.IPM"
+    p.write_text(SAMPLE)
+    m = read_ipm(p)
+    assert m.name == "TEST_MWD" and len(m.terms) == 6

--- a/welleng/composition.py
+++ b/welleng/composition.py
@@ -60,6 +60,25 @@ __all__ = ["SurveySection", "SurveyComposition"]
 #: Default ISCWSA error model when a section does not name one.
 DEFAULT_ERROR_MODEL = "ISCWSA MWD Rev5.11"
 
+
+def _model_key(error_model) -> object:
+    """Hashable identity for a section's error model.
+
+    Named models are their string; prebuilt model DICTS (e.g. an EDM/COMPASS
+    IPM from ``welleng.errors.edm_ipm``) are unhashable, so key on the
+    object's identity — two sections share a tool run only when they carry
+    the SAME model object, which is the correct correlation semantics for a
+    tool-specific imported IPM.
+    """
+    return error_model if isinstance(error_model, str) else id(error_model)
+
+
+def _model_name(error_model) -> str:
+    """Display name for a section's error model (str or model dict)."""
+    if isinstance(error_model, str):
+        return error_model
+    return error_model.get('metadata', {}).get('short_name', 'custom-dict-model')
+
 #: Survey-date gap (years) beyond which an unspecified tie auto-defaults to
 #: ``all_independent`` (geomag secular variation makes the global realisation
 #: effectively independent between campaigns this far apart).
@@ -250,7 +269,7 @@ class SurveyComposition:
             md, inc_rad, azi_grid_rad, header, error_model = (
                 self._section_grid(section)
             )
-            key = (error_model, section.tool_id)
+            key = (_model_key(error_model), section.tool_id)
             same_tool = bool(groups) and key == prev_key
 
             if same_tool:
@@ -314,7 +333,7 @@ class SurveyComposition:
         last = self.sections[0]
         for section in self.sections:
             error_model = section.error_model or DEFAULT_ERROR_MODEL
-            key = (error_model, section.tool_id)
+            key = (_model_key(error_model), section.tool_id)
             if not (gi >= 0 and key == prev_key):
                 gi += 1
             if gi == group_index:
@@ -506,12 +525,12 @@ class SurveyComposition:
         station, so without this the tie station would be mis-computed.
         """
         groups = self._groups[k:j + 1]
-        models = {g.error_model for g in groups}
+        models = {_model_key(g.error_model) for g in groups}
         if len(models) > 1:
             warnings.warn(
-                "shared-error tie spans multiple error models "
-                f"{sorted(models)}; the shared component uses "
-                f"{groups[0].error_model!r} as the reference model",
+                "shared-error tie spans multiple error models; the shared "
+                f"component uses {_model_name(groups[0].error_model)!r} as "
+                "the reference model",
                 RuntimeWarning,
             )
         md = self._stitch_1d([g.md for g in groups])

--- a/welleng/error.py
+++ b/welleng/error.py
@@ -156,11 +156,31 @@ class ErrorModel():
         ----------
         survey : welleng.survey.Survey
             The survey to compute errors for.
-        error_model : str, optional
+        error_model : str or dict, optional
             Name of the error model to apply. Defaults to the Rev 5.11
             compliant ``"ISCWSA MWD Rev5.11"``. The legacy name
             ``"ISCWSA MWD Rev5"`` is accepted as a deprecated alias.
+            Alternatively a prebuilt ISCWSA-JSON-shaped model dict — e.g.
+            a COMPASS IPM imported from an EDM export by
+            ``welleng.errors.edm_ipm`` — evaluated by the formula
+            interpreter without any file resolution.
         """
+
+        if isinstance(error_model, dict):
+            self.error_model = error_model.get(
+                'metadata', {}
+            ).get('short_name', 'custom-dict-model')
+            self.survey = survey
+            self.survey_rad = np.stack((
+                self.survey.md,
+                self.survey.inc_rad,
+                self.survey.azi_true_rad
+            ), axis=-1)
+            self.survey_drdp = self.survey_rad
+            self.drdp = self._drdp(self.survey_drdp)
+            self.drdp_sing = self._drdp_sing(self.survey_drdp)
+            self.errors = ToolError(error=self, model=error_model)
+            return
 
         if error_model in _DEPRECATED_ERROR_MODEL_ALIASES:
             replacement = _DEPRECATED_ERROR_MODEL_ALIASES[error_model]

--- a/welleng/error.py
+++ b/welleng/error.py
@@ -180,6 +180,7 @@ class ErrorModel():
             self.survey_drdp = self.survey_rad
             self.drdp = self._drdp(self.survey_drdp)
             self.drdp_sing = self._drdp_sing(self.survey_drdp)
+            self._validate_mag_reference(error_model)
             self.errors = ToolError(error=self, model=error_model)
             return
 
@@ -227,24 +228,32 @@ class ErrorModel():
             model=model
         )
 
-    def _validate_mag_reference(self, model: str) -> None:
+    def _validate_mag_reference(self, model) -> None:
         """Magnetic models need a real geomagnetic reference — refuse package
         defaults.
 
         Magnetic-compass models' weighting functions consume the header's
         ``b_total``/``dip``/``declination``; gyro models (OWSG ``A<nn>G*``,
-        the GYRO short names, the SPE-90408 example model) do not. Those
-        values must be either user-provided or looked up for a user-provided
-        location — the header's fallback values (or a lookup at the fallback
-        location) are placeholders, not a geomagnetic reference, and would
-        silently bias every magnetic term. Unclassified models are treated
-        as magnetic (the strict direction). See ``SurveyHeader.mag_source``.
+        the GYRO short names, the SPE-90408 example model, and dict models
+        whose ``metadata.tool_type`` says gyro / inclination-only) do not.
+        Those values must be either user-provided or looked up for a
+        user-provided location — the header's fallback values (or a lookup at
+        the fallback location) are placeholders, not a geomagnetic reference,
+        and would silently bias every magnetic term. Unclassified models are
+        treated as magnetic (the strict direction). See
+        ``SurveyHeader.mag_source``.
         """
-        is_gyro = (
-            re.match(r"^A\d+G", model) is not None
-            or 'GYRO' in self.error_model.upper()
-            or '90408' in model
-        )
+        if isinstance(model, dict):
+            tool_type = str(
+                model.get('metadata', {}).get('tool_type', '')
+            ).lower()
+            is_gyro = tool_type in ('gyro', 'inclination_only')
+        else:
+            is_gyro = (
+                re.match(r"^A\d+G", model) is not None
+                or 'GYRO' in self.error_model.upper()
+                or '90408' in model
+            )
         if is_gyro:
             return
         sources = getattr(self.survey.header, 'mag_source', None)

--- a/welleng/errors/edm_ipm.py
+++ b/welleng/errors/edm_ipm.py
@@ -1,0 +1,417 @@
+"""EDM IPM import — build error models from an EDM export's survey-tool layer.
+
+An EDM (Landmark Engineer's Data Model) export can carry the COMPASS
+error-model layer alongside the well data:
+
+- ``CD_SURVEY_TOOL`` — the named survey-tool definitions;
+- ``DP_TOOL_TERM``  — the full instrument performance model (IPM) per tool:
+  one row per error term with its magnitude (``c_value``), units
+  (``c_units``), weighting function as a text formula (``c_formula``),
+  vector direction (``vector_type``) and tie-on/propagation (``tie_type``);
+- ``CD_SURVEY_HEADER.survey_tool_id`` — which tool ran each survey interval;
+- ``DP_MAGNETIC`` — the per-wellbore geomagnetic reference used at the time.
+
+This module parses those tables and converts each tool's IPM into the
+ISCWSA-JSON-shaped model dict that welleng's formula-interpreter error engine
+evaluates (`welleng.errors.tool_errors`), so a survey's uncertainty can be
+computed with the *actual tool models the operator ran* instead of a
+nearest-standard-model guess:
+
+>>> # doctest: +SKIP
+>>> ipm = parse_edm_ipm("data/Volve.xml")
+>>> model = ipm.error_model("5pod5")          # a survey_tool_id or tool name
+>>> s = Survey(md, inc, azi, header=header, error_model=model)
+
+COMPASS IPM conventions (COMPASS 5000 manual, ch. 3 "Survey Tool Editor"):
+
+- ``vector_type``: ``a`` azimuth, ``i`` inclination (highside), ``e`` depth
+  (ISCWSA), ``d`` depth (Wolff & de Wardt), ``l`` lateral (equivalent to an
+  azimuth error divided by sin(inclination)), ``b``/``j`` azimuth/inclination
+  bias, ``m`` misalignment, ``n`` intermediate (see below).
+- ``tie_type``: ``r`` random, ``s`` systematic, ``w`` well-by-well,
+  ``g`` global, ``n`` **not used in accumulation** — an intermediate value
+  other formulas reference by name (e.g. ``latsf``, ``tvdsf``).
+- Formulas are Excel-style text over lower-case variables: ``inc``, ``azm``
+  (magnetic azimuth), ``azt`` (true), ``azi`` (grid), ``tmd`` (measured
+  depth), ``dmd`` (course length to the previous station), ``tvd``,
+  ``gtot`` (total gravity), ``mtot`` (total B-field, nT), ``dip``, ``lat``
+  (latitude), ``erot`` (earth rate), ``mtf`` (metres-to-feet — identity
+  here, welleng evaluates in SI).
+
+Intermediate names may contain ``-`` (e.g. ``ngxy-b1``), which would parse
+as subtraction — they are mangled to ``_`` in both definitions and
+referencing formulas before evaluation.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass, field
+from typing import Dict, List
+
+from ..exchange.edm_stream import ToolKind, classify_tool
+
+# COMPASS c_units -> the ISCWSA-JSON units enum welleng's engine converts
+# from (see tool_errors._MAG_UNIT_TO_BASE). COMPASS 'm'/'im' encode the
+# metres<->feet conversions of its feet-internal engine; welleng evaluates
+# in SI so lengths stay metres.
+_COMPASS_UNITS = {
+    "d": "deg",
+    "m": "m",
+    "im": "1/m",
+    "nt": "nT",
+    "dnt": "deg/nT",
+    "-": "-",
+    "": "-",
+}
+
+_TIE_TO_PROPAGATION = {
+    "r": "Random",
+    "s": "Systematic",
+    "w": "Well",
+    "g": "Global",
+}
+
+# regex helpers for the streaming XML scan (the Volve export is ~200 MB;
+# a DOM parse is not an option and only flat attribute rows are needed)
+_ROW_PATTERNS = {
+    tag: re.compile(rf"<{tag}\s([^>]*?)/?>")
+    for tag in (
+        "CD_SURVEY_TOOL", "DP_TOOL_TERM", "DP_MAGNETIC", "CD_SURVEY_HEADER",
+    )
+}
+_ATTR = re.compile(r'([\w-]+)="([^"]*)"')
+
+
+@dataclass
+class IPMTerm:
+    """One ``DP_TOOL_TERM`` row."""
+
+    name: str
+    sequence_no: int
+    vector_type: str            # a | i | e | d | l | b | j | m | n
+    tie_type: str               # r | s | w | g | n
+    value: float
+    units: str                  # raw COMPASS units code
+    formula: str
+    min_inc: float = 0.0        # inclination range gate (deg); 0/0 = none
+    max_inc: float = 0.0
+
+
+@dataclass
+class IPMTool:
+    """A survey tool and its full IPM."""
+
+    tool_id: str
+    name: str
+    description: str = ""
+    kind: ToolKind = ToolKind.OTHER
+    terms: List[IPMTerm] = field(default_factory=list)
+
+    @property
+    def intermediates(self) -> List[IPMTerm]:
+        return [t for t in self.terms if t.tie_type == "n"]
+
+    @property
+    def error_terms(self) -> List[IPMTerm]:
+        return [t for t in self.terms if t.tie_type != "n"]
+
+
+def _mangle(name: str) -> str:
+    """COMPASS term names may contain '-', invalid in a parsed formula."""
+    return name.replace("-", "_")
+
+
+def _mangle_formula(formula: str, hyphenated: List[str]) -> str:
+    """Replace hyphenated intermediate NAMES before '-' means subtraction.
+
+    Longest-first so ``ngxy-gd1`` is replaced before any shorter overlap.
+    """
+    for name in sorted(hyphenated, key=len, reverse=True):
+        formula = formula.replace(name, _mangle(name))
+    return formula
+
+
+class EDMIPMError(ValueError):
+    """The EDM export lacks the requested tool / IPM content."""
+
+
+@dataclass
+class EDMIPM:
+    """The parsed error-model layer of an EDM export."""
+
+    tools: Dict[str, IPMTool]                 # keyed by survey_tool_id
+    run_tool_map: Dict[str, str]              # survey_header_id -> tool_id
+    magnetics: List[Dict[str, str]]           # DP_MAGNETIC rows, raw
+
+    def tool(self, key: str) -> IPMTool:
+        """Fetch a tool by ``survey_tool_id`` or (case-insensitive) name."""
+        if key in self.tools:
+            return self.tools[key]
+        lowered = key.lower()
+        matches = [
+            t for t in self.tools.values() if t.name.lower() == lowered
+        ]
+        if not matches:
+            raise EDMIPMError(f"no survey tool {key!r} in the EDM export")
+        if len(matches) > 1:
+            raise EDMIPMError(
+                f"tool name {key!r} is ambiguous; use the survey_tool_id "
+                f"({', '.join(t.tool_id for t in matches)})"
+            )
+        return matches[0]
+
+    def error_model(self, key: str) -> dict:
+        """Build the welleng error-model dict for a tool (see
+        :func:`ipm_to_error_model`)."""
+        return ipm_to_error_model(self.tool(key))
+
+
+def tool_from_ipm_model(model) -> IPMTool:
+    """Bridge a parsed ``.IPM`` file (:class:`welleng.exchange.ipm.IPMModel`)
+    to an :class:`IPMTool`, so file-based tool models run the same
+    conversion/engine path as EDM-embedded ones:
+
+    >>> # doctest: +SKIP
+    >>> from welleng.exchange.ipm import read_ipm
+    >>> tool = tool_from_ipm_model(read_ipm("MWD+SAG.IPM"))
+    >>> s = Survey(md, inc, azi, header=h, error_model=ipm_to_error_model(tool))
+    """
+    name = model.short_name or model.name
+    return IPMTool(
+        tool_id=name,
+        name=name,
+        description=model.description,
+        kind=classify_tool(name, model.description),
+        terms=[
+            IPMTerm(
+                name=t.name,
+                sequence_no=i,
+                vector_type=t.vector.lower(),
+                tie_type=t.tie_on.lower(),
+                value=t.value,
+                units=t.unit.lower(),
+                formula=t.formula,
+            )
+            for i, t in enumerate(model.terms)
+        ],
+    )
+
+
+def parse_edm_ipm(path: str) -> EDMIPM:
+    """Stream-parse an EDM export's survey-tool error-model layer.
+
+    Parameters
+    ----------
+    path : str
+        The EDM XML export (e.g. the public Volve dataset's ``Volve.xml``).
+
+    Returns
+    -------
+    EDMIPM
+    """
+    rows: Dict[str, List[Dict[str, str]]] = {t: [] for t in _ROW_PATTERNS}
+    with open(path, encoding="utf-8", errors="replace") as fh:
+        tail = ""
+        for chunk in iter(lambda: fh.read(1 << 20), ""):
+            buf = tail + chunk
+            for tag, pattern in _ROW_PATTERNS.items():
+                for m in pattern.finditer(buf):
+                    rows[tag].append(dict(_ATTR.findall(m.group(1))))
+            # keep a tail longer than any row so no match spans a boundary
+            tail = buf[-(1 << 14):]
+    # de-duplicate rows the overlapping tail scanned twice
+    for tag in rows:
+        seen, unique = set(), []
+        for r in rows[tag]:
+            k = tuple(sorted(r.items()))
+            if k not in seen:
+                seen.add(k)
+                unique.append(r)
+        rows[tag] = unique
+
+    tools: Dict[str, IPMTool] = {}
+    for r in rows["CD_SURVEY_TOOL"]:
+        tool_id = r.get("survey_tool_id", "")
+        name = r.get("tool_name", "") or r.get("name", "")
+        desc = r.get("description", "")
+        tools[tool_id] = IPMTool(
+            tool_id=tool_id, name=name, description=desc,
+            kind=classify_tool(name, desc),
+        )
+
+    for r in rows["DP_TOOL_TERM"]:
+        tool_id = r.get("survey_tool_id", "")
+        if tool_id not in tools:
+            tools[tool_id] = IPMTool(tool_id=tool_id, name=tool_id)
+        tools[tool_id].terms.append(IPMTerm(
+            name=r.get("term_name", ""),
+            sequence_no=int(float(r.get("sequence_no", "0"))),
+            vector_type=r.get("vector_type", "").lower(),
+            tie_type=r.get("tie_type", "").lower(),
+            value=float(r.get("c_value", "0") or 0),
+            units=r.get("c_units", "").lower(),
+            formula=r.get("c_formula", "0"),
+            min_inc=float(r.get("min_range", "0") or 0),
+            max_inc=float(r.get("max_range", "0") or 0),
+        ))
+    for t in tools.values():
+        t.terms.sort(key=lambda term: term.sequence_no)
+
+    run_tool_map = {
+        r["survey_header_id"]: r["survey_tool_id"]
+        for r in rows["CD_SURVEY_HEADER"]
+        if r.get("survey_header_id") and r.get("survey_tool_id")
+    }
+    return EDMIPM(
+        tools=tools, run_tool_map=run_tool_map,
+        magnetics=rows["DP_MAGNETIC"],
+    )
+
+
+def ipm_to_error_model(tool: IPMTool) -> dict:
+    """Convert one tool's IPM to the welleng (ISCWSA-JSON-shaped) model dict.
+
+    The dict can be passed straight to ``Survey(..., error_model=model)`` /
+    ``ErrorModel(survey, error_model=model)``.
+
+    Conversion rules
+    ----------------
+    - vector ``a``/``b`` -> azimuth formula; ``i``/``j`` -> inclination;
+      ``e``/``d`` -> depth; ``l`` (lateral) -> azimuth formula divided by
+      ``sin(inc)`` (clamped near vertical — the ``1/sin`` cancels against
+      the ``sin(inc)`` in the position sensitivity to azimuth, which is the
+      standard ISCWSA lateral treatment); ``m`` (misalignment disc) -> equal
+      inclination and lateral components.
+    - tie ``r``/``s``/``w``/``g`` -> Random/Systematic/Well/Global.
+    - tie ``n`` rows become named intermediates evaluated (in sequence
+      order) into the formula namespace: ``name = value * formula``.
+    """
+    hyphenated = [t.name for t in tool.intermediates if "-" in t.name]
+
+    intermediates = [
+        {
+            "name": _mangle(t.name),
+            "value": t.value * _unit_multiplier(t.units),
+            "formula": _mangle_formula(t.formula, hyphenated),
+        }
+        for t in tool.intermediates
+    ]
+
+    # Rows sharing a NAME are components of the SAME error source (the
+    # COMPASS convention: reuse the name to add onto the same source — e.g.
+    # a misalignment with an inclination row AND a lateral row). They share
+    # one random realisation, so they must land in ONE term whose per-axis
+    # weight formulas carry each component — not independent terms (and not
+    # clobber each other in a name-keyed dict). Rows sharing a name but NOT
+    # a tie type (e.g. a gyro's 'grexy' with a random and a systematic leg)
+    # cannot share a realisation across propagation modes — they become
+    # separate terms disambiguated by tie type.
+    grouped: Dict[tuple, List[IPMTerm]] = {}
+    for t in tool.error_terms:
+        grouped.setdefault((t.name, t.tie_type), []).append(t)
+    name_counts: Dict[str, int] = {}
+    for (nm, _tie) in grouped:
+        name_counts[nm] = name_counts.get(nm, 0) + 1
+
+    terms = []
+    for (name, tie), rows in grouped.items():
+        ref = rows[0]
+        if tie not in _TIE_TO_PROPAGATION:
+            raise EDMIPMError(
+                f"tool {tool.name!r} term {name!r}: unsupported "
+                f"tie_type {tie!r}"
+            )
+        if name_counts[name] > 1:
+            name = f"{name}({tie})"
+        axes = {"d": [], "i": [], "a": []}
+        # vertical-hole singularity weights (ISCWSA Rev5.13 Sec 11.5): at a
+        # vertical station the inclination component acts along the (canonical
+        # azi=0 ->) NORTH axis and the lateral component along EAST — the
+        # standard XYM3/XYM4 treatment. Without this, the "east" disc mode of
+        # a near-vertical misalignment silently vanishes (dr/dAz -> 0).
+        sing_n, sing_e = [], []
+        for t in rows:
+            formula = _mangle_formula(t.formula, hyphenated)
+            # same source, possibly different magnitude per component —
+            # scale relative to the group's reference value
+            if t.value != ref.value:
+                if ref.value == 0:
+                    raise EDMIPMError(
+                        f"tool {tool.name!r} term {name!r}: zero reference "
+                        "value with non-zero component"
+                    )
+                formula = f"({t.value / ref.value}) * ({formula})"
+            vector = t.vector_type
+            if vector in ("a", "b"):
+                axes["a"].append(formula)
+            elif vector in ("i", "j"):
+                axes["i"].append(formula)
+                sing_n.append(formula)
+            elif vector in ("e", "d"):
+                axes["d"].append(formula)
+            elif vector == "l":
+                axes["a"].append(
+                    f"({formula}) / maximum(sin(inc), 1e-9)"
+                )
+                sing_e.append(formula)
+            elif vector == "m":
+                axes["i"].append(formula)
+                sing_n.append(formula)
+                axes["a"].append(
+                    f"({formula}) / maximum(sin(inc), 1e-9)"
+                )
+                sing_e.append(formula)
+            else:
+                raise EDMIPMError(
+                    f"tool {tool.name!r} term {name!r}: unsupported "
+                    f"vector_type {vector!r}"
+                )
+
+        def _sum(parts: List[str]) -> str:
+            return " + ".join(f"({p})" for p in parts) if parts else "0"
+
+        # The singularity substitution REPLACES the term's whole position
+        # error at vertical stations, so it is only emitted for purely
+        # angular terms; a mixed depth+angular source would lose its depth
+        # part there (no such tool exists in the Volve set).
+        has_sing = (sing_n or sing_e) and not axes["d"]
+        entry = {
+            "name": name,
+            "value": ref.value,
+            "units": _COMPASS_UNITS.get(ref.units, "-"),
+            "propagation_mode": _TIE_TO_PROPAGATION[tie],
+            "depth_formula": _sum(axes["d"]),
+            "inclination_formula": _sum(axes["i"]),
+            "azimuth_formula": _sum(axes["a"]),
+            "north_singularity": _sum(sing_n) if has_sing else None,
+            "east_singularity": _sum(sing_e) if has_sing else None,
+            "vertical_singularity": "0" if has_sing else None,
+        }
+        if ref.max_inc > ref.min_inc:
+            entry["inc_range"] = [ref.min_inc, ref.max_inc]
+        terms.append(entry)
+
+    return {
+        "metadata": {
+            "model_id": tool.tool_id,
+            "short_name": tool.name,
+            "long_name": f"EDM IPM: {tool.name}",
+            "tool_type": tool.kind.value,
+            "source": "EDM export DP_TOOL_TERM",
+            "framework": "COMPASS IPM",
+        },
+        "parameters": {"inc_min": 0, "inc_max": 180},
+        "edm_intermediates": intermediates,
+        "terms": terms,
+    }
+
+
+def _unit_multiplier(units: str) -> float:
+    """COMPASS unit code -> multiplier into welleng's SI evaluation base."""
+    import numpy as np
+
+    return {
+        "d": np.pi / 180.0,
+        "dnt": np.pi / 180.0,
+    }.get(units, 1.0)

--- a/welleng/errors/tool_errors.py
+++ b/welleng/errors/tool_errors.py
@@ -184,7 +184,13 @@ def _json_to_em_adapter(model: dict) -> dict:
             # Carry through the formula strings for the interpreter.
             "_iscwsa_term": term,
         }
-    return {"header": header, "codes": codes}
+    em = {"header": header, "codes": codes}
+    # EDM/COMPASS IPM models (welleng/errors/edm_ipm.py) carry named
+    # intermediate values (tie-type 'n' rows) that later formulas reference;
+    # they are evaluated into the interpreter bindings in sequence order.
+    if model.get("edm_intermediates"):
+        em["edm_intermediates"] = model["edm_intermediates"]
+    return em
 
 # since this is running on different OS flavors
 PATH = os.path.dirname(__file__)
@@ -233,10 +239,16 @@ class ToolError:
         # Some JSON files are named by Short Name (the converter's
         # default), so we walk the iscwsa_json/ tree looking at both
         # the OWSG prefix and the metadata.short_name of each JSON.
-        yaml_filename = os.path.join(PATH, 'tool_codes', f"{model}.yaml")
-
         self._json_path = None
-        if os.path.isfile(yaml_filename):
+        if isinstance(model, dict):
+            # A prebuilt model dict (ISCWSA-JSON-shaped) — e.g. an EDM/COMPASS
+            # IPM converted by welleng.errors.edm_ipm. No file resolution.
+            self._json_model = model
+            self.em = _json_to_em_adapter(model)
+            yaml_filename = None
+        elif os.path.isfile(
+            yaml_filename := os.path.join(PATH, 'tool_codes', f"{model}.yaml")
+        ):
             # Legacy YAML path (e.g. the MWD models). Cached parse; do NOT resolve
             # the JSON tree here -- the name-resolution walk is only needed when
             # the YAML is absent (it re-reads ~100 files otherwise).
@@ -444,6 +456,24 @@ class ToolError:
         _xcl_tort = hdr.get("Default Tortusity (rad/m)")
         if _xcl_tort is not None:
             bindings["XCLTortuosity"] = float(_xcl_tort)
+
+        # COMPASS/EDM IPM vocabulary (welleng/errors/edm_ipm.py): those
+        # formulas speak lowercase names. All lengths in metres (COMPASS's
+        # feet-internal mtf conversion is identity in SI evaluation).
+        bindings.update({
+            "inc": inc, "azm": azm, "azt": azt, "azi": azg,
+            "tmd": md, "dmd": md - _prev(md),
+            "tvd": bindings["TVD"],
+            "gtot": bindings["Gfield"], "mtot": bindings["BField"],
+            "dip": bindings["Dip"], "lat": bindings["Latitude"],
+            "erot": earth_rate, "mtf": 1.0,
+        })
+        # Named intermediates (COMPASS tie-type 'n' rows), evaluated in
+        # sequence order so later ones may reference earlier ones.
+        for interm in self.em.get("edm_intermediates", []):
+            bindings[interm["name"]] = (
+                interm["value"] * evaluate_formula(interm["formula"], bindings)
+            )
 
         # Recurrence terms (continuous gyro): the azimuth formula references
         # its own accumulated state from the previous station

--- a/welleng/exchange/edm_stream.py
+++ b/welleng/exchange/edm_stream.py
@@ -102,18 +102,27 @@ def classify_tool(
     classified as :attr:`ToolKind.GYRO` -- the gyro sensor governs the error
     behaviour even though the tool is conveyed on an MWD string.
     """
-    text = " ".join(t for t in (name, description) if t).lower().strip()
-    if not text:
+    def _classify(text: Optional[str]) -> ToolKind:
+        text = (text or "").lower().strip()
+        if not text:
+            return ToolKind.OTHER
+        if any(k in text for k in _GYRO_KEYWORDS):
+            return ToolKind.GYRO
+        if any(k in text for k in _INC_ONLY_KEYWORDS):
+            return ToolKind.INCLINATION_ONLY
+        if any(k in text for k in _DEFINITIVE_KEYWORDS):
+            return ToolKind.DEFINITIVE
+        if any(k in text for k in _MWD_KEYWORDS):
+            return ToolKind.MWD
         return ToolKind.OTHER
-    if any(k in text for k in _GYRO_KEYWORDS):
-        return ToolKind.GYRO
-    if any(k in text for k in _INC_ONLY_KEYWORDS):
-        return ToolKind.INCLINATION_ONLY
-    if any(k in text for k in _DEFINITIVE_KEYWORDS):
-        return ToolKind.DEFINITIVE
-    if any(k in text for k in _MWD_KEYWORDS):
-        return ToolKind.MWD
-    return ToolKind.OTHER
+
+    # Classify the NAME on its own first; the description only breaks a tie
+    # when the name is inconclusive. (A description like "Magnetic tools
+    # without gyro-verification" must not turn a magnetic tool into a gyro.)
+    kind = _classify(name)
+    if kind is ToolKind.OTHER:
+        kind = _classify(description)
+    return kind
 
 
 # ---------------------------------------------------------------------------

--- a/welleng/exchange/ipm.py
+++ b/welleng/exchange/ipm.py
@@ -30,7 +30,8 @@ Columns
   ``dip``, ``gtot``, ``mtot``, ``tmd``, ``tvd`` ...). Stored verbatim; this reader does
   not evaluate it.
 
-This module only *parses* the file into :class:`IPMModel` / :class:`IPMTerm`; mapping the
+This module only *parses* the file into :class:`IPMModel` / :class:`IPMTerm`;
+mapping the
 terms onto a propagation engine is left to the caller.
 """
 from __future__ import annotations
@@ -70,7 +71,8 @@ class IPMModel:
         return sorted({t.name for t in self.terms})
 
     def by_tie_on(self, tie_on: str) -> List[IPMTerm]:
-        """All terms with the given propagation mode (``'s'``/``'r'``/``'g'``/``'w'``)."""
+        """All terms with the given propagation mode
+        (``'s'``/``'r'``/``'g'``/``'w'``)."""
         return [t for t in self.terms if t.tie_on == tie_on]
 
     def to_dict(self) -> dict:
@@ -94,7 +96,8 @@ def _parse_lines(lines) -> IPMModel:
             continue
         if line.startswith("#"):
             body = line[1:]
-            # the column-header row (starts with 'Name', contains 'Vector') is not metadata
+            # the column-header row (starts with 'Name', contains
+            # 'Vector') is not metadata
             if re.match(r"\s*Name\b", body) and "Vector" in body:
                 continue
             if ":" in body:

--- a/welleng/exchange/ipm.py
+++ b/welleng/exchange/ipm.py
@@ -1,0 +1,153 @@
+"""
+Reader for **IPM** (Instrument Performance Model) survey-tool error-model files.
+
+The ``.IPM`` format is the de-facto industry exchange format for directional-survey
+error models (Landmark Engineer's Desktop / COMPASS, Schlumberger Drilling Office and
+others export it). Each file describes one survey tool as a set of ISCWSA-style
+weight-function terms: an error source, the axis it perturbs, its propagation
+(correlation) mode, a 1-sigma magnitude and the weight-function *formula*.
+
+File structure::
+
+    #Tool Name  : MWD+SAG
+    #ShortName  : MWD+SAG
+    #Description: ...
+    #Remarks    : ...
+    #Name<TAB>Vector<TAB>Tie-On<TAB>Unit<TAB>Value<TAB>Formula
+    abx<TAB>i<TAB>s<TAB>-<TAB>0.004<TAB>(-cos(inc)*sin(tfo))/gtot
+    ...
+
+Columns
+-------
+- **Name** — error-source code (``abx``, ``mbz``, ``sag``, ``decg`` ...).
+- **Vector** — axis the term perturbs: ``i`` inclination, ``a`` azimuth, ``l`` lateral
+  (and ``d``/``e``/``f`` depth-family in some dialects).
+- **Tie-On** — propagation/correlation mode: ``s`` systematic, ``r`` random,
+  ``g`` global, ``w`` well-by-well.
+- **Unit** — magnitude unit (``-`` dimensionless, ``nt``, ``deg`` ...).
+- **Value** — the 1-sigma error magnitude.
+- **Formula** — the weight function (an expression in ``inc``, ``azm``, ``tfo``,
+  ``dip``, ``gtot``, ``mtot``, ``tmd``, ``tvd`` ...). Stored verbatim; this reader does
+  not evaluate it.
+
+This module only *parses* the file into :class:`IPMModel` / :class:`IPMTerm`; mapping the
+terms onto a propagation engine is left to the caller.
+"""
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass, field
+from typing import Dict, List
+
+__all__ = ["IPMTerm", "IPMModel", "read_ipm", "loads_ipm"]
+
+
+@dataclass
+class IPMTerm:
+    """A single error-model term (one row of an IPM file)."""
+
+    name: str
+    vector: str
+    tie_on: str
+    unit: str
+    value: float
+    formula: str
+
+
+@dataclass
+class IPMModel:
+    """A parsed IPM survey-tool error model."""
+
+    name: str = ""
+    short_name: str = ""
+    description: str = ""
+    remarks: str = ""
+    header: Dict[str, str] = field(default_factory=dict)
+    terms: List[IPMTerm] = field(default_factory=list)
+
+    def sources(self) -> List[str]:
+        """Sorted, de-duplicated error-source names (each may span i/a/l rows)."""
+        return sorted({t.name for t in self.terms})
+
+    def by_tie_on(self, tie_on: str) -> List[IPMTerm]:
+        """All terms with the given propagation mode (``'s'``/``'r'``/``'g'``/``'w'``)."""
+        return [t for t in self.terms if t.tie_on == tie_on]
+
+    def to_dict(self) -> dict:
+        """JSON-serialisable representation."""
+        return {
+            "name": self.name,
+            "short_name": self.short_name,
+            "description": self.description,
+            "remarks": self.remarks,
+            "header": dict(self.header),
+            "terms": [vars(t) for t in self.terms],
+        }
+
+
+def _parse_lines(lines) -> IPMModel:
+    header: Dict[str, str] = {}
+    terms: List[IPMTerm] = []
+    for raw in lines:
+        line = raw.rstrip("\r\n")
+        if not line.strip():
+            continue
+        if line.startswith("#"):
+            body = line[1:]
+            # the column-header row (starts with 'Name', contains 'Vector') is not metadata
+            if re.match(r"\s*Name\b", body) and "Vector" in body:
+                continue
+            if ":" in body:
+                key, _, val = body.partition(":")
+                header[key.strip()] = val.strip()
+            continue
+        # data row — tab-separated, fall back to runs of whitespace
+        parts = [p.strip() for p in line.split("\t")]
+        if len(parts) < 6:
+            parts = [p for p in re.split(r"\t|\s{2,}", line.strip()) if p != ""]
+        if len(parts) < 6:
+            continue
+        name, vector, tie_on, unit, value = parts[:5]
+        formula = "\t".join(parts[5:]).strip()
+        try:
+            magnitude = float(value)
+        except ValueError:
+            continue
+        terms.append(IPMTerm(name, vector, tie_on, unit, magnitude, formula))
+    return IPMModel(
+        name=header.get("Tool Name", ""),
+        short_name=header.get("ShortName", ""),
+        description=header.get("Description", ""),
+        remarks=header.get("Remarks", ""),
+        header=header,
+        terms=terms,
+    )
+
+
+def read_ipm(path, encoding: str = "latin-1") -> IPMModel:
+    """Parse an ``.IPM`` file from ``path`` into an :class:`IPMModel`.
+
+    Parameters
+    ----------
+    path : str or path-like
+        Path to the ``.IPM`` file.
+    encoding : str, default ``'latin-1'``
+        Text encoding (IPM exports are typically latin-1; degree signs etc.).
+
+    Returns
+    -------
+    IPMModel
+
+    Examples
+    --------
+    >>> model = read_ipm("MWD+SAG.IPM")            # doctest: +SKIP
+    >>> model.name, len(model.terms)               # doctest: +SKIP
+    ('MWD+SAG', 30)
+    """
+    with open(path, "r", encoding=encoding) as f:
+        return _parse_lines(f)
+
+
+def loads_ipm(text: str) -> IPMModel:
+    """Parse an IPM model from an in-memory string (see :func:`read_ipm`)."""
+    return _parse_lines(text.splitlines())

--- a/welleng/survey.py
+++ b/welleng/survey.py
@@ -847,7 +847,7 @@ class Survey(MinCurve):
 
         # initialize errors (ERROR_MODELS is derived from errors/tool_index.yaml)
         error_models = ERROR_MODELS
-        if error_model is not None:
+        if error_model is not None and not isinstance(error_model, dict):
             assert error_model in error_models, "Unrecognized error model"
         self.error_model = error_model
 
@@ -1070,7 +1070,8 @@ class Survey(MinCurve):
         AssertionError
             If ``error_model`` is not a recognized model name.
         """
-        assert error_model in ERROR_MODELS, "Undefined error model"
+        if not isinstance(error_model, dict):
+            assert error_model in ERROR_MODELS, "Undefined error model"
 
         self.error_model = error_model
         self._get_errors()


### PR DESCRIPTION
An EDM export can embed the complete COMPASS error-model layer (DP_TOOL_TERM: 836 rows in the public Volve dataset — magnitudes, units, weighting-function formulas, vector directions, tie-on modes, per tool). This lands the pipeline that turns those into live welleng error models, so survey uncertainty is computed with the very instrument performance models the operator ran instead of a nearest-standard-model guess.

- **welleng/errors/edm_ipm.py** — streaming parser + IPM→model-dict converter: COMPASS vector codes → per-axis weight formulas, tie codes → propagation modes, tie-type 'n' rows → named intermediates, same-name rows grouped into one correlated term, vertical-hole singularity weights (ISCWSA Rev5.13 §11.5) for angular terms.
- **Engine injection** — ErrorModel / Survey / SurveyComposition accept prebuilt model dicts; the formula interpreter gains the lowercase COMPASS vocabulary (SI). Dict models respect the 0.21 magnetic-reference gate (classified from metadata tool_type).
- **welleng/exchange/ipm.py** — the .IPM file reader (from the earlier feat/ipm-parser work) bridged into the same path via tool_from_ipm_model(); toolface-explicit terms are a documented gap (warn + zero).
- **classify_tool** — name classified before description (a description like 'magnetic tools without gyro-verification' must not make a gyro).

**Validation (public Volve data, in-repo tests):** F-12 single-tool definitive vs COMPASS's own stored 1-sigma covariances — sigma_N/sigma_E within ±1% at every station; F-14 composed gyro→MWD→MWD via SurveyComposition per-section IPMs — within 4% at every station. sigma_V asserted as a characterised residual band (well-level vertical-reference term the export doesn't carry). All 30 Volve tools parse and run with every formula bound. Benchmarks logged (no hot-path regression).

Retires branches feat/ipm-parser, feat/exchange-ipm, feat/schematic-catalog-ipm (content consolidated here).

🤖 Generated with [Claude Code](https://claude.com/claude-code)