### PR TITLE
feat(hierarchy): network_from_edm — EDM export to WellNetwork + Volve field visual

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -56,6 +56,9 @@ papers/**/*-NOTES.md
 # welleng.schematic example render outputs
 examples/schematic_output/
 
+# volve_field_network.py render output
+examples/volve_field_network.html
+
 # local scratch / prototypes (never commit)
 temp/
 .claude/settings.json

--- a/examples/volve_field_network.py
+++ b/examples/volve_field_network.py
@@ -1,0 +1,188 @@
+"""Volve field: the whole wellbore network in one interactive 3D figure.
+
+Streams the public Equinor Volve EDM export (CC BY 4.0 -- attribute Equinor
+and the Volve licence partners) with ``EDMReader``, builds the master-data
+hierarchy + wellbore forest via ``network_from_edm`` with the definitive
+surveys attached, and renders one line per wellbore trajectory (coloured per
+Well, hover = wellbore name) plus site/wellhead markers. The figure is saved
+as a standalone HTML file next to this script.
+
+Requirements: ``pip install welleng plotly``. Point ``WELLENG_VOLVE_XML`` at
+the ~211 MB ``Volve.xml`` export, or place it at ``data/Volve.xml``.
+"""
+import os
+import pathlib
+import sys
+import warnings
+
+from welleng.exchange.edm_stream import EDMReader
+from welleng.hierarchy import Site, Well, Wellbore, network_from_edm
+
+# --------------------------------------------------------------------------- #
+# chart chrome + a fixed-order categorical palette (colour follows the Well;
+# wells beyond the fixed list fall back to muted grey -- identity is always
+# carried by the hover label and the legend, never by colour alone)
+# --------------------------------------------------------------------------- #
+SURFACE = "#fcfcfb"
+INK_PRIMARY = "#0b0b0b"
+INK_MUTED = "#898781"
+GRIDLINE = "#e1e0d9"
+PALETTE = [
+    "#2a78d6", "#008300", "#e87ba4", "#eda100",   # slots 1-8 (light mode)
+    "#1baf7a", "#eb6834", "#4a3aa7", "#e34948",
+    "#3987e5", "#d55181", "#c98500", "#199e70",   # darker steps of the same
+    "#d95926", "#9085e9", "#e66767",              # hues extend the fixed order
+]
+OVERFLOW = INK_MUTED
+
+
+def resolve_volve_path() -> str | None:
+    """Return the Volve.xml path, or None with a message if unavailable."""
+    path = os.environ.get(
+        "WELLENG_VOLVE_XML",
+        str(pathlib.Path(__file__).resolve().parent.parent / "data" / "Volve.xml"),
+    )
+    if os.path.isfile(path):
+        return path
+    print(
+        "Volve.xml not found. Download the public Volve dataset (Equinor, "
+        "CC BY 4.0) and set WELLENG_VOLVE_XML to its path, or place it at "
+        f"{path}."
+    )
+    return None
+
+
+def parent_well(node: Wellbore) -> Well | None:
+    """Walk the parent chain of a wellbore up to its Well."""
+    p = node.parent
+    while p is not None and not isinstance(p, Well):
+        p = p.parent
+    return p
+
+
+def main() -> int:
+    try:
+        import plotly.graph_objects as go
+    except ImportError:
+        print(
+            "plotly is required for this example: pip install plotly "
+            "(or welleng[easy])."
+        )
+        return 1
+
+    path = resolve_volve_path()
+    if path is None:
+        return 0
+
+    print("Indexing the EDM export (one streaming sweep)...")
+    reader = EDMReader(path)
+    print(
+        f"  {len(reader.wells)} wells / {len(reader.wellbores)} wellbores on "
+        f"site(s): {', '.join(s['site_name'] for s in reader.sites.values())}"
+    )
+
+    print("Building the well network with definitive surveys...")
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        net = network_from_edm(reader, surveys=True)
+    wellbores = [n for n in net._nodes.values() if isinstance(n, Wellbore)]
+    surveyed = [wb for wb in wellbores if wb.survey is not None]
+    print(
+        f"  {len(surveyed)}/{len(wellbores)} wellbores carry a definitive "
+        f"ACTUAL survey ({len(caught)} skipped with warnings)."
+    )
+
+    # fixed colour assignment: wells sorted by name, in palette order
+    well_names = sorted({
+        w.name for w in (parent_well(wb) for wb in surveyed) if w is not None
+    })
+    colour = {
+        name: (PALETTE[i] if i < len(PALETTE) else OVERFLOW)
+        for i, name in enumerate(well_names)
+    }
+
+    fig = go.Figure()
+    seen_wells: set[str] = set()
+    for wb in sorted(surveyed, key=lambda n: n.name):
+        well = parent_well(wb)
+        wname = well.name if well is not None else "unknown"
+        # field-frame position: survey offsets are well-local; shift by the
+        # well's slot offset from the site origin (all metres)
+        slot_ns, slot_ew = (well.slot if well is not None and well.slot
+                            else (0.0, 0.0))
+        s = wb.survey
+        fig.add_trace(go.Scatter3d(
+            x=s.e + slot_ew, y=s.n + slot_ns, z=s.tvd,
+            mode="lines",
+            line=dict(color=colour.get(wname, OVERFLOW), width=3),
+            name=wname,
+            legendgroup=wname,
+            showlegend=wname not in seen_wells,
+            text=[wb.name] * len(s.md),
+            customdata=s.md,
+            hovertemplate=(
+                "%{text}<br>MD %{customdata:.0f} m | TVD %{z:.0f} m"
+                "<extra>" + wname + "</extra>"
+            ),
+        ))
+        seen_wells.add(wname)
+
+    # site origin + wellhead slot markers (surface reference layer)
+    sites = [n for n in net._nodes.values() if isinstance(n, Site)]
+    fig.add_trace(go.Scatter3d(
+        x=[0.0], y=[0.0], z=[0.0],
+        mode="markers+text",
+        marker=dict(size=8, color=INK_PRIMARY, symbol="diamond"),
+        text=[sites[0].name if sites else "site"],
+        textposition="top center",
+        textfont=dict(color=INK_MUTED, size=11),
+        name="site origin",
+        hovertemplate="%{text}<extra>site origin</extra>",
+    ))
+    slot_wells = [
+        w for w in net._nodes.values()
+        if isinstance(w, Well) and w.slot is not None and w.name in colour
+    ]
+    fig.add_trace(go.Scatter3d(
+        x=[w.slot[1] for w in slot_wells],
+        y=[w.slot[0] for w in slot_wells],
+        z=[0.0] * len(slot_wells),
+        mode="markers",
+        marker=dict(size=4, color=INK_MUTED, symbol="circle"),
+        name="well slots",
+        text=[w.name for w in slot_wells],
+        hovertemplate="%{text}<extra>well slot</extra>",
+    ))
+
+    axis = dict(
+        showbackground=True, backgroundcolor=SURFACE,
+        gridcolor=GRIDLINE, zerolinecolor=GRIDLINE,
+        color=INK_MUTED,
+    )
+    fig.update_layout(
+        title=dict(
+            text="Volve field — definitive wellbore trajectories",
+            font=dict(color=INK_PRIMARY),
+        ),
+        paper_bgcolor=SURFACE,
+        font=dict(
+            family='system-ui, -apple-system, "Segoe UI", sans-serif',
+            color=INK_MUTED,
+        ),
+        scene=dict(
+            xaxis=dict(title="East (m)", **axis),
+            yaxis=dict(title="North (m)", **axis),
+            zaxis=dict(title="TVD (m)", autorange="reversed", **axis),
+            aspectmode="data",
+        ),
+        legend=dict(title="Well", font=dict(color=INK_PRIMARY)),
+    )
+
+    out = pathlib.Path(__file__).resolve().parent / "volve_field_network.html"
+    fig.write_html(str(out), include_plotlyjs="cdn")
+    print(f"Saved interactive figure to {out}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_network_from_edm.py
+++ b/tests/test_network_from_edm.py
@@ -1,0 +1,164 @@
+"""Tests for welleng.hierarchy.network_from_edm (EDM -> WellNetwork adapter).
+
+A small synthetic EDM XML fixture exercises the mapping (entities, parent
+linkage, unit conversion, optional survey attachment, OSDU round-trip); the
+public Volve export (Equinor, CC BY 4.0) is exercised when available locally.
+"""
+import math
+import os
+import pathlib
+import warnings
+
+import pytest
+
+from welleng import osdu
+from welleng.exchange.edm_stream import EDMReader, FEET_TO_METERS
+from welleng.hierarchy import Datum, Site, Well, Wellbore, network_from_edm
+
+ROOT = pathlib.Path(__file__).resolve().parent.parent
+VOLVE_XML = os.environ.get("WELLENG_VOLVE_XML", str(ROOT / "data" / "Volve.xml"))
+
+FIXTURE_XML = """<export><TOPLEVEL>
+<CD_PROJECT project_id="P1" project_name="TESTFIELD" geo_datum_id="ED50"
+    geo_zone_id="UTM-31N" />
+<CD_SITE site_id="S1" project_id="P1" site_name="Pad A" convergence="-1.0"
+    is_field_center="Y" geo_map_northing="10000.0" geo_map_easting="20000.0" />
+<CD_WELL well_id="W1" site_id="S1" well_common_name="T-1" slot_ns="10.0"
+    slot_ew="-20.0" slot_radial_error="1.0" wellhead_depth="300.0" />
+<CD_DATUM datum_id="D1" well_id="W1" datum_name="Rotary Table"
+    datum_elevation="100.0" is_default="Y" />
+<CD_DATUM datum_id="D2" well_id="W1" datum_name="Sea Level"
+    datum_elevation="0.0" is_default="N" />
+<CD_WELLBORE wellbore_id="WB1" well_id="W1" wellbore_name="T-1 main" />
+<CD_WELLBORE wellbore_id="WB2" well_id="W1" wellbore_name="T-1 A"
+    parent_wellbore_id="WB1" ko_md="1000.0" />
+<CD_DEFINITIVE_SURVEY_HEADER def_survey_header_id="DH1" wellbore_id="WB1"
+    phase="ACTUAL" name="def WB1" />
+<CD_DEFINITIVE_SURVEY_STATION def_survey_header_id="DH1" md="0.0"
+    inclination="0.0" azimuth="0.0" tvd="0.0" offset_north="0.0"
+    offset_east="0.0" sequence_no="0" />
+<CD_DEFINITIVE_SURVEY_STATION def_survey_header_id="DH1" md="500.0"
+    inclination="5.0" azimuth="45.0" tvd="499.0" offset_north="15.0"
+    offset_east="15.0" sequence_no="1" />
+<CD_DEFINITIVE_SURVEY_STATION def_survey_header_id="DH1" md="1000.0"
+    inclination="10.0" azimuth="45.0" tvd="990.0" offset_north="60.0"
+    offset_east="60.0" sequence_no="2" />
+</TOPLEVEL></export>
+"""
+
+
+@pytest.fixture
+def reader(tmp_path):
+    path = tmp_path / "edm.xml"
+    path.write_text(FIXTURE_XML)
+    return EDMReader(str(path))
+
+
+# --------------------------------------------------------------------------- #
+# structure-only mapping
+# --------------------------------------------------------------------------- #
+def test_entity_counts_and_types(reader):
+    net = network_from_edm(reader)
+    nodes = net._nodes
+    assert isinstance(nodes["S1"], Site)
+    assert isinstance(nodes["W1"], Well)
+    assert isinstance(nodes["WB1"], Wellbore)
+    assert isinstance(nodes["WB2"], Wellbore)
+    wellbores = [n for n in nodes.values() if isinstance(n, Wellbore)]
+    assert len(wellbores) == 2
+
+
+def test_site_mapping(reader):
+    net = network_from_edm(reader)
+    site = net.node("S1")
+    assert site.name == "Pad A"
+    assert site.crs == "EPSG:23031"          # ED50 + UTM-31N only
+    assert site.convergence == pytest.approx(math.radians(-1.0))
+    assert site.is_field_centre is True
+    assert site.location == pytest.approx(
+        (10000.0 * FEET_TO_METERS, 20000.0 * FEET_TO_METERS))
+    assert site.parent.name == "TESTFIELD"   # CD_PROJECT -> Field
+
+
+def test_well_and_datum_metres(reader):
+    net = network_from_edm(reader)
+    well = net.node("W1")
+    assert well.name == "T-1"
+    assert well.parent is net.node("S1")
+    assert well.slot == pytest.approx(
+        (10.0 * FEET_TO_METERS, -20.0 * FEET_TO_METERS))
+    assert well.slot_radial_error == pytest.approx(1.0 * FEET_TO_METERS)
+    assert well.wellhead_depth == pytest.approx(300.0 * FEET_TO_METERS)
+    assert isinstance(well.datum, Datum)
+    assert well.datum.name == "Rotary Table"     # the default datum wins
+    assert well.datum.elevation == pytest.approx(100.0 * FEET_TO_METERS)
+
+
+def test_parent_linkage_and_kickoff(reader):
+    net = network_from_edm(reader)
+    assert [n.id for n in net.roots()] == ["WB1"]
+    sidetrack = net.node("WB2")
+    assert sidetrack.parent is net.node("WB1")
+    assert sidetrack.kickoff_md == pytest.approx(1000.0 * FEET_TO_METERS)
+    assert net.lowest_common_ancestor("WB2", "WB1") == "WB1"
+
+
+# --------------------------------------------------------------------------- #
+# optional survey attachment
+# --------------------------------------------------------------------------- #
+def test_structure_only_attaches_no_surveys(reader):
+    net = network_from_edm(reader)
+    assert net.node("WB1").survey is None
+    assert net.node("WB2").survey is None
+
+
+def test_surveys_true_attaches_and_warns_per_missing(reader):
+    with warnings.catch_warnings(record=True) as w:
+        warnings.simplefilter("always")
+        net = network_from_edm(reader, surveys=True)
+    s = net.node("WB1").survey
+    assert s is not None
+    assert max(s.md) == pytest.approx(1000.0 * FEET_TO_METERS)  # metres
+    assert s.header.azi_reference == "grid"
+    # WB2 has no definitive survey: warned + skipped, import not aborted
+    assert net.node("WB2").survey is None
+    assert any("T-1 A" in str(x.message) for x in w)
+
+
+# --------------------------------------------------------------------------- #
+# OSDU round-trip sanity
+# --------------------------------------------------------------------------- #
+def test_osdu_export_does_not_crash(reader):
+    net = network_from_edm(reader)
+    records = [osdu.to_osdu(n) for n in net._nodes.values()]
+    assert len(records) == 5                 # Field, Site, Well, 2 Wellbores
+    # sidetrack record carries the parent-wellbore edge
+    by_id = {r["id"]: r for r in records}
+    assert by_id["WB2"]["data"]["KickOffWellbore"] == "WB1"
+    # wellbore records re-import into a network without error
+    net2 = osdu.network_from_osdu(records)
+    assert net2.lowest_common_ancestor("WB2", "WB1") == "WB1"
+
+
+# --------------------------------------------------------------------------- #
+# public Volve export (skipped unless the ~211 MB file is present locally)
+# --------------------------------------------------------------------------- #
+@pytest.mark.skipif(
+    not os.path.isfile(VOLVE_XML), reason="Volve.xml not available"
+)
+def test_volve_structure_only_import():
+    net = network_from_edm(EDMReader(VOLVE_XML))
+    wellbores = [
+        n for n in net._nodes.values() if isinstance(n, Wellbore)
+    ]
+    assert len(wellbores) >= 50              # the export carries 54
+    # empirically-verified parentage: wellbore "F-15D" sidetracks off "F-15"
+    (f15d,) = [n for n in wellbores if n.name == "F-15D"]
+    assert isinstance(f15d.parent, Wellbore)
+    assert f15d.parent.name == "F-15"
+    assert f15d.kickoff_md == pytest.approx(4296.587926492 * FEET_TO_METERS)
+    # the single Volve site maps with its project-derived CRS
+    sites = [n for n in net._nodes.values() if isinstance(n, Site)]
+    assert len(sites) == 1
+    assert sites[0].name == "Volve F"
+    assert sites[0].crs == "EPSG:23031"

--- a/welleng/hierarchy.py
+++ b/welleng/hierarchy.py
@@ -37,6 +37,7 @@ between wells of common ancestry.
 """
 from __future__ import annotations
 
+import math
 from dataclasses import dataclass, field
 from typing import Iterator, Optional
 
@@ -1152,6 +1153,194 @@ class WellNetwork:
 
     def _parent_id(self, id_: str) -> Optional[str]:
         return self._parents.get(id_)
+
+
+def network_from_edm(reader, *, surveys: bool = False) -> WellNetwork:
+    """Build a :class:`WellNetwork` from a parsed EDM/COMPASS export.
+
+    Maps the EDM master-data spine indexed by
+    :class:`welleng.exchange.edm_stream.EDMReader` onto the hierarchy
+    entities and wires the wellbore forest (parent-wellbore sidetrack edges,
+    root wellbores parented by their Well). All lengths are converted from
+    the reader's source units (feet for the public Volve export) to metres
+    at this boundary; angles arrive in degrees and convergence is stored in
+    radians.
+
+    The table -> entity mapping:
+
+    ========================  =================================================
+    EDM table                 Hierarchy entity
+    ========================  =================================================
+    ``CD_PROJECT``            :class:`Field` (``project_name``); also supplies
+                              the site CRS (geo datum + zone) when derivable
+    ``CD_SITE``               :class:`Site` (name, convergence [deg -> rad],
+                              ``is_field_center``, map location [-> metres])
+    ``CD_WELL``               :class:`Well` (name, slot ``(ns, ew)`` + radial
+                              error, wellhead depth [-> metres])
+    ``CD_DATUM``              :class:`Datum` on its Well (elevation
+                              [-> metres]; the default datum is preferred)
+    ``CD_WELLBORE``           :class:`Wellbore`; ``parent_wellbore_id`` is the
+                              sidetrack edge, ``ko_md`` [-> metres] the
+                              kickoff; root wellbores parent to their Well
+    ========================  =================================================
+
+    Parameters
+    ----------
+    reader : welleng.exchange.edm_stream.EDMReader
+        An indexed EDM reader (or any object exposing the same ``projects``
+        / ``sites`` / ``wells`` / ``datums`` / ``wellbores`` /
+        ``source_units`` / ``survey()`` surface).
+    surveys : bool, keyword-only, default False
+        When ``True``, attach each wellbore's definitive ACTUAL survey
+        (converted to metres, grid azimuth reference) via
+        ``reader.survey(...)``. A wellbore whose survey is missing or fails
+        to assemble is skipped with a :class:`UserWarning` — the import
+        never aborts on a single wellbore. The default (``False``) builds
+        the cheap structure-only network.
+
+    Returns
+    -------
+    WellNetwork
+        The assembled network: Field -> Site -> Well (+ Datum) -> Wellbore
+        forest, with surveys attached when requested.
+
+    Warns
+    -----
+    UserWarning
+        Per wellbore whose survey cannot be assembled (``surveys=True``
+        only), and per wellbore whose ``parent_wellbore_id`` cannot be
+        resolved (it is rooted to its Well instead).
+    """
+    import warnings
+
+    src = str(getattr(reader, "source_units", "feet")).lower()
+    length = 0.3048 if src in ("feet", "ft") else 1.0
+
+    def _f(row: dict, key: str) -> Optional[float]:
+        v = row.get(key)
+        if v in (None, ""):
+            return None
+        try:
+            return float(v)
+        except (TypeError, ValueError):
+            return None
+
+    # -- CD_PROJECT -> Field (+ derivable site CRS) ------------------------- #
+    fields: dict[str, Field] = {}
+    project_crs: dict[str, Optional[str]] = {}
+    for pid, row in reader.projects.items():
+        fields[pid] = Field(id=pid, name=row.get("project_name", pid))
+        # Only the empirically-confirmed combination maps to an EPSG code;
+        # anything else is left unset rather than guessed.
+        if (row.get("geo_datum_id") == "ED50"
+                and row.get("geo_zone_id") == "UTM-31N"):
+            project_crs[pid] = "EPSG:23031"
+        else:
+            project_crs[pid] = None
+
+    # -- CD_SITE -> Site ---------------------------------------------------- #
+    sites: dict[str, Site] = {}
+    for sid, row in reader.sites.items():
+        conv = _f(row, "convergence")
+        northing = _f(row, "geo_map_northing")
+        easting = _f(row, "geo_map_easting")
+        location = (
+            (northing * length, easting * length)
+            if northing is not None and easting is not None else None
+        )
+        sites[sid] = Site(
+            id=sid,
+            name=row.get("site_name", sid),
+            parent=fields.get(row.get("project_id")),
+            crs=project_crs.get(row.get("project_id")),
+            convergence=None if conv is None else math.radians(conv),
+            is_field_centre=row.get("is_field_center") == "Y",
+            location=location,
+        )
+
+    # -- CD_WELL (+ CD_DATUM) -> Well --------------------------------------- #
+    wells: dict[str, Well] = {}
+    for wid, row in reader.wells.items():
+        slot_ns, slot_ew = _f(row, "slot_ns"), _f(row, "slot_ew")
+        slot = (
+            (slot_ns * length, slot_ew * length)
+            if slot_ns is not None and slot_ew is not None else None
+        )
+        radial = _f(row, "slot_radial_error")
+        wellhead = _f(row, "wellhead_depth")
+        # Prefer the well's default datum row; fall back to the first.
+        datum = None
+        datum_rows = reader.datums.get(wid, [])
+        if datum_rows:
+            row_d = next(
+                (d for d in datum_rows if d.get("is_default") == "Y"),
+                datum_rows[0],
+            )
+            elevation = _f(row_d, "datum_elevation")
+            datum = Datum(
+                name=row_d.get("datum_name", row_d.get("datum_id", "datum")),
+                elevation=0.0 if elevation is None else elevation * length,
+                reference="MSL",
+            )
+        wells[wid] = Well(
+            id=wid,
+            name=row.get("well_common_name", wid),
+            parent=sites.get(row.get("site_id")),
+            slot=slot,
+            slot_radial_error=0.0 if radial is None else radial * length,
+            wellhead_depth=None if wellhead is None else wellhead * length,
+            datum=datum,
+        )
+
+    # -- CD_WELLBORE -> Wellbore forest ------------------------------------- #
+    net = WellNetwork()
+    wellbores: dict[str, Wellbore] = {}
+    for wbid, wb in reader.wellbores.items():
+        ko_md = _f(wb.raw, "ko_md")
+        wellbores[wbid] = Wellbore(
+            id=wbid,
+            name=wb.name,
+            kickoff_md=None if ko_md is None else ko_md * length,
+        )
+    for wbid, wb in reader.wellbores.items():
+        node = wellbores[wbid]
+        pid = wb.parent_wellbore_id
+        if pid == wbid:                      # self-reference guard
+            pid = None
+        if pid and pid in wellbores:
+            node.parent = wellbores[pid]
+        else:
+            if pid:
+                warnings.warn(
+                    f"wellbore {wb.name!r}: parent wellbore id {pid!r} not "
+                    "in the export; rooting it to its well",
+                    stacklevel=2,
+                )
+            node.parent = wells.get(wb.well_id)
+        net.add(node)
+
+    # -- optional survey attachment ----------------------------------------- #
+    if surveys:
+        for wbid, node in wellbores.items():
+            try:
+                edm_survey = reader.survey(
+                    wbid, kind="definitive", phase="ACTUAL"
+                )
+                node.survey = edm_survey.to_welleng(
+                    units="meters", azi_reference="grid"
+                )
+            except Exception as exc:
+                warnings.warn(
+                    f"wellbore {node.name!r}: no definitive survey attached "
+                    f"({exc})",
+                    stacklevel=2,
+                )
+
+    # register any well/site/field that has no wellbore (net.add only walks
+    # ancestors of added wellbores)
+    for entity in (*fields.values(), *sites.values(), *wells.values()):
+        net._nodes.setdefault(entity.id, entity)
+    return net
 
 
 def _datum_dict(datum: Optional[Datum]) -> Optional[dict]:


### PR DESCRIPTION
Thin adapter closing the EDM→hierarchy→OSDU loop: `network_from_edm(reader, surveys=False)` maps the EDM master-data spine (CD_PROJECT/CD_SITE/CD_WELL/CD_DATUM/CD_WELLBORE) onto the hierarchy entities with the wellbore sidetrack forest, feet→metres at the boundary, optional definitive-survey attachment (warn-per-wellbore, never abort), and CRS only where derivable (ED50+UTM-31N → EPSG:23031, never guessed).

Plus `examples/volve_field_network.py`: the whole public Volve field as an interactive 3D plotly figure from one import (21 wells / 54 wellbores, 26 with definitive ACTUAL surveys).

Tests: synthetic EDM fixture (entities, conversions, sidetrack parentage, OSDU round-trip) + Volve integration (F-15D→F-15 parentage). Full suite 819 passed; ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)