### PR TITLE
fix(composition): compose 'well' terms + per-term cross-run realisation sharing

### DIFF
--- a/tests/test_edm_ipm.py
+++ b/tests/test_edm_ipm.py
@@ -309,11 +309,12 @@ def test_f14_actual_composed_multi_tool_vs_compass(ipm):
     with SurveyComposition using the per-section ACTUAL tool IPMs and
     compared against COMPASS's own composed covariances.
 
-    Result: sigma_N and sigma_E within a few percent of COMPASS at every
-    covariance-bearing station (a single standard model misses the composed
-    covariance by tens of percent); sigma_V carries the same well-level
-    vertical-reference residual documented on the F-12 case (largest in the
-    vertical gyro section), asserted as a band pending its resolution.
+    With per-term cross-run realisation sharing and the 'well' bucket
+    composed (both landed after probcol's multi-well lateral-under-run
+    report), the perpendicular-to-heading axes sit within ~1% of COMPASS at
+    TD and NOTHING runs materially under — the residuals are on the
+    conservative side (sigma_V up to ~+28% mid-well). Bands assert exactly
+    that: no non-conservative under-run, bounded overshoot.
     """
     from welleng.composition import SurveyComposition, SurveySection
     from welleng.exchange.edm_stream import EDMReader, FEET_TO_METERS
@@ -366,11 +367,83 @@ def test_f14_actual_composed_multi_tool_vs_compass(ipm):
         [cov[:, 0, 0], cov[:, 1, 1], cov[:, 2, 2]], axis=1))
     sig_cp = np.sqrt(np.stack([cc[:, 3], cc[:, 0], cc[:, 5]], axis=1))
 
-    diff = np.abs(sig_we - sig_cp)
-    tol = np.maximum(0.04 * sig_cp, 0.02)   # 4% or 2 cm (shallow stations)
-    assert np.all(diff[:, 0] <= tol[:, 0]), "sigma_N outside 4% of COMPASS"
-    assert np.all(diff[:, 1] <= tol[:, 1]), "sigma_E outside 4% of COMPASS"
-    m = sig_cp[:, 2] > 0.05
-    v_ratio = sig_we[m, 2] / sig_cp[m, 2]
-    assert np.all((v_ratio > 0.50) & (v_ratio < 1.02)), \
-        "sigma_V outside the open vertical-reference residual band"
+    m = sig_cp > 0.05
+    for col, label, lo, hi in ((0, "N", 0.95, 1.12), (1, "E", 0.95, 1.12)):
+        ratio = sig_we[m[:, col], col] / sig_cp[m[:, col], col]
+        assert np.all((ratio > lo) & (ratio < hi)), \
+            f"sigma_{label} outside [{lo}, {hi}] of COMPASS"
+    v_ratio = sig_we[m[:, 2], 2] / sig_cp[m[:, 2], 2]
+    assert np.all((v_ratio > 0.90) & (v_ratio < 1.30)), \
+        "sigma_V outside the conservative-side band"
+
+
+def test_f15d_ew_high_inc_no_lateral_underrun(ipm):
+    """F-15D — the E-W high-inclination case (azi ~106 deg holding while
+    building to ~80 deg inc): the well that exposed the systematic lateral
+    under-run (sigma_N -11% at TD, the NON-conservative direction for
+    anti-collision). With per-term cross-run global sharing (the IFR
+    reference is ONE realisation across both MWD runs) the
+    perpendicular-to-heading axis is within ~1% at TD and nothing runs
+    materially under COMPASS.
+    """
+    from welleng.composition import SurveyComposition, SurveySection
+    from welleng.exchange.edm_stream import EDMReader, FEET_TO_METERS
+
+    r = EDMReader(VOLVE)
+    st = None
+    for hid, stations in r._def_stations.items():
+        h = r.headers[hid]
+        wb = r.wellbores.get(h.wellbore_id)
+        if wb and wb.name == "F-15D" and h.phase == "ACTUAL":
+            st = sorted(stations, key=lambda s: s["md"])
+            header = h
+    assert st is not None
+    mag = [m for m in ipm.magnetics
+           if m.get("wellbore_id") == header.wellbore_id][0]
+
+    F = FEET_TO_METERS
+    md = np.array([s["md"] for s in st]) * F
+    inc = np.array([s["inc"] for s in st])
+    azi = np.array([s["azi"] for s in st])
+    cc = np.array([s["cov"] for s in st]) * F ** 2
+
+    sh = we.survey.SurveyHeader(
+        name="F-15D", azi_reference="grid",
+        latitude=58.4416, longitude=1.8875,
+        b_total=float(mag["field_strength"]),
+        dip=float(mag["dip_angle"]),
+        declination=float(mag["declination"]),
+    )
+    gyro = ipm.error_model("Wellbore Surveyor, stat")
+    mwd1 = ipm.error_model("Magn, IFR, mag-corr, dual incl")
+    mwd2 = ipm.error_model("Magn, IFR, non-mag, dual incl")
+    i1 = int(np.argmin(np.abs(md - 1310.0)))
+    i2 = int(np.argmin(np.abs(md - 3220.0)))
+    comp = SurveyComposition(sections=[
+        SurveySection(md=md[:i1 + 1], inc=inc[:i1 + 1], azi=azi[:i1 + 1],
+                      header=sh, error_model=gyro, tool_id="gyro"),
+        SurveySection(md=md[i1:i2 + 1], inc=inc[i1:i2 + 1],
+                      azi=azi[i1:i2 + 1], header=sh, error_model=mwd1,
+                      tool_id="mwd1", share_mode="all_independent"),
+        # both MWD runs reference the same IFR geomag realisation
+        SurveySection(md=md[i2:], inc=inc[i2:], azi=azi[i2:], header=sh,
+                      error_model=mwd2, tool_id="mwd2",
+                      share_mode="globals_shared"),
+    ]).survey()
+    cov = comp.cov_nev
+
+    sig_we = np.sqrt(np.stack(
+        [cov[:, 0, 0], cov[:, 1, 1], cov[:, 2, 2]], axis=1))
+    sig_cp = np.sqrt(np.stack([cc[:, 3], cc[:, 0], cc[:, 5]], axis=1))
+    td = sig_we[-1] / sig_cp[-1]
+
+    # N (perpendicular to the E-W heading — the axis that under-ran)
+    assert 0.95 < td[0] < 1.05, f"sigma_N TD ratio {td[0]:.3f}"
+    # E and V: bounded, conservative-side residuals (open items)
+    assert 0.95 < td[1] < 1.25, f"sigma_E TD ratio {td[1]:.3f}"
+    assert 0.90 < td[2] < 1.20, f"sigma_V TD ratio {td[2]:.3f}"
+    # nothing materially under COMPASS anywhere sigma is macroscopic
+    m = sig_cp > 0.5
+    for col in range(3):
+        ratio = sig_we[m[:, col], col] / sig_cp[m[:, col], col]
+        assert np.all(ratio > 0.90), "non-conservative under-run returned"

--- a/welleng/composition.py
+++ b/welleng/composition.py
@@ -44,7 +44,6 @@ wellbores with correct cancellation of shared global terms.
 
 from __future__ import annotations
 
-import warnings
 from dataclasses import dataclass, field
 from datetime import datetime
 from typing import List, Optional, Sequence
@@ -71,13 +70,6 @@ def _model_key(error_model) -> object:
     tool-specific imported IPM.
     """
     return error_model if isinstance(error_model, str) else id(error_model)
