### PR TITLE
Fix ruff lint on 0.23.0 additions

### DIFF
--- a/tests/test_kick_ideal_gas.py
+++ b/tests/test_kick_ideal_gas.py
@@ -11,7 +11,6 @@ Reference case (ideal, single-shoe, vertical): TD 10000 ft, MW 10 ppg,
 BHP 5400 psi, shoe 6000 ft, 8.5 in hole x 5 in DP, MAASP 900 psi (FP 12.885 ppg
 at shoe), gas 2.0 ppg at BHP. Textbook single-bubble Boyle -> 56.06 bbl.
 """
-import numpy as np
 import pytest
 
 from welleng.kick_tolerance.core import KickInputs, drill_kick

--- a/welleng/exchange/nlog.py
+++ b/welleng/exchange/nlog.py
@@ -219,7 +219,8 @@ class NLOGClient:
         WELLBORE / NITG_NR / UWI and carries no borehole id) and the
         API (which keys on the numeric id in the map-viewer URL).
         """
-        url = f"{BASE}/nlog-mapviewer/rest/search/suggest/brh/{urllib.parse.quote(query)}"
+        url = (f"{BASE}/nlog-mapviewer/rest/search/suggest/brh/"
+               f"{urllib.parse.quote(query)}")
         req = urllib.request.Request(
             url, headers={"Accept": "application/json",
                           "User-Agent": self.user_agent})
@@ -232,8 +233,9 @@ class NLOGClient:
     def id_for_name(self, wellbore_name: str) -> int | None:
         """Resolve a bulk-dump WELLBORE name to a borehole id, exact
         match on title. Returns None if the portal does not know it."""
+        target = wellbore_name.strip().upper()
         for hit in self.suggest(wellbore_name):
-            if str(hit.get("title", "")).strip().upper() == wellbore_name.strip().upper():
+            if str(hit.get("title", "")).strip().upper() == target:
                 return int(hit["objectId"])
         return None
 
@@ -278,7 +280,9 @@ class NLOGClient:
             return r.read()
 
     # -- convenience --------------------------------------------------
-    def survey_documents(self, borehole_id: int, pattern: str = r"dip|survey|devi|direction") -> list[dict]:
+    def survey_documents(
+        self, borehole_id: int, pattern: str = r"dip|survey|devi|direction"
+    ) -> list[dict]:
         """Documents whose title suggests a directional or dipmeter
         record — used to check whether an unmeasured azimuth could be
         recovered from an archived report."""


### PR DESCRIPTION
Lint-only: remove unused numpy import in test_kick_ideal_gas; wrap three long lines in exchange/nlog.py. No behaviour change. 🤖 Generated with [Claude Code](https://claude.com/claude-code)