### PR TITLE
feat(kick-tolerance): SIDP/SICP per migration step + ideal-gas mode

### DIFF
--- a/tests/test_migration.py
+++ b/tests/test_migration.py
@@ -505,3 +505,60 @@ if __name__ == "__main__":
     print(f"min FP margin     = {r.min_fp_margin_psi:.1f} psi")
     print(f"binding TVD/step  = {r.binding_tvd:.0f} ft / step {r.binding_step}")
     print(f"bha_length_exceeded = {r.bha_length_exceeded}")
+
+
+# --- SIDP / SICP on MigrationStep: Rada Jancic ideal-gas hand-calc -----------
+# Well-control single-bubble reference (welleng-api spec 2026-07-22):
+#   MW 10 ppg, vertical TVD 10000 ft, annular capacity 0.0459 bbl/ft,
+#   influx 5 bbl -> 108.9 ft gas column, gas gradient 0.1 psi/ft, SIDP 200 psi.
+# Ideal gas (Z=1, isothermal), bubble at bottom:
+#   SIDP = 200.00, SICP = 245.87 (at welleng's native g=0.0521).
+# Rada's hand-calc gives 200.00 / 245.75 at his rounded g=0.052 -- the 0.12 psi
+# is purely that gravitational-constant rounding, not a modelling difference.
+def test_rada_ideal_sidp_sicp_bubble_at_bottom():
+    G = G_PSI_PER_PPG_FT                       # 0.0521
+    MW, TVD, CAP, INFLUX, GGRAD = 10.0, 10000.0, 0.0459, 5.0, 0.1
+    bhp = 200.0 + G * MW * TVD                 # BHP consistent with SIDP=200
+    rho_gas = GGRAD / G                        # 0.1 psi/ft gas gradient -> ppg
+    T_bh = 560.0                               # rankine (isothermal, ideal)
+    sections = [WellSection(0.0, TVD, CAP, True)]
+
+    res = migrate(
+        sections, pp=([0, TVD], [8.0, 8.0]), fp=([0, TVD], [16.0, 16.0]),
+        bhp_psi=bhp, influx_bbl_bh=INFLUX, rho_mud_ppg=MW,
+        gas_bh_state=(bhp, T_bh, 1.0, rho_gas), gas_density_mode="exact",
+        n_steps=50, ideal_gas=True,
+    )
+    bottom = res.steps[0]                       # march starts with the bubble at TD
+    assert bottom.gas_length_ft == pytest.approx(108.9, abs=0.5)
+    assert bottom.sidp_psi == pytest.approx(200.00, abs=0.05)
+    assert bottom.sicp_psi == pytest.approx(245.87, abs=0.1)   # 245.75 @ g=0.052
+    # the ideal single-bubble identity SICP = SIDP + (g_mud - g_gas)*h_gas
+    assert bottom.sicp_psi == pytest.approx(
+        200.0 + (G * MW - GGRAD) * bottom.gas_length_ft, abs=0.05)
+
+
+def test_sidp_constant_sicp_is_a_rising_schedule():
+    # SIDP is position-independent -> constant across the walk. SICP rises as the
+    # bubble expands (Boyle), even in ideal mode -- it is a schedule, not flat.
+    G = G_PSI_PER_PPG_FT
+    MW, TVD, CAP, INFLUX = 10.0, 10000.0, 0.0459, 5.0
+    bhp = 200.0 + G * MW * TVD
+    sections = [WellSection(0.0, TVD, CAP, True)]
+    kw = dict(
+        pp=([0, TVD], [8.0, 8.0]), fp=([0, TVD], [16.0, 16.0]),
+        bhp_psi=bhp, influx_bbl_bh=INFLUX, rho_mud_ppg=MW,
+        gas_density_mode="exact", n_steps=40,
+    )
+    ideal = migrate(sections, gas_bh_state=(bhp, 560.0, 1.0, 0.1 / G),
+                    ideal_gas=True, **kw)
+    sidp = [s.sidp_psi for s in ideal.steps]
+    sicp = [s.sicp_psi for s in ideal.steps]
+    assert max(sidp) - min(sidp) < 1e-6            # SIDP constant
+    assert sicp[-1] > sicp[0] + 50.0               # SICP rises up the walk
+
+    # real gas (HY Z) gives a DIFFERENT schedule but the SAME deepest value
+    real = migrate(sections, gas_bh_state=(bhp, 560.0, None, None), **kw)
+    assert real.steps[0].sicp_psi == pytest.approx(ideal.steps[0].sicp_psi, abs=1.0)
+    real_sicp = [s.sicp_psi for s in real.steps]
+    assert abs(real_sicp[-1] - sicp[-1]) > 1.0     # schedules diverge up the walk