-
-
-def _model_name(error_model) -> str:
-    """Display name for a section's error model (str or model dict)."""
-    if isinstance(error_model, str):
-        return error_model
-    return error_model.get('metadata', {}).get('short_name', 'custom-dict-model')
 
 #: Survey-date gap (years) beyond which an unspecified tie auto-defaults to
 #: ``all_independent`` (geomag secular variation makes the global realisation
@@ -387,13 +379,21 @@ class SurveyComposition:
         # per-group instead would inject a small propagation-context artifact
         # at every tool change.
         share_random = [
-            groups[k].error_model == groups[k - 1].error_model
+            _model_key(groups[k].error_model)
+            == _model_key(groups[k - 1].error_model)
             for k in range(len(groups))
         ]
         # k=0 has no tie before it.
         share_global[0] = False
         share_systematic[0] = False
         share_random[0] = False
+
+        # 'well' terms (COMPASS tie W — e.g. a depth-scale error): correlated
+        # while the same measurement SYSTEM continues (same tool run), reset
+        # at a tool change — a wireline gyro's depth and an MWD pipe tally
+        # are different realisations. Validated empirically on the Volve
+        # composed wells (chaining across tool changes overstates sigma_V).
+        share_well = list(share_systematic)
 
         glob = self._compose_component(
             "cov_nev_global", share_global, start_nevs
@@ -404,12 +404,16 @@ class SurveyComposition:
         rand = self._compose_component(
             "cov_nev_random", share_random, start_nevs
         )
+        well = self._compose_component(
+            "cov_nev_well", share_well, start_nevs
+        )
 
         # 3. Stitch per-group arrays (drop duplicate tie station of each
         #    subsequent group) into unified per-station arrays.
         cov_global = self._stitch(glob)
         cov_systematic = self._stitch(syst)
         cov_random = self._stitch(rand)
+        cov_well = self._stitch(well)
 
         # 3a. Re-bucket the non-cancellable global. The ``cov_nev_global``
         #     bucket is what cancels against another wellbore that shares the
@@ -424,7 +428,7 @@ class SurveyComposition:
         cov_global, cov_systematic = self._rebucket_global(
             cov_global, cov_systematic, share_global
         )
-        cov_nev = cov_global + cov_systematic + cov_random
+        cov_nev = cov_global + cov_systematic + cov_random + cov_well
 
         # 4. Unified geometry -> one Survey with the composed covariance.
         md = self._stitch_1d([g.md for g in groups])
@@ -446,6 +450,7 @@ class SurveyComposition:
         survey.cov_nev_global = cov_global
         survey.cov_nev_systematic = cov_systematic
         survey.cov_nev_random = cov_random
+        survey.cov_nev_well = cov_well
         return survey
 
     def _rebucket_global(self, cov_global, cov_systematic, share_global):
@@ -527,12 +532,12 @@ class SurveyComposition:
         groups = self._groups[k:j + 1]
         models = {_model_key(g.error_model) for g in groups}
         if len(models) > 1:
-            warnings.warn(
-                "shared-error tie spans multiple error models; the shared "
-                f"component uses {_model_name(groups[0].error_model)!r} as "
-                "the reference model",
-                RuntimeWarning,
-            )
+            # Different models sharing a realisation cannot be built as one
+            # reference-model survey (that evaluates the wrong weights over
+            # the other runs' spans and badly overstates the shared growth).
+            # Chain per-term instead: each run with its OWN model, same-name
+            # error sources continuing one realisation across the ties.
+            return self._run_component_per_term(attr, k, j, start_nev)
         md = self._stitch_1d([g.md for g in groups])
         inc = self._stitch_1d([g.inc_rad for g in groups])
         azi = self._stitch_1d([g.azi_grid_rad for g in groups])
@@ -547,6 +552,78 @@ class SurveyComposition:
             error_model=groups[0].error_model, start_nev=start_nev,
         )
         return getattr(run, attr)[:n_real]
