### PR TITLE
fix(error-model): XCLA/XCLH tool-independence — route through hand-coded weight fns for all models

### DIFF
--- a/tests/test_xcl_tool_independence.py
+++ b/tests/test_xcl_tool_independence.py
@@ -1,0 +1,60 @@
+"""XCLA/XCLH (extended course length, Codling SPE-187249) are GEOMETRIC,
+tool-independent terms: the survey-interval position error depends on the
+wellbore path, not the survey instrument. So on the SAME well they must give the
+SAME covariance across MWD and gyro tool models.
+
+Regression for the 0.25.0 item-1 fix: gyro models previously routed XCLA/XCLH
+through the pointwise JSON interpreter (which can't express the cross-station
+Max(Δangle, tortuosity·course-length) recurrence -> a different, unvalidated
+form), while MWD used the hand-coded weight functions validated against the
+ISCWSA diagnostics. Both now route through the hand-coded path.
+"""
+import numpy as np
+
+import welleng as we
+
+
+def _cov(model, term):
+    md = np.linspace(0, 3000, 40)
+    inc = np.linspace(2, 72, 40)
+    azi = np.linspace(10, 88, 40)
+    s = we.survey.Survey(
+        md=md, inc=inc, azi=azi, deg=True,
+        header=we.survey.SurveyHeader(
+            b_total=50000, dip=70, declination=0, azi_reference="grid"),
+        error_model=model,
+    )
+    return np.asarray(s.err.errors.errors[term].cov_NEV)
+
+
+MODELS = ["MWD+SRGM", "GYRO-NS", "GYRO-MWD"]
+
+
+def test_xcla_is_tool_independent():
+    ref = _cov("MWD+SRGM", "XCLA")
+    for m in MODELS[1:]:
+        assert np.allclose(_cov(m, "XCLA"), ref, atol=1e-12), (
+            f"XCLA cov differs between MWD+SRGM and {m} -- XCLA is geometric and "
+            f"must be tool-independent"
+        )
+
+
+def test_xclh_is_tool_independent():
+    ref = _cov("MWD+SRGM", "XCLH")
+    for m in MODELS[1:]:
+        assert np.allclose(_cov(m, "XCLH"), ref, atol=1e-12)
+
+
+def test_xcla_is_the_validated_position_form():
+    # The hand-coded form puts weight in the depth/inclination position columns
+    # (not the interpreter's azimuth-only form). Guard that gyro didn't revert to
+    # the interpreter form (which had e_DIA ~ [0, 0, azi]).
+    s = we.survey.Survey(
+        md=np.linspace(0, 3000, 40), inc=np.linspace(2, 72, 40),
+        azi=np.linspace(10, 88, 40), deg=True,
+        header=we.survey.SurveyHeader(
+            b_total=50000, dip=70, declination=0, azi_reference="grid"),
+        error_model="GYRO-NS",
+    )
+    e = np.asarray(s.err.errors.errors["XCLA"].e_DIA)[-1]
+    assert abs(e[0]) > 1e-6, "gyro XCLA reverted to the interpreter (no depth weight)"

--- a/welleng/errors/tool_errors.py
+++ b/welleng/errors/tool_errors.py
@@ -208,8 +208,17 @@ def _json_to_em_adapter(model: dict) -> dict:
     codes = OrderedDict()
     for term in model.get("terms", []):
         name = term["name"]
+        # XCLA/XCLH (extended course length, Codling SPE-187249) are GEOMETRIC,
+        # tool-independent terms whose weight is a CROSS-STATION recurrence
+        # (Max(Δangle, tortuosity·course-length)). The pointwise interpreter cannot
+        # express that recurrence (the silent-zero/constant XCL gap), so on JSON
+        # models it produced a DIFFERENT, unvalidated XCLA than the legacy MWD path
+        # -- which IS validated against the ISCWSA diagnostics. Route XCLA/XCLH
+        # through the hand-coded weight functions for ALL models so gyro/SRGM XCLA
+        # == MWD XCLA == the ISCWSA-validated form (tool-independence).
+        func = name if name in ("XCLA", "XCLH") else "_INTERPRETER_"
         codes[name] = {
-            "function": "_INTERPRETER_",
+            "function": func,
             "magnitude": float(term["value"]),
             "propagation": _JSON_PROP_TO_LEGACY.get(
                 term["propagation_mode"], "systematic"


### PR DESCRIPTION
## Summary

**0.25.0 cycle, item 1.** XCLA/XCLH (extended course length, Codling SPE-187249) are **geometric, tool-independent** terms, but welleng gave **different covariance for MWD+SRGM vs GYRO-NS on the same well** (surfaced by welleng-api's gyro covariance vectorisation).

**Root cause:** JSON tool models route every term through the pointwise interpreter, which cannot express XCLA/XCLH's cross-station `Max(Δangle, tortuosity·course-length)` recurrence — producing a different, unvalidated form than the legacy MWD hand-coded path (which **is** validated against the ISCWSA diagnostics, #296).

**Ruling** (Codling/Hanak derivation + the ISCWSA `.dat`): the hand-coded position-form is canonical; the gyro JSON-interpreter form is the bug. XCLA is geometric — MWD and gyro must give the same weight function.

**Fix:** route XCLA/XCLH through the hand-coded `func_dict` for **all** models. Now gyro/SRGM XCLA == MWD XCLA == the ISCWSA-validated form.

## Validation

- New `test_xcl_tool_independence.py`: XCLA/XCLH cov identical across MWD+SRGM / GYRO-NS / GYRO-MWD on the same well; gyro didn't revert to the interpreter form.
- MWD `.dat` diagnostic validation, gyro SPE-90408 Appendix-E, and JSON conformance all remain green (91 passed / 3 xfailed).

Unblocks welleng-api's gyro XCLA parity (it can now assert gyro XCLA == MWD == welleng once re-pinned).

🤖 Generated with [Claude Code](https://claude.com/claude-code)