### PR TITLE
fix(error-model): XYM3E/XYM4E must keep the azimuth-trig sign (ISCWSA v5.13)

### DIFF
--- a/tests/test_xym_abs_sign.py
+++ b/tests/test_xym_abs_sign.py
@@ -1,0 +1,79 @@
+"""Regression: XYM3E / XYM4E weight functions must keep the azimuth-trig SIGN.
+
+ISCWSA Error Model Definition v5.13 §5.1.2:
+
+    XYM3E   inc: M.Abs(Cos(I)) * Cos(AzT)      azi: -M.(Abs(Cos(I)) * Sin(AzT)) / Sin(I)
+    XYM4E   inc: M.Abs(Cos(I)) * Sin(AzT)      azi:  M.(Abs(Cos(I)) * Cos(AzT)) / Sin(I)
+
+``Abs`` wraps ``Cos(I)`` ONLY -- the azimuth trig (Cos/Sin(AzT)) keeps its sign,
+and so does the overall weight. welleng's hand-coded E-variants previously wrapped
+the whole product in ``Abs`` (XYM3E) or dropped the ``Abs(Cos(I))`` entirely
+(XYM4E), forcing a wrong sign for azi in 90-270 deg (XYM3E) or inc > 90 deg (XYM4E).
+
+The single ISCWSA Standard Test Well stays azi <= 75 deg and inc <= 90 deg, where
+``Abs(cos*cos) == Abs(cos)*cos`` and ``cos(inc) == Abs(cos(inc))`` EXACTLY, so the
+bug is a 0.0-difference no-op there and the per-term validation never caught it.
+These wells deliberately cross azi = 90/180/270 and inc = 90 to exercise it.
+"""
+import numpy as np
+
+import welleng as we
+
+MODEL = "ISCWSA MWD Rev5.11"
+
+
+def _survey(inc, azi):
+    md = np.arange(0.0, 300.0 * len(inc), 300.0)
+    sh = we.survey.SurveyHeader(
+        name="xym-wide", b_total=50000.0, dip=70.0,
+        declination=0.0, azi_reference="grid",
+    )
+    return we.survey.Survey(
+        md=md, inc=np.asarray(inc, float), azi=np.asarray(azi, float),
+        header=sh, error_model=MODEL,
+    )
+
+
+# stations spanning cos(azi) < 0 (azi 120/200/300/260) and cos(inc) < 0 (inc 95/120)
+_INC = [5, 30, 60, 95, 120, 80]
+_AZI = [20, 120, 200, 300, 45, 260]
+
+
+def test_xym3e_inclination_weight_keeps_cos_azi_sign():
+    s = _survey(_INC, _AZI)
+    e_inc = np.asarray(s.err.errors.errors["XYM3E"].e_DIA)[1:, 1]
+    cos_azi = np.cos(np.radians(_AZI))[1:]
+    # inc weight = Abs(cos(inc)) * cos(azi) * coeff, and Abs(cos(inc)) >= 0,
+    # coeff > 0 => the sign of the weight must equal the sign of cos(azi).
+    # (Pre-fix Abs wrapped the whole product => weight was always >= 0.)
+    assert np.all(np.sign(e_inc) == np.sign(cos_azi)), (
+        f"XYM3E inclination weight lost the cos(azi) sign:\n"
+        f"  weight  = {e_inc}\n  cos(azi)= {cos_azi}"
+    )
+    # and it must actually go negative somewhere here (guards a degenerate pass)
+    assert (e_inc < 0).any()
+
+
+def test_xym4e_inclination_weight_keeps_sin_azi_sign():
+    s = _survey(_INC, _AZI)
+    e_inc = np.asarray(s.err.errors.errors["XYM4E"].e_DIA)[1:, 1]
+    sin_azi = np.sin(np.radians(_AZI))[1:]
+    # inc weight = Abs(cos(inc)) * sin(azi) * coeff => sign == sign(sin(azi)),
+    # INCLUDING at inc > 90 where cos(inc) < 0 (pre-fix bare cos(inc) flipped it).
+    assert np.all(np.sign(e_inc) == np.sign(sin_azi)), (
+        f"XYM4E inclination weight lost the sin(azi)/Abs(cos inc) sign:\n"
+        f"  weight  = {e_inc}\n  sin(azi)= {sin_azi}"
+    )
+
+
+def test_xym4e_survives_inc_over_90():
+    # inc > 90 is where XYM4E's missing Abs(cos(inc)) flipped the azimuth weight.
+    inc = [95.0, 120.0, 100.0]
+    azi = [30.0, 60.0, 45.0]
+    s = _survey(inc, azi)
+    e_azi = np.asarray(s.err.errors.errors["XYM4E"].e_DIA)[1:, 2]
+    cos_azi = np.cos(np.radians(azi))[1:]
+    # azi weight = Abs(cos(inc)) * cos(azi) / sin(inc) * coeff; sin(inc) > 0 for
+    # inc in (0,180), Abs(cos inc) >= 0, coeff > 0 => sign == sign(cos(azi)),
+    # even though cos(inc) < 0 here (pre-fix bare cos(inc) flipped it).
+    assert np.all(np.sign(e_azi) == np.sign(cos_azi))