--- a/welleng/kick_tolerance/migration.py
+++ b/welleng/kick_tolerance/migration.py
@@ -399,6 +399,22 @@ class MigrationStep:
     min_fp_margin_psi: float    # min over exposed depths of FP(d) - P(d) [psi]
     binding_tvd: float          # exposed depth achieving that minimum    [ft]
     p_at_binding_psi: float     # imposed pressure at binding_tvd          [psi]
+    # Shut-in gauge readings for THIS bubble position (well-control kill sheet):
+    sidp_psi: float             # shut-in drill-pipe pressure [psi]
+    sicp_psi: float             # shut-in casing (annulus) pressure [psi]
+    #  SIDP = BHP - g.rho_mud.bottom_tvd -- drill pipe full of MUD (influx in the
+    #    annulus, not the string: the standard kick-in-annulus assumption). It is
+    #    position-INDEPENDENT, so it is constant across the walk; out of scope if
+    #    the influx entered the drill string.
+    #  SICP = imposed pressure evaluated at surface (depth 0) for this step -- the
+    #    existing annulus profile at the top. Per step it equals
+    #    SIDP + (g_mud - g_gas).h_gas with the CURRENT gas length/density. Under
+    #    constant BHP the bubble EXPANDS as it rises (h_gas grows, rho_gas falls),
+    #    so SICP RISES up the walk -- the steps are a SICP schedule, not a flat
+    #    line. IDEAL gas (Z=1, isothermal) expands by Boyle only; REAL gas adds the
+    #    Z(P,T) correction -- the two give different schedules (the differentiator),
+    #    and agree at the initial (deepest) bubble position where no expansion has
+    #    happened yet (the well-control single-bubble hand-calc value).
 
 
 @dataclass
