### PR TITLE
fix(error-model): DRFR carries mag² at a surface-root station 0 (ISCWSA)

### DIFF
--- a/tests/test_iscwsa_diagnostics.py
+++ b/tests/test_iscwsa_diagnostics.py
@@ -29,12 +29,13 @@ from welleng.error import get_errors
 
 DIAG_DIR = Path(__file__).parent / "test_data"
 
-# Known welleng-vs-ISCWSA differences pending a fix. TA0 ruled 2026-07-21:
-# match ISCWSA. DRFR (random depth) carries no variance at the surface station
-# in welleng (drk_dDepth zeros station 0), where ISCWSA gives mag^2. Fix is a
-# foundational datum change (must not disturb the systematic depth terms that
-# correctly match at station 0), tracked separately. Keyed (source, station).
-KNOWN_DIFFS = {("DRFR", 0)}
+# Known welleng-vs-ISCWSA differences pending a fix, keyed (source, station).
+# Empty: the DRFR station-0 gap (random depth carried no surface variance where
+# ISCWSA gives mag^2) was fixed in 0.25.0 -- ``_drdp`` now seeds the station-0
+# depth column with the wellbore tangent so the random depth source's own
+# measurement error propagates at the surface, without disturbing the
+# systematic depth terms (whose weight vanishes at md=0). See ``error.py``.
+KNOWN_DIFFS = set()
 
 
 def _parse_dat(path: Path):
@@ -124,9 +125,11 @@ def test_per_term_covariance_matches_iscwsa_diagnostics(dat_name):
     )
 
 
-def test_known_diff_is_actually_present():
-    """Guard: the DRFR station-0 gap we're excluding must still be real, so the
-    KNOWN_DIFFS waiver can't silently mask a later regression / accidental fix."""
+def test_drfr_station0_matches_iscwsa():
+    """Regression for the 0.25.0 DRFR station-0 fix: a random depth source must
+    carry its full variance at the surface (cov_VV(0) = mag^2 = 0.35^2 = 0.1225),
+    matching the ISCWSA diagnostics. Guards against reverting to the old
+    station-0-zeroed datum."""
     path = DIAG_DIR / "iscwsa_diagnostics_3.dat"
     if not path.exists():
         pytest.skip("diagnostic #3 not shipped")
@@ -134,7 +137,7 @@ def test_known_diff_is_actually_present():
     s = _survey(ref, stations)
     got = np.array(get_errors(np.asarray(s.err.errors.errors["DRFR"].cov_NEV[0])))
     exp = np.array(stations[0]["src"]["DRFR"])
-    # if this ever starts matching, DRFR was fixed -> drop it from KNOWN_DIFFS.
-    assert not np.allclose(got, exp, atol=1e-3), (
-        "DRFR station-0 now matches ISCWSA -- remove ('DRFR', 0) from KNOWN_DIFFS"
+    assert np.allclose(got, exp, atol=1e-3), (
+        f"DRFR station-0 must match ISCWSA (mag^2 at the surface); got {got}, "
+        f"expected {exp}"
     )

--- a/welleng/error.py
+++ b/welleng/error.py
@@ -316,7 +316,13 @@ class ErrorModel():
             + self.drdp[:, 8] * A
         ])
 
-        arr[0] = 0
+        # NB: station 0 is NOT blanket-zeroed here (unlike ``_e_NEV``). ``drdp``
+        # seeds the station-0 depth column with the wellbore tangent (see
+        # ``_drdp``), so a random depth source's own measurement error carries
+        # its full variance at the surface (ISCWSA DRFR cov_VV(0) = mag^2).
+        # inc/azi columns are zero at station 0 -> every non-depth term (and any
+        # systematic depth term, whose weight vanishes at md=0) stays 0 there,
+        # exactly matching the ISCWSA diagnostics.
 
         return arr
 
@@ -419,7 +425,14 @@ class ErrorModel():
 
         Equal to 0.5 * (unit_vec[i] + unit_vec[i+1]) in NEV coordinates --
         the direction-cosine part of minimum curvature without the RF or
-        delta_md.
+        delta_md. When the survey starts at the zero datum (md[0] == 0) station
+        0 has no segment above it and takes the full station-0 wellbore tangent
+        instead of the half-segment average: a depth error at the first station
+        shifts the along-hole position by the full tangent (ISCWSA random depth
+        carries its full variance at the surface, DRFR cov_VV(0) = mag^2). A
+        survey that starts below the datum (md[0] != 0) is tied on, so its
+        station 0 stays zero (see ``_drdp``). This row-0 value is consumed only
+        by ``_e_NEV_star`` (``drkplus1_dDepth`` slices ``[1:]``).
 
         Parameters
         ----------