--- a/welleng/errors/tool_errors.py
+++ b/welleng/errors/tool_errors.py
@@ -2330,8 +2330,13 @@ def XYM3E(code, error, mag=0.00524, propagation='random', NEV=True, **kwargs):
     ), axis=-1), axis=-1)
 
     dpde = np.zeros((len(error.survey.md), 3))
-    dpde[1:, 1] = np.absolute(
-        cos(error.survey.inc_rad[1:])
+    # ISCWSA v5.13 §5.1.2 (XYM3E): M.Abs(Cos(I)) * Cos(AzT) -- Abs wraps Cos(I)
+    # ONLY; Cos(AzT) keeps its sign. Matches the XYM3 base fn (above) and the
+    # JSON inclination_formula. (Previously Abs wrapped the whole product,
+    # dropping the Cos(AzT) sign for azi in 90-270 deg -- invisible on the
+    # single ISCWSA test well, which stays azi<=75 deg.)
+    dpde[1:, 1] = (
+        np.absolute(cos(error.survey.inc_rad[1:]))
         * cos(error.survey.azi_true_rad[1:])
         * coeff[1:]
     )
@@ -2448,8 +2453,13 @@ def XYM4E(code, error, mag=0.00524, propagation='random', NEV=True, **kwargs):
     ), axis=-1), axis=-1)
 
     dpde = np.zeros((len(error.survey.md), 3))
+    # ISCWSA v5.13 §5.1.2 (XYM4E): M.Abs(Cos(I)) * Sin(AzT) and
+    # M.(Abs(Cos(I)) * Cos(AzT)) / Sin(I) -- Abs wraps Cos(I) ONLY. Matches the
+    # XYM4 base fn (above) and the JSON formulas. (Previously Cos(I) had no Abs,
+    # giving the wrong sign for inc>90 deg -- invisible on the ISCWSA test well,
+    # which stays inc<=90 deg.)
     dpde[1:, 1] = (
-        cos(error.survey.inc_rad[1:])
+        np.absolute(cos(error.survey.inc_rad[1:]))
         * sin(error.survey.azi_true_rad[1:])
         * coeff[1:]
     )
@@ -2458,7 +2468,7 @@ def XYM4E(code, error, mag=0.00524, propagation='random', NEV=True, **kwargs):
         dpde[1:, 2] = np.nan_to_num(
             (
                 (
-                    cos(error.survey.inc_rad[1:])
+                    np.absolute(cos(error.survey.inc_rad[1:]))
                     * cos(error.survey.azi_true_rad[1:])
                     / sin(error.survey.inc_rad[1:])
                 )


### PR DESCRIPTION
## Summary

The hand-coded `XYM3E` / `XYM4E` weight functions in `tool_errors.py` place `Abs()` wrongly versus the **ISCWSA Error Model Definition v5.13 §5.1.2**:

```
XYM3E   inc: M.Abs(Cos(I)) * Cos(AzT)     -- Abs wraps Cos(I) ONLY; Cos(AzT) signed
XYM4E   inc: M.Abs(Cos(I)) * Sin(AzT)     -- Abs wraps Cos(I) ONLY; Sin(AzT) signed
```

welleng wrapped the **whole product** in `Abs` (XYM3E) or **dropped `Abs(Cos(I))` entirely** (XYM4E), forcing the wrong sign:
- **XYM3E** — wrong for **azi ∈ (90°, 270°)** (cos(azi) < 0)
- **XYM4E** — wrong for **inc > 90°** (cos(inc) < 0)

The base `XYM3`/`XYM4` functions and the JSON `*_formula` strings are already correct — the E variants mis-transcribed the `Abs` when the station-spacing amplifier `Max(1, sqrt(10/(MD-MDPrev)))` was added.

## Why this wasn't caught

The per-term ISCWSA validation (`test_iscwsa_mwd_error.py`, rtol 5e-5) checks each source's covariance — but the **single Standard Test Well spans only azi 0–75° and inc 0–90°**, where `Abs(cos·cos) == Abs(cos)·cos` and `cos(inc) == Abs(cos(inc))` hold **exactly**. The bug is a **0.0-difference no-op** on that well, so nothing flagged it. Verified: max cell diff between buggy and fixed weight on the standard well = `0.0`.

## Fix + test

Three sites corrected (XYM3E inc-weight; XYM4E inc- and azi-weight) to match v5.13 + the JSON + the base `XYM3`/`XYM4` convention. New `tests/test_xym_abs_sign.py` exercises wells crossing azi 90/180/270 and inc 90, asserting the weight sign follows the azimuth trig.

The standard ISCWSA validation and the JSON conformance suite remain green (the fix is invisible there by construction).

## Follow-ups (tracked, not in this PR)

- Audit `XCLA`/`XCLH`/`AMIL` `Abs` placement vs v5.13 (XCLA has its own Rev5.11 correction history).
- The hand-coded↔JSON conformance harness silently skips `XYM3E`/`XYM4E` (`NO_LEGACY`: `_ShimError` lacks `drdp_sing`, so calling them throws and is swallowed) — complete the shim so these terms are actually cross-checked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)