@@ -549,6 +565,7 @@ def migrate(
     geothermal: TempProfileLike = None,
     n_steps: int = 100,
     mode: str = "thorough",
+    ideal_gas: bool = False,
 ) -> MigrationResult:
     """March a single gas bubble up the annulus under constant BHP.
 
@@ -611,7 +628,15 @@ def migrate(
 
     P_bh, T_bh_r, Z_bh, rho_gas_ppg = _resolve_bh_state(gas_bh_state, bhp_psi)
     gas_bh = (P_bh, T_bh_r, Z_bh, rho_gas_ppg)  # bottom-hole anchor for rho_gas(P)
-    if temp_profile is None:
+    # Ideal gas (Z=1, isothermal): forces Z=1 everywhere (expansion + column) and
+    # isothermal at T_bh. The bubble STILL expands (Boyle), so SICP still rises up
+    # the walk -- ideal vs real differ in the expansion Z (Boyle vs Boyle+Z), i.e.
+    # the SICP schedule shape, and agree at the initial bubble position. Real gas
+    # (default) keeps the Hall-Yarborough Z + any temperature profile.
+    z_ideal = (lambda _p, _t: 1.0) if ideal_gas else None
+    if ideal_gas:
+        temp_profile = None                # isothermal at T_bh
+    elif temp_profile is None:
         temp_profile = geothermal          # geothermal is the default when supplied
     temp_fn = _as_temp_callable(temp_profile, T_bh_r)  # still None -> isothermal at T_bh
 
@@ -674,6 +699,11 @@ def migrate(
     global_binding_step = 0
     all_within = True
 
+    # SIDP -- drill pipe full of mud, influx in the annulus (kick-in-annulus).
+    # Position-independent, so constant across the whole walk: BHP minus the mud
+    # hydrostatic over the full TVD to the bit.
+    sidp_psi = bhp_psi - G_PSI_PER_PPG_FT * rho_mud_ppg * bottom_tvd
+
     for i, gas_top in enumerate(gas_top_march):
         # Fixed-point on the representative bubble pressure P_rep (at the gas
         # top -- the lowest pressure / largest, safe-side bubble). Boyle uses Z(P)
@@ -683,7 +713,7 @@ def migrate(
         T_local = float(temp_fn(gas_top))  # local T at the representative (gas-top) depth
         gas_bottom, gas_len = gas_top, 0.0
         for _ in range(100):
-            Z = _z_at(P_rep, T_local)
+            Z = 1.0 if ideal_gas else _z_at(P_rep, T_local)
             # V(P,T,Z) = V_bh * (P_bh*Z*T_local) / (P*Z_bh*T_bh); T_local=T_bh -> old.
             V = influx_bbl_bh * (P_bh * Z * T_local) / (P_rep * Z_bh * T_bh_r)
             gas_bottom, gas_len = _fill_down(gas_top, V, sections_sorted, bottom_tvd)
@@ -691,7 +721,8 @@ def migrate(
                 gas_top, gas_top_tvd=gas_top, gas_bottom_tvd=gas_bottom,
                 bottom_tvd=bottom_tvd, bhp_psi=bhp_psi,
                 rho_mud_ppg=rho_mud_ppg, gas_bh=gas_bh,
-                gas_density_mode=gas_density_mode, temp_profile=temp_profile, n_sub=20,
+                gas_density_mode=gas_density_mode, temp_profile=temp_profile,
+                n_sub=20, z_fn=z_ideal,
             ))
             P_new = max(P_new, 1.0)
             if abs(P_new - P_rep) < 1e-4:
@@ -708,6 +739,7 @@ def migrate(
             bottom_tvd=bottom_tvd, bhp_psi=bhp_psi,
             rho_mud_ppg=rho_mud_ppg, gas_bh=gas_bh,
             gas_density_mode=gas_density_mode, temp_profile=temp_profile,
+            z_fn=z_ideal,
         )
         fp_margin = fp_psi - P          # >= 0 required (no breakdown)
         pp_margin = P - pp_psi          # >= 0 required (no further influx)
@@ -715,6 +747,18 @@ def migrate(
         step_min = float(fp_margin[j])
         step_binding_tvd = float(exposed_depths[j])
         step_p_binding = float(P[j])
+
+        # SICP = the same imposed annulus profile evaluated at surface (depth 0)
+        # for this bubble position (no new physics -- the existing profile at the
+        # top). Ideal gas -> flat across the walk; real gas -> varies as the
+        # bubble expands. SIDP is position-independent (computed once, above).
+        sicp = float(pressure_at_depth(
+            0.0, gas_top_tvd=gas_top, gas_bottom_tvd=gas_bottom,
+            bottom_tvd=bottom_tvd, bhp_psi=bhp_psi,
+            rho_mud_ppg=rho_mud_ppg, gas_bh=gas_bh,
+            gas_density_mode=gas_density_mode, temp_profile=temp_profile,
+            z_fn=z_ideal,
+        ))
 
         if not (np.all(fp_margin >= 0.0) and np.all(pp_margin >= 0.0)):
             all_within = False
@@ -726,6 +770,8 @@ def migrate(
             min_fp_margin_psi=step_min,
             binding_tvd=step_binding_tvd,
             p_at_binding_psi=step_p_binding,
+            sidp_psi=sidp_psi,
+            sicp_psi=sicp,
         ))
 
         if step_min < global_min:


### PR DESCRIPTION
## Summary

Part A of the KT kill-sheet spec (welleng-api 2026-07-22, JJ TA0 directive). Adds shut-in gauge readings to each `MigrationStep`:

- **`sidp_psi`** — shut-in drill-pipe pressure = `BHP − g·ρ_mud·bottom_tvd` (drill pipe full of mud, influx in the annulus = the standard kick-in-annulus assumption). Position-independent → **constant** across the walk.
- **`sicp_psi`** — shut-in casing (annulus) pressure = the existing `pressure_at_depth` profile evaluated at **surface (depth 0)** per bubble position. No new physics.

Also adds **`ideal_gas=True`** to `migrate()` (Z=1 + isothermal), matching the analytical path's `KickInputs.ideal_gas`.

## Correction to the spec's "ideal SICP is flat"

The spec states ideal-gas SICP is flat across the walk. **It isn't** — under constant BHP the bubble expands (Boyle), so `h_gas` grows / `ρ_gas` falls and SICP **rises** up the walk even in ideal mode. It's a **SICP schedule**, not a flat line. Even the spec's own identity `SICP = SIDP + (g_mud−g_gas)·h_gas`, applied per-step with the expanding `h_gas`, rises. Ideal vs real differ in the expansion Z (Boyle vs Boyle+Z) — the schedule *shape* — and agree at the deepest bubble position (the single-bubble hand-calc value). Implemented the physically-correct behaviour.

## Validation

Rada Jancic ideal-gas hand-calc, bubble at bottom: **SIDP=200.00, SICP=245.87** at welleng's native g=0.0521 (Rada's 245.75 is his g=0.052 rounding — a gravitational-constant rounding, not a modelling difference). Pinned as regression tests, plus SIDP-constant / SICP-rising-schedule / real-vs-ideal-diverge checks. Full migration + KT suite green (65 passed).

## Downstream

welleng-api surfaces `sidp_psi`/`sicp_psi` per-step in the KT response + GUI (API contract change, TA0-gated, handled api-side). Part B (IWCF/API kill-sheet calculator) is a separate, larger piece — needs canonical worked examples first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)