+
+    #: composed-covariance attribute -> the term propagation mode it holds
+    _ATTR_TO_PROPAGATION = {
+        "cov_nev_global": "global",
+        "cov_nev_systematic": "systematic",
+        "cov_nev_well": "well",
+    }
+
+    def _run_component_per_term(self, attr, k, j, start_nev):
+        """Shared component of a MULTI-MODEL run, chained per error source.
+
+        Same-name error sources share ONE physical realisation across the
+        runs (the COMPASS convention — e.g. ``dbh`` in two IFR-referenced
+        MWD runs is the same geomagnetic reference error; ``dsf`` is the
+        same rig depth-scale error), but each run's weighting must be
+        evaluated with that run's OWN model. So, per term name, the
+        cumulative error vector continues across the tie:
+
+            v_name(station in run g) = sum of run-end vectors of every
+            earlier run carrying the name  +  the in-run cumulative vector
+
+        and each station's covariance is the sum over names of the outer
+        product of ``v_name`` (independent sources; correlation coefficient
+        one within a source across runs). A source absent from the current
+        run keeps contributing its frozen accumulated vector — a position
+        error, once made, persists. A single-model run degenerates to the
+        existing continuous-survey result.
+
+        Random components never take this path (``share_random`` requires an
+        identical model).
+        """
+        prop = self._ATTR_TO_PROPAGATION[attr]
+        frozen: dict = {}                     # name -> accumulated (3,) vector
+        parts: List[NDArray[np.float64]] = []
+        for gi in range(k, j + 1):
+            g = self._groups[gi]
+            md, inc, azi = g.md, g.inc_rad, g.azi_grid_rad
+            n_g = len(md)
+            # ghost continuation station (see _run_component)
+            if gi + 1 < len(self._groups) and len(self._groups[gi + 1].md) > 1:
+                nxt = self._groups[gi + 1]
+                md = np.append(md, nxt.md[1])
+                inc = np.append(inc, nxt.inc_rad[1])
+                azi = np.append(azi, nxt.azi_grid_rad[1])
+            run = Survey(
+                md=md, inc=inc, azi=azi, deg=False, header=g.header,
+                error_model=g.error_model, start_nev=start_nev,
+            )
+            errors = run.err.errors.errors
+            cov = np.zeros((n_g, 3, 3))
+            names_here = set()
+            for name, term in errors.items():
+                if term.propagation != prop:
+                    continue
+                names_here.add(name)
+                v = np.asarray(term.sigma_e_NEV[:n_g], dtype=float)
+                base = frozen.get(name)
+                if base is not None:
+                    v = v + base[None, :]
+                cov += v[:, :, None] * v[:, None, :]
+            for name, base in frozen.items():
+                if name not in names_here:
+                    cov += np.outer(base, base)[None]
+            for name in names_here:
+                end = np.asarray(
+                    errors[name].sigma_e_NEV[n_g - 1], dtype=float
+                )
+                frozen[name] = frozen.get(name, 0.0) + end
+            parts.append(cov)
+        return np.concatenate(
+            [parts[0]] + [p[1:] for p in parts[1:]], axis=0
+        )
 
     # ------------------------------------------------------------------ #
     # stitching helpers (drop the duplicate tie station of each next group)