@@ -441,7 +454,16 @@ class ErrorModel():
             si1 * sa1 + si2 * sa2,       # E
             np.cos(inc1) + np.cos(inc2), # V
         ), axis=-1)
-        return np.vstack((np.zeros((1, 3)), NEV))
+        md0, i0, a0 = np.array(survey[0]).T
+        if md0 == 0.0:
+            row0 = np.array([
+                np.sin(i0) * np.cos(a0),
+                np.sin(i0) * np.sin(a0),
+                np.cos(i0),
+            ])
+        else:
+            row0 = np.zeros(3)
+        return np.vstack((row0, NEV))
 
     def drk_dInc(self, survey):
         """Derivative of position with respect to inclination at each station.
@@ -621,6 +643,27 @@ class ErrorModel():
         result[1:, 0] = dc_N
         result[1:, 1] = dc_E
         result[1:, 2] = dc_V
+
+        # Station-0 direct depth-measurement derivative -- ONLY for a survey
+        # that starts at the zero datum (md[0] == 0, a true surface root). A
+        # depth error at that first station shifts the along-hole position by
+        # the FULL wellbore tangent (not the half-segment min-curvature average
+        # -- there is no segment above station 0), so the ISCWSA random-depth
+        # source carries its full variance at the surface: DRFR cov_VV(0) =
+        # mag^2. Only the depth column is seeded -- inc/azi errors have zero
+        # lever arm at station 0.
+        #
+        # When md[0] != 0 the survey starts BELOW the datum: station 0 is a
+        # tie-on whose uncertainty is carried externally (a composed section's
+        # freeze-carry tie, or a hierarchy sidetrack inheriting its parent), so
+        # NO fresh direct-depth term is added -- the row-0 depth column stays 0,
+        # exactly as the pre-0.25.0 datum. This keeps the station-0 term local
+        # to the random branch AND preserves the composition/hierarchy tie
+        # invariant that a sub-run's station 0 injects no new error.
+        if md[0] == 0.0:
+            result[0, 0] = si[0] * ca[0]
+            result[0, 1] = si[0] * sa[0]
+            result[0, 2] = ci[0]
 
         # drk_dInc: rows 1..n-1 (wrt inc at station i+1)
         result[1:, 3] = half_dmd * ci[1:] * ca[1:]


### PR DESCRIPTION
## What

The ISCWSA Error Model Diagnostics give a random depth source (**DRFR**) its full variance at the first station of a surface well: `cov_VV(0) = mag²` (0.35² = **0.1225** on wells #1/#2/#3). welleng zeroed station 0 for every term, so DRFR under-read there — the one documented `KNOWN_DIFFS` waiver in `test_iscwsa_diagnostics.py` (TA0-ruled: match ISCWSA).

## Why it was non-trivial

Physically a depth error at the first station shifts the along-hole position by the **full wellbore tangent** (there is no segment above station 0), so the direct-measurement term is `u0·δD` → `cov_VV(0) = mag²` for a vertical top. inc/azi errors have zero lever arm at the surface, so every non-depth term — and any systematic depth term (weight ∝ md → 0 at md=0) — stays 0 there, exactly matching the diagnostics.

**The catch:** the blanket `arr[0]=0` in `_e_NEV_star` was doing double duty — it is also the **tie-station reset** that the `SurveyComposition` freeze-carry and the hierarchy sidetrack inheritance rely on. Removing it unconditionally injected a spurious fresh depth-reference error at every composed sub-run's tie station, which propagated to TD.

## Fix

Seed the `_drdp` (and matching `drk_dDepth`) station-0 depth column with the full tangent `u0`, drop the blanket `arr[0]=0` — but **only when the survey starts at the zero datum (`md[0] == 0`, a true surface root)**. A survey starting below the datum is tied-on: its station-0 uncertainty is carried externally (a composed section's freeze-carry tie, or a hierarchy sidetrack inheriting its parent), so it keeps the pre-0.25.0 zero datum. This keeps the term **local to the random branch** (`_e_NEV[0]` and the systematic seed stay zeroed) and **preserves the composition/hierarchy tie invariant**.

## Verification

- ISCWSA #1/#2/#3 diagnostics green — DRFR st0 = 0.1225 on all three.
- Composed EDM/COMPASS Volve wells (F-15D/F-12/F-14, md0=91) and the hierarchy zero-at-kickoff invariant **bit-identical** to before.
- `("DRFR", 0)` dropped from `KNOWN_DIFFS`; the guard test inverted into a positive regression.
- Full suite: **920 passed**, 7 skipped, 3 xfailed.

Bundles with #301 (XCLA tool-independence) into 0.25.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)