### PR TITLE
ci(publish): wheel smoke supplies a real geomagnetic reference (0.21 gate)

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -58,8 +58,12 @@ jobs:
           from welleng.survey import Survey, SurveyHeader
           from welleng.catalog import Catalog
           from welleng.utils import arc_inc_azi_extrema
+          # magnetic models refuse default references from 0.21.0 — the
+          # smoke must supply a real one, like any user
           s = Survey(md=[0, 500, 1000, 2000], inc=[0, 10, 45, 90],
-                     azi=[0, 20, 90, 90], header=SurveyHeader(),
+                     azi=[0, 20, 90, 90],
+                     header=SurveyHeader(b_total=50_000., dip=72.,
+                                         declination=-2.),
                      error_model="ISCWSA MWD Rev5.11")
           assert s.cov_nev.shape == (4, 3, 3)            # error-model json/yaml data
           assert Catalog.load("casing") is not None       # catalog json data


### PR DESCRIPTION
The 0.21.0 magnetic-reference gate correctly refused the publish workflow's own default-header smoke survey — the workflow failed before publishing (the gate caught its own release). The smoke now provides explicit b_total/dip/declination, as any user must.

🤖 Generated with [Claude Code](https://claude.com/claude-code)