--- a/welleng/errors/tool_errors.py
+++ b/welleng/errors/tool_errors.py
@@ -348,6 +348,7 @@ class ToolError:
         self.cov_NEVs_random = np.zeros(shape)
         self.cov_NEVs_systematic = np.zeros(shape)
         self.cov_NEVs_global = np.zeros(shape)
+        self.cov_NEVs_well = np.zeros(shape)
         self.cov_NEVs_within_pad = np.zeros(shape)
         for _, value in self.errors.items():
             self.cov_NEVs += value.cov_NEV
@@ -357,6 +358,12 @@ class ToolError:
                 self.cov_NEVs_systematic += value.cov_NEV
             elif value.propagation == 'global':
                 self.cov_NEVs_global += value.cov_NEV
+            elif value.propagation == 'well':
+                # 'well' (COMPASS tie W): systematic throughout the WELL —
+                # one realisation across every run/tool in the wellbore.
+                # Without its own bucket these terms are in the total but
+                # invisible to bucket consumers (composition dropped them).
+                self.cov_NEVs_well += value.cov_NEV
             elif value.propagation == 'within_pad':
                 self.cov_NEVs_within_pad += value.cov_NEV
 

--- a/welleng/survey.py
+++ b/welleng/survey.py
@@ -906,6 +906,7 @@ class Survey(MinCurve):
         self.cov_nev_random = None
         self.cov_nev_systematic = None
         self.cov_nev_global = None
+        self.cov_nev_well = None
         self.cov_nev_within_pad = None
 
         self._get_errors()
@@ -1148,6 +1149,7 @@ class Survey(MinCurve):
             self.cov_nev_random = self.err.errors.cov_NEVs_random
             self.cov_nev_systematic = self.err.errors.cov_NEVs_systematic
             self.cov_nev_global = self.err.errors.cov_NEVs_global
+            self.cov_nev_well = self.err.errors.cov_NEVs_well
             self.cov_nev_within_pad = self.err.errors.cov_NEVs_within_pad
         else:
             if self.cov_nev is not None and self.cov_hla is None:


### PR DESCRIPTION
Two composed-covariance defects found by multi-well validation against COMPASS's own stored covariances (public Volve):

1. **'well'-propagation terms silently dropped from composed covariances** — ToolError had no bucket for COMPASS tie-W terms (e.g. the dsf depth-scale term in every Volve tool): present in a single Survey's total, invisible to the bucket sum composition builds. New cov_NEVs_well / Survey.cov_nev_well, composed with reset-at-tool-change semantics.
2. **Cross-model shared ties evaluated the wrong weights** — reference-model-whole-span semantics badly overstated shared growth, and the only alternative (severing) understated the perpendicular-to-heading uncertainty: the NON-conservative direction for anti-collision. New per-term chaining: each run evaluates its own model; same-name sources continue one realisation across ties.

Validation: systematic lateral under-run eliminated (F-15D E-W high-inc sigma_N TD 0.96→0.99, F-14 0.79→0.99 vs COMPASS); residuals now conservative-side and banded in tests, including the new F-15D E-W high-inclination case. Suite 811 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)