### PR TITLE
docs(error-model): flag inc==0 azimuth canonicalisation as a Survey-bypass precondition

### DIFF
--- a/welleng/error.py
+++ b/welleng/error.py
@@ -455,6 +455,14 @@ class ErrorModel():
         -------
         numpy.ndarray
             Shape (n, 3) array of NEV derivatives.
+
+        Note
+        ----
+        The N/E columns are azimuth-dependent even at ``inc == 0`` (½·Δmd·cos(inc)
+        ·{cos,sin}(azi)). ``Survey`` canonicalises azimuth to 0 at vertical
+        stations (see ``Survey._make_angles``); a consumer feeding this model
+        WITHOUT that preprocessing must apply ``azi = where(inc == 0, 0, azi)``
+        first, or the covariance diverges at vertical stations.
         """
         md1, inc1, azi1 = np.array(survey[:-1]).T
         md2, inc2, azi2 = np.array(survey[1:]).T

--- a/welleng/survey.py
+++ b/welleng/survey.py
@@ -1097,7 +1097,17 @@ class Survey(MinCurve):
         # undefined there (no toolface has evolved yet), so default it to 0 -- a
         # clear "vertical / not yet steered" sentinel -- rather than carrying the
         # arbitrary input azimuth through. inc == 0 => no N/E displacement, so this
-        # never changes geometry; it only makes the stored azimuth meaningful.
+        # never changes the survey GEOMETRY.
+        #
+        # PRECONDITION for the error model (not merely cosmetic): the ISCWSA
+        # weight-function Jacobian is azimuth-dependent even at inc == 0 --
+        # ``drk_dInc`` N/E columns are ½·Δmd·cos(inc)·{cos,sin}(azi) (error.py) --
+        # so a vertical station carrying a raw non-zero azimuth perturbs the
+        # covariance (a systematic term then taints every downstream station via
+        # the cumsum). Any consumer that evaluates the error model WITHOUT going
+        # through Survey (e.g. a vectorised/batched covariance backend) MUST
+        # replicate this ``azi = where(inc == 0, 0, azi)`` step, or it diverges
+        # from the reference at vertical stations.
         vertical = self.inc_rad == 0.0
         if np.any(vertical):
             self.azi_grid_rad = np.where(vertical, 0.0, self.azi_grid_rad)


### PR DESCRIPTION
## Summary

**Comments only — zero behaviour change.**

The ISCWSA weight-function Jacobian (`drk_dInc`) is azimuth-dependent even at `inc == 0` (N/E columns = ½·Δmd·cos(inc)·{cos,sin}(azi)). `Survey._make_angles` canonicalises azimuth → 0 at vertical stations, so the welleng path is always correct. But a consumer evaluating the error model **without** going through `Survey` (a vectorised/batched covariance backend) must replicate `azi = where(inc == 0, 0, azi)`, or the covariance diverges at vertical stations — and because the affected term is systematic, the cumsum then taints every downstream station.

Documents the precondition at both sites (the canonicalisation in `survey.py`, the Jacobian in `error.py`) so the survey-preprocessing contract is discoverable from either side. The existing `survey.py` comment said this "never changes geometry" — true for position, but misleading, since it *is* load-bearing for the error model.

## Context

A downstream Survey-bypass covariance backend hit exactly this (a vertical-topped well fed raw azimuth at inc==0 stations → an 8.55e-3 m² covariance divergence that accumulated over the well). welleng itself was correct; this note prevents the next bypass consumer from repeating